### PR TITLE
Prevent digi_mixer_start_sound() from trying to play nonexisting sounds.

### DIFF
--- a/similar/arch/sdl/digi_mixer.cpp
+++ b/similar/arch/sdl/digi_mixer.cpp
@@ -168,6 +168,10 @@ int digi_mixer_start_sound(short soundnum, fix volume, int pan, int looping, int
 	int channel;
 
 	if (!digi_initialised) return -1;
+
+	if (soundnum < 0)
+		return -1;
+
 	Assert(GameSounds[soundnum].data != (void *)-1);
 
 	mixdigi_convert_sound(soundnum);


### PR DESCRIPTION
There is a an out-of-bounds access in digi_mixer_start_sound() when
soundnum is < 0. The bounds check I added here is already present in
digi_audio_start_sound().

This bug was triggered on the RPi d2x built when trying to show the
briefing screen because briefing_new_screen() tries to play
SOUND_BRIEFING_HUM, which digi_xlat_sound() translated to -1 in this
situation. The game finally crashed in mixdigi_convert_sound() because
GameSounds[-1] happened to contain some non-zero data (on my Linux desktop,
that memory seems to be always 0 by accident...). This was also the reason
why the pi version tried to allocate lots of memory before it crashed in
memcpy().
