### PR TITLE
Use Travis for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ compiler:
 - clang
 
 before_install:
+- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 - sudo apt-get update -qq
 - sudo apt-get install -y libphysfs-dev libsdl1.2-dev libsdl-mixer1.2-dev
+- if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
 script: scons

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 compiler:
 - gcc
-- clang
+#- clang
 
 before_install:
 - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: cpp
+
+compiler:
+- gcc
+- clang
+
+before_install:
+- sudo apt-get update -qq
+- sudo apt-get install -y libphysfs-dev libsdl1.2-dev libsdl-mixer1.2-dev
+
+script: scons

--- a/contrib/dxx-rebirth.xcodeproj/project.pbxproj
+++ b/contrib/dxx-rebirth.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXFileReference section */
 		1469259F1A57A0E50014A414 /* ntstring.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ntstring.h; sourceTree = "<group>"; };
+		14AC23E81ABE1AF60067931F /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		14F8A91B1A2D6320003AA93A /* 2dsline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = 2dsline.cpp; sourceTree = "<group>"; };
 		14F8A91C1A2D6320003AA93A /* bitblt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bitblt.cpp; sourceTree = "<group>"; };
 		14F8A91D1A2D6320003AA93A /* bitmap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bitmap.cpp; sourceTree = "<group>"; };
@@ -482,6 +483,7 @@
 		141FE1011A2D62B100A4FB18 /* .. */ = {
 			isa = PBXGroup;
 			children = (
+				14AC23E81ABE1AF60067931F /* .travis.yml */,
 				14F8AA1E1A2D6320003AA93A /* common */,
 				14F8AA2B1A2D6320003AA93A /* contrib */,
 				14F8AA2C1A2D6320003AA93A /* COPYING.txt */,

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -24,7 +24,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
  */
 
 #include <stdio.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string.h>
 #include <stdarg.h>
 #include <ctype.h>


### PR DESCRIPTION
By adding .travis.yml and registering your repo at travis-ci.org, you can have the build automatically tested any time code is checked in. Even pull requests can be automatically checked.

I'm not sure when or if it will be possible to add a native OS X to the supported builds at travis, but having automatic checks on linux for clang and gcc should be pretty useful. I imagine it might be possible to get cross-compiles working for mingw and os x.

My fork is on travis here: https://travis-ci.org/btb/dxx-rebirth
Unfortunately it doesn't build yet. Perhaps you could help me figure out why.
