### PR TITLE
always_inline d_debugbreak()

### DIFF
--- a/common/include/dxxerror.h
+++ b/common/include/dxxerror.h
@@ -63,6 +63,10 @@ void Error(const char *func, unsigned line, const char *fmt,...) __noreturn __at
 #endif
 
 /* Allow macro override */
+
+#if defined __GNUC__
+__attribute__((always_inline))
+#endif
 static inline void d_debugbreak()
 {
 	/* If NDEBUG, expand to nothing */


### PR DESCRIPTION
probably the main drawback of wrapping debugbreak in a function is that the debugger will then stop in that function, instead of the calling code. This does a pretty good job taking care of that.
