### PR TITLE
more OS X issues

### DIFF
--- a/contrib/dxx-rebirth.xcodeproj/project.pbxproj
+++ b/contrib/dxx-rebirth.xcodeproj/project.pbxproj
@@ -356,7 +356,6 @@
 		14F8AA9F1A2D6320003AA93A /* txb2tex.1 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.man; path = txb2tex.1; sourceTree = "<group>"; };
 		14F8AAA01A2D6320003AA93A /* txb2tex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = txb2tex.c; sourceTree = "<group>"; };
 		14F8AAA31A2D6320003AA93A /* GPL-3.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "GPL-3.txt"; sourceTree = "<group>"; };
-		14F8AAA41A2D6320003AA93A /* sconf.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sconf.log; sourceTree = "<group>"; };
 		14F8AAA51A2D6320003AA93A /* SConstruct */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SConstruct; sourceTree = "<group>"; };
 		14F8AAA61A2D6320003AA93A /* font.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = font.cpp; sourceTree = "<group>"; };
 		14F8AAA71A2D6320003AA93A /* palette.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = palette.cpp; sourceTree = "<group>"; };
@@ -489,7 +488,6 @@
 				14F8AA561A2D6320003AA93A /* d1x-rebirth */,
 				14F8AAA21A2D6320003AA93A /* d2x-rebirth */,
 				14F8AAA31A2D6320003AA93A /* GPL-3.txt */,
-				14F8AAA41A2D6320003AA93A /* sconf.log */,
 				14F8AAA51A2D6320003AA93A /* SConstruct */,
 				14F8AB261A2D6320003AA93A /* similar */,
 			);
@@ -1513,7 +1511,8 @@
 				SDKROOT = macosx;
 				dxx_build_dir = "builddir=build/$(PRODUCT_NAME)";
 				dxx_build_type = "debug=True editor=False";
-				scons_args = "$(dxx_build_target) $(dxx_build_renderer) $(dxx_build_type) $(dxx_build_dir)";
+				dxx_net_opts = "ipv6=False use_udp=True use_tracker=True";
+				scons_args = "$(dxx_build_target) $(dxx_build_renderer) $(dxx_build_type) $(dxx_build_dir) $(dxx_net_opts)";
 			};
 			name = Debug;
 		};
@@ -1550,7 +1549,8 @@
 				SDKROOT = macosx;
 				dxx_build_dir = "builddir=build/$(PRODUCT_NAME)";
 				dxx_build_type = "debug=False editor=False";
-				scons_args = "$(dxx_build_target) $(dxx_build_renderer) $(dxx_build_type) $(dxx_build_dir)";
+				dxx_net_opts = "ipv6=False use_udp=True use_tracker=True";
+				scons_args = "$(dxx_build_target) $(dxx_build_renderer) $(dxx_build_type) $(dxx_build_dir) $(dxx_net_opts)";
 			};
 			name = Release;
 		};
@@ -1593,7 +1593,8 @@
 				SDKROOT = macosx;
 				dxx_build_dir = "builddir=build/$(PRODUCT_NAME)";
 				dxx_build_type = "debug=True editor=True";
-				scons_args = "$(dxx_build_target) $(dxx_build_renderer) $(dxx_build_type) $(dxx_build_dir)";
+				dxx_net_opts = "ipv6=False use_udp=True use_tracker=True";
+				scons_args = "$(dxx_build_target) $(dxx_build_renderer) $(dxx_build_type) $(dxx_build_dir) $(dxx_net_opts)";
 			};
 			name = Editor;
 		};

--- a/similar/arch/sdl/jukebox.cpp
+++ b/similar/arch/sdl/jukebox.cpp
@@ -109,7 +109,7 @@ const file_extension_t jukebox_exts[7] = { SONG_EXT_HMP, SONG_EXT_MID, SONG_EXT_
 static int read_m3u(void)
 {
 	FILE *fp;
-	uint_fast32_t length;
+	std::size_t length;
 	char *buf;
 	array<char, PATH_MAX> absbuf;
 	if (PHYSFSX_exists(GameCfg.CMLevelMusicPath.data(), 0)) // it's a child of Sharepath, build full path

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -27,7 +27,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 #include <algorithm>
 #include <stdio.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string.h>
 #include <stdarg.h>
 


### PR DESCRIPTION
first commit fixes this problem:
```
Compiling d2x-rebirth build/d2x-rebirth-opengl/ similar/arch/sdl/jukebox.cpp
similar/arch/sdl/jukebox.cpp:143:10: error: use of overloaded operator '[]' is ambiguous (with operand types 'RAIIdmem<char []>' and 'uint_fast32_t' (aka 'unsigned int'))
        list_buf[length] = '\0';        // make sure the last string is terminated
        ~~~~~~~~^~~~~~~
        typename tt::enable_if<tt::rank<T>::value != 0, element_type &>::type operator[](std::size_t i) const
                                                                              ^
        typename tt::enable_if<tt::rank<T>::value != 0, element_type &>::type operator[](int i) const
                                                                              ^
        list_buf[length] = '\0';        // make sure the last string is terminated
                ^
1 error generated.
```

couple more on the way