### PR TITLE
Allow frameworks to go in app bundle for Mac OS X

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3066,6 +3066,7 @@ class DXXCommon(LazyObjectConstructor):
 				CPPPATH = [os.path.join(library_frameworks, 'SDL.framework/Headers'), '/Library/Frameworks/SDL.framework/Headers'],
 				FRAMEWORKS = ['ApplicationServices', 'Cocoa', 'SDL'],
 				FRAMEWORKPATH = [library_frameworks, '/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks'],
+				LINKFLAGS = ['-Xlinker', '-rpath', '-Xlinker', '@loader_path/../Frameworks'],	# Allow libraries & frameworks to go in app bundle
 			)
 			if self.user_settings.opengl or self.user_settings.opengles:
 				env.Append(FRAMEWORKS = ['OpenGL'])


### PR DESCRIPTION
Allow frameworks and libraries to be packaged into the DXX-Rebirth app bundle for Mac OS X (under Contents/Frameworks).

Previously this could be achieved by setting the install path to `@executable_path/../Frameworks/<path to framework>` for each framework or library, but for Mac OS X 10.5 onwards, these frameworks (namely SDL and SDL_mixer) are set by default to install to `@rpath` for greater flexibility. `@rpath` is then set by the binary, in this case DXX-Rebirth to `@loader_path/../Frameworks` via SCons.

On Mac OS X it is common practice to distribute applications with any frameworks or libraries specific to that application within the application bundle.