### PR TITLE
Fix editor crash introduced in unification.

### DIFF
--- a/common/include/editor/kdefs.h
+++ b/common/include/editor/kdefs.h
@@ -181,7 +181,10 @@ int med_keypad_goto();
 int med_increase_tilings();
 int med_decrease_tilings();
 int ToggleAutosave();
+#ifndef NDEBUG
+int MarkStart();
 int MarkEnd();
+#endif
 
 //	Texture.c
 int	TexFlipX();

--- a/common/main/game.h
+++ b/common/main/game.h
@@ -375,6 +375,9 @@ extern fix64	Time_flash_last_played;
 
 #ifdef EDITOR
 void dump_used_textures_all();
+#ifndef NDEBUG
+extern int Mark_count;      // number of debugging marks set
+#endif
 #endif
 
 #endif

--- a/similar/editor/kfuncs.cpp
+++ b/similar/editor/kfuncs.cpp
@@ -228,6 +228,10 @@ const FUNCTION med_functions[] = {
 {   "med-segment-exchange",             0,      ExchangeMarkandCurseg },
 {   "med-segment-mark",                 0,      CopySegToMarked },
 {	 "med-about",								 0,      ShowAbout },
+#ifndef NDEBUG
+{	 "med-mark-start",						 0,		MarkStart },
+{	 "med-mark-end",						 	 0,		MarkEnd },
+#endif
 
 //	In group.c
 {	 "med-group-load",						 0, 		LoadGroup },

--- a/similar/editor/med.cpp
+++ b/similar/editor/med.cpp
@@ -1273,3 +1273,24 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 	
 	return rval;
 }
+
+#ifndef NDEBUG
+int MarkStart(void)
+{
+	char mystr[30];
+	sprintf(mystr,"mark %i start",Mark_count);
+//	_MARK_(mystr);//Nuked to compile -KRB
+
+	return 1;
+}
+
+int MarkEnd(void)
+{
+	char mystr[30];
+	sprintf(mystr,"mark %i end",Mark_count);
+	Mark_count++;
+//	_MARK_(mystr);//Nuked to compile -KRB
+
+	return 1;
+}
+#endif

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -115,6 +115,10 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "partial_range.h"
 #include "segiter.h"
 
+#ifndef NDEBUG
+int	Mark_count = 0;                 // number of debugging marks set
+#endif
+
 static fix64 last_timer_value=0;
 fix ThisLevelTime=0;
 

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -126,7 +126,11 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 using std::min;
 
-// Global Variables -----------------------------------------------------------
+// External Variables -----------------------------------------------------------
+
+#ifndef NDEBUG
+extern int	Mark_count;
+#endif
 
 //	Function prototypes --------------------------------------------------------
 #ifndef RELEASE


### PR DESCRIPTION
Imported functions and variables relating to med-mark-start and med-mark-end (both in common/include/editor/kdefs.h) that were somehow lost from v0.58.1 to unification. If dxx-rebirth was compiled with both editor=True and debug=True, it would crash as soon as the editor was opened.