### PR TITLE
fix incorrect tracker_register length

### DIFF
--- a/similar/main/net_udp.cpp
+++ b/similar/main/net_udp.cpp
@@ -425,7 +425,7 @@ static int udp_tracker_unregister()
 static int udp_tracker_register()
 {
 	// Variables
-	int iLen = 14;
+	int iLen = 15;
 	ubyte pBuf[iLen];
 	
 	// Reset the last tracker message


### PR DESCRIPTION
The tracker register messages actually packs 15 bytes of data into the pBuf, however, only 14 bytes are allocated. This causes a SegV exception on OS X when attempting to host a network game.
