### PR TITLE
Use no code optimisation for the Debugger build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3379,7 +3379,12 @@ class DXXCommon(LazyObjectConstructor):
 		env = self.env
 		user_settings = self.user_settings
 
-		env.Prepend(CXXFLAGS = ['-g', '-O2'])
+		if user_settings.debug:
+			env.Prepend(CXXFLAGS = ['-O0'])
+		else:
+			env.Prepend(CXXFLAGS = ['-O2'])
+
+		env.Prepend(CXXFLAGS = ['-g'])
 		# Raspberry Pi?
 		if user_settings.raspberrypi:
 			rpi_vc_path = user_settings.rpi_vc_path

--- a/common/main/newmenu.h
+++ b/common/main/newmenu.h
@@ -135,12 +135,12 @@ public:
 		return get_union_member(nm_private_slider);
 	}
 	number_slider_common_type *number_or_slider() {
-		return (type == nm_private_number.nm_type || type == nm_private_slider.nm_type)
+		return (type == NM_TYPE_NUMBER || type == NM_TYPE_SLIDER)
 			? &nm_private_number
 			: nullptr;
 	}
 	input_common_type *input_or_menu() {
-		return (type == nm_private_input.nm_type || type == nm_private_imenu.nm_type)
+		return (type == NM_TYPE_INPUT || type == NM_TYPE_INPUT_MENU)
 			? &nm_private_input
 			: nullptr;
 	}


### PR DESCRIPTION
Use no code optimisation for the Debugger build, so Xcode's debugger (others?) can debug properly.

After making this change to SConstruct Apple's linker complains of missing symbols:
```
Undefined symbols for architecture x86_64:
  "newmenu_item::imenu_specific_type::nm_type", referenced from:
      newmenu_item::input_or_menu() in .d1x-rebirth.newmenu.o
  "newmenu_item::input_specific_type::nm_type", referenced from:
      newmenu_item::input_or_menu() in .d1x-rebirth.newmenu.o
  "newmenu_item::number_specific_type::nm_type", referenced from:
      newmenu_item::number_or_slider() in .d1x-rebirth.newmenu.o
  "newmenu_item::slider_specific_type::nm_type", referenced from:
      newmenu_item::number_or_slider() in .d1x-rebirth.newmenu.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

```
Therefore, using #define constants instead of integral constants so Clang (others?) doesn't get confused when -O0 optimisation is used.

Making a branch for this in case there are any issues with using no optimisation I was unaware of.