### PR TITLE
Enlarge movielib_files, make non-const.

### DIFF
--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -98,7 +98,7 @@ public:
 
 // Movielib data
 
-static const char movielib_files[][FILENAME_LEN] = {"intro","other","robots"};
+static char movielib_files[4][FILENAME_LEN] = {"intro","other","robots"};
 
 #define N_MOVIE_LIBS (sizeof(movielib_files) / sizeof(*movielib_files))
 #define N_BUILTIN_MOVIE_LIBS (N_MOVIE_LIBS - 1)


### PR DESCRIPTION
Briefing robot movies were never being loaded by init_movies, because N_BUILTIN_MOVIE_LIBS was too small.
movielib_files also needs an extra element and needs to be non-const so that init_extra_robot_movie can load addon mission robots (e.g. Vertigo).
