### PR TITLE
Unification: RPi updates

### DIFF
--- a/common/main/object.h
+++ b/common/main/object.h
@@ -351,7 +351,7 @@ struct object_rw
 	int     signature;      // Every object ever has a unique signature...
 	ubyte   type;           // what type of object this is... robot, weapon, hostage, powerup, fireball
 	ubyte   id;             // which form of object...which powerup, robot, etc.
-#ifdef WORDS_NEED_ALIGNMENT
+#if defined(WORDS_NEED_ALIGNMENT) && !defined(RPI)
 	short   pad;
 #endif
 	short   next,prev;      // id of next and previous connected object in Objects, -1 = no connection
@@ -394,7 +394,7 @@ struct object_rw
 		vclip_info_rw      vclip_info;     // vclip
 	} __pack__ rtype;
 
-#ifdef WORDS_NEED_ALIGNMENT
+#if defined(WORDS_NEED_ALIGNMENT) && !defined(RPI)
 	short   pad2;
 #endif
 } __pack__;

--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -852,10 +852,10 @@ void ogl_upixelc(int x, int y, int c)
 
 unsigned char ogl_ugpixel(const grs_bitmap &bitmap, unsigned x, unsigned y)
 {
-	GLint gl_draw_buffer;
 	ubyte buf[4];
 
 #ifndef OGLES
+	GLint gl_draw_buffer;
 	glGetIntegerv(GL_DRAW_BUFFER, &gl_draw_buffer);
 	glReadBuffer(gl_draw_buffer);
 #endif

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -288,6 +288,8 @@ static void ogl_texture_stats(void)
 	res = SWIDTH * SHEIGHT;
 #ifndef OGLES
 	glGetIntegerv(GL_INDEX_BITS, &idx);
+#else
+	idx=16;
 #endif
 	glGetIntegerv(GL_RED_BITS, &r);
 	glGetIntegerv(GL_GREEN_BITS, &g);
@@ -295,6 +297,8 @@ static void ogl_texture_stats(void)
 	glGetIntegerv(GL_ALPHA_BITS, &a);
 #ifndef OGLES
 	glGetIntegerv(GL_DOUBLEBUFFER, &dbl);
+#else
+	dbl=1;
 #endif
 	dbl += 1;
 	glGetIntegerv(GL_DEPTH_BITS, &depth);

--- a/similar/main/state.cpp
+++ b/similar/main/state.cpp
@@ -890,9 +890,6 @@ int state_save_all_sub(const char *filename, const char *desc)
 {
 	int i;
 	char mission_filename[9];
-#ifdef OGL
-	GLint gl_draw_buffer;
-#endif
 	fix tmptime32 = 0;
 
 	#ifndef NDEBUG
@@ -939,6 +936,7 @@ int state_save_all_sub(const char *filename, const char *desc)
 		RAIIdmem<uint8_t[]> buf;
 		MALLOC(buf, uint8_t[], THUMBNAIL_W * THUMBNAIL_H * 4);
 #ifndef OGLES
+		GLint gl_draw_buffer;
  		glGetIntegerv(GL_DRAW_BUFFER, &gl_draw_buffer);
  		glReadBuffer(gl_draw_buffer);
 #endif


### PR DESCRIPTION
These patches make the RPi port compile again. There has always been some warnings about unused and uninitialized variables, which are now treated as errors, so fix those.

There is also a patch included which does not change the alignment of the `object_rw` structure for RPI builds, so that those should become compatible to desktop build network games, as well as savagame-compatible, as discussed here: 
http://www.dxx-rebirth.com/frm/index.php/topic,1986.msg21232.html#msg21232