### PR TITLE
Restore inclusion of byteutil.h in similiar/3d/interp.cpp

### DIFF
--- a/similar/3d/interp.cpp
+++ b/similar/3d/interp.cpp
@@ -20,6 +20,7 @@
 #include "common/3d/globvars.h"
 #include "polyobj.h"
 #include "gr.h"
+#include "byteutil.h"
 #include "u_mem.h"
 
 static const unsigned OP_EOF = 0;   //eof


### PR DESCRIPTION
c4a84320817b9e02f86f3ec2dd2678e3367cddcc removed lots of inclusions of byteutil.h in various source files. However, when building with WORDS_NEED_ALIGNMENT, interp.cpp makes use of the INTEL_SHORT and GET_INTEL_SHORT macros defined there, breaking the RPi builds which it intented to fix.

Fixes: c4a84320817b9e02f86f3ec2dd2678e3367cddcc  ("Remove WORDS_NEED_ALIGNMENT memcpy src cast to const uint8_t*")