### PR TITLE
compiling without USE_UDP

### DIFF
--- a/common/main/multi.h
+++ b/common/main/multi.h
@@ -31,7 +31,6 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "powerup.h"
 #include "fwdobject.h"
 
-#ifdef USE_UDP
 #ifdef _WIN32
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT
@@ -586,5 +585,4 @@ namespace multi
 	};
 }
 
-#endif
 #endif


### PR DESCRIPTION
even when compiling without USE_UDP, almost everything in multi.h is needed.
With this change, dxx-rebirth can be compiled with use_udp=False

I needed that to work because net_udp.cpp now causes clang to crash for some reason.