### PR TITLE
Add include directive for <locale>

### DIFF
--- a/similar/main/inferno.cpp
+++ b/similar/main/inferno.cpp
@@ -51,6 +51,7 @@ char copyright[] = "DESCENT II  COPYRIGHT (C) 1994-1996 PARALLAX SOFTWARE CORPOR
 #endif
 
 #include <cctype>
+#include <locale>
 #include "pstypes.h"
 #include "strutil.h"
 #include "console.h"


### PR DESCRIPTION
Add include directive for <locale>, fixing four compiler errors on Apple Clang.
I thought I would get you to review this first just in case. Still very green with C++!