### PR TITLE
change namespace dcx to dsx in common/include/interp.h

### DIFF
--- a/common/include/interp.h
+++ b/common/include/interp.h
@@ -63,7 +63,7 @@ int g3_poly_get_color(const uint8_t *model_ptr);
 }
 #endif
 
-namespace dcx {
+namespace dsx {
 #ifdef WORDS_BIGENDIAN
 // routine to convert little to big endian in polygon model data
 void swap_polygon_model_data(ubyte *data);


### PR DESCRIPTION
Some functions only present in the `WORDS_BIGENDIAN` and `WORDS_NEED_ALIGNMENT` case were declared in `namespace dcx` in the header `common/include/interp.h`, while they were defined in `namepsace dsx` in `similiar/3d/interp.cpp`. This broke the RPi build. This changes the declaration to match the definition.

Fixes: 32051298ae3f5a1ce5cae21377b2a7f99d9a649f