### PR TITLE
Allow window subclasses

### DIFF
--- a/common/arch/sdl/window.cpp
+++ b/common/arch/sdl/window.cpp
@@ -25,7 +25,7 @@ namespace dcx {
 static window *FrontWindow = NULL;
 static window *FirstWindow = NULL;
 
-window::window(grs_canvas *src, int x, int y, int w, int h, window_subfunction<void> event_callback, void *data, const void *createdata)
+window::window(grs_canvas *src, int x, int y, int w, int h, window_alloc_type type, window_subfunction<void> event_callback, void *data, const void *createdata)
 {
 	window *prev_front = window_get_front();
 	d_create_event event;
@@ -36,6 +36,7 @@ window::window(grs_canvas *src, int x, int y, int w, int h, window_subfunction<v
 	wind->w_callback = event_callback;
 	wind->w_visible = 1;	// default to visible
 	wind->w_modal =	1;		// default to modal
+	wind->w_alloc = type;
 	wind->w_data = data;
 
 	if (FirstWindow == NULL)
@@ -53,11 +54,30 @@ window::window(grs_canvas *src, int x, int y, int w, int h, window_subfunction<v
 	WINDOW_SEND_EVENT(wind, EVENT_WINDOW_ACTIVATED);
 }
 
+void window::unlink()
+{
+	if (this == FrontWindow)
+		FrontWindow = this->prev;
+	if (this == FirstWindow)
+		FirstWindow = this->next;
+	if (this->next)
+		this->next->prev = this->prev;
+	if (this->prev)
+		this->prev->next = this->next;
+}
+
+window::~window()
+{
+	if (w_alloc == window_alloc_type::subclass)
+		unlink();
+}
+
 int window_close(window *wind)
 {
 	window *prev;
 	d_event event;
 	window_event_result (*w_callback)(window *wind,const d_event &event, void *data) = wind->w_callback;
+	window_alloc_type type = wind->w_alloc;
 
 	if (wind == window_get_front())
 		WINDOW_SEND_EVENT(wind, EVENT_WINDOW_DEACTIVATED);	// Deactivate first
@@ -72,21 +92,19 @@ int window_close(window *wind)
 		return 0;
 	}
 
-	if (wind == FrontWindow)
-		FrontWindow = wind->prev;
-	if (wind == FirstWindow)
-		FirstWindow = wind->next;
-	if (wind->next)
-		wind->next->prev = wind->prev;
-	if (wind->prev)
-		wind->prev->next = wind->next;
+	if (type == window_alloc_type::separate)
+		wind->unlink();		// Remove from the window list
 
 	if ((prev = window_get_front()))
 		WINDOW_SEND_EVENT(prev, EVENT_WINDOW_ACTIVATED);
 
+	// Callback needs to recognise this is a NULL pointer! (And 'wind' will be a dangling pointer for window_alloc_type::subclass)
 	event.type = EVENT_WINDOW_CLOSED;
-	w_callback(wind, event, NULL);	// callback needs to recognise this is a NULL pointer!
-	delete wind;
+	w_callback(wind, event, NULL);
+	
+	if (type == window_alloc_type::separate)
+		delete wind;
+
 	return 1;
 }
 

--- a/common/arch/sdl/window.cpp
+++ b/common/arch/sdl/window.cpp
@@ -22,17 +22,6 @@
 
 namespace dcx {
 
-struct window
-{
-	grs_canvas w_canv;					// the window's canvas to draw to
-	window_event_result (*w_callback)(window *wind,const d_event &event, void *data);	// the event handler
-	int w_visible;						// whether it's visible
-	int w_modal;						// modal = accept all user input exclusively
-	void *data;							// whatever the user wants (eg menu data for 'newmenu' menus)
-	struct window *prev;				// the previous window in the doubly linked list
-	struct window *next;				// the next window in the doubly linked list
-};
-
 static window *FrontWindow = NULL;
 static window *FirstWindow = NULL;
 
@@ -127,16 +116,6 @@ window *window_get_first(void)
 	return FirstWindow;
 }
 
-window *window_get_next(window &wind)
-{
-	return wind.next;
-}
-
-window *window_get_prev(window &wind)
-{
-	return wind.prev;
-}
-
 // Make wind the front window
 void window_select(window &wind)
 {
@@ -156,7 +135,7 @@ void window_select(window &wind)
 	wind.next = nullptr;
 	FrontWindow = &wind;
 	
-	if (window_is_visible(wind))
+	if (window_is_visible(&wind))
 	{
 		if (prev)
 			WINDOW_SEND_EVENT(prev, EVENT_WINDOW_DEACTIVATED);
@@ -181,16 +160,6 @@ window *window_set_visible(window &w, int visible)
 	return wind;
 }
 
-int window_is_visible(window &wind)
-{
-	return wind.w_visible;
-}
-
-grs_canvas &window_get_canvas(window &wind)
-{
-	return wind.w_canv;
-}
-
 #if !DXX_USE_OGL
 void window_update_canvases()
 {
@@ -205,23 +174,5 @@ void window_update_canvases()
 							wind->w_canv.cv_bitmap.bm_h);
 }
 #endif
-
-window_event_result window_send_event(window &wind, const d_event &event)
-{
-	auto r = wind.w_callback(&wind, event, wind.data);
-	if (r == window_event_result::close)
-		window_close(&wind);
-	return r;
-}
-
-void window_set_modal(window &wind, int modal)
-{
-	wind.w_modal = modal;
-}
-
-int window_is_modal(window &wind)
-{
-	return wind.w_modal;
-}
 
 }

--- a/common/arch/sdl/window.cpp
+++ b/common/arch/sdl/window.cpp
@@ -25,18 +25,18 @@ namespace dcx {
 static window *FrontWindow = NULL;
 static window *FirstWindow = NULL;
 
-window *window_create(grs_canvas *src, int x, int y, int w, int h, window_subfunction<void> event_callback, void *data, const void *createdata)
+window::window(grs_canvas *src, int x, int y, int w, int h, window_subfunction<void> event_callback, void *data, const void *createdata)
 {
-	window *prev = window_get_front();
+	window *prev_front = window_get_front();
 	d_create_event event;
-	window *wind = new window;
+	window *wind = this;
 	Assert(src != NULL);
 	Assert(event_callback != NULL);
 	gr_init_sub_canvas(wind->w_canv, *src, x, y, w, h);
 	wind->w_callback = event_callback;
 	wind->w_visible = 1;	// default to visible
 	wind->w_modal =	1;		// default to modal
-	wind->data = data;
+	wind->w_data = data;
 
 	if (FirstWindow == NULL)
 		FirstWindow = wind;
@@ -45,14 +45,12 @@ window *window_create(grs_canvas *src, int x, int y, int w, int h, window_subfun
 		FrontWindow->next = wind;
 	wind->next = NULL;
 	FrontWindow = wind;
-	if (prev)
-		WINDOW_SEND_EVENT(prev, EVENT_WINDOW_DEACTIVATED);
+	if (prev_front)
+		WINDOW_SEND_EVENT(prev_front, EVENT_WINDOW_DEACTIVATED);
 
 	event.createdata = createdata;
 	WINDOW_SEND_EVENT(wind, EVENT_WINDOW_CREATED);
 	WINDOW_SEND_EVENT(wind, EVENT_WINDOW_ACTIVATED);
-
-	return wind;
 }
 
 int window_close(window *wind)

--- a/common/include/fwd-window.h
+++ b/common/include/fwd-window.h
@@ -36,18 +36,18 @@ int window_close(window *wind);
 int window_exists(window *wind);
 window *window_get_front();
 window *window_get_first();
-window *window_get_next(window &wind);
-window *window_get_prev(window &wind);
+static inline window *window_get_next(window &wind);
+static inline window *window_get_prev(window &wind);
 void window_select(window &wind);
 window *window_set_visible(window &wind, int visible);
-int window_is_visible(window &wind);
-grs_canvas &window_get_canvas(window &wind);
+static inline int window_is_visible(window &wind);
+static inline grs_canvas &window_get_canvas(window &wind);
 #if !DXX_USE_OGL
 void window_update_canvases();
 #endif
-window_event_result window_send_event(window &wind,const d_event &event);
-void window_set_modal(window &wind, int modal);
-int window_is_modal(window &wind);
+static inline window_event_result window_send_event(window &wind,const d_event &event);
+static inline void window_set_modal(window &wind, int modal);
+static inline int window_is_modal(window &wind);
 
 #define WINDOW_SEND_EVENT(w, e)	(event.type = e, (WINDOW_SEND_EVENT)(*w, event, __FILE__, __LINE__, #e))
 

--- a/common/include/fwd-window.h
+++ b/common/include/fwd-window.h
@@ -24,13 +24,14 @@ enum class window_event_result : uint8_t;
 template <typename T>
 using window_subfunction = window_event_result (*)(window *menu,const d_event &event, T *userdata);
 
+template <typename T>
+using window_subclass_subfunction = window_event_result (*)(T *menu,const d_event &event, void*);
+	
 class unused_window_userdata_t;
 
 /* No declaration for embed_window_pointer_t or ignore_window_pointer_t
  * since every user needs the full definition.
  */
-
-window *window_create(grs_canvas *src, int x, int y, int w, int h, window_subfunction<void> event_callback, void *userdata, const void *createdata);
 
 int window_close(window *wind);
 int window_exists(window *wind);

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -57,14 +57,20 @@ private:
 	window_event_result (*w_callback)(window *wind,const d_event &event, void *data);	// the event handler
 	int w_visible;						// whether it's visible
 	int w_modal;						// modal = accept all user input exclusively
-	void *data;							// whatever the user wants (eg menu data for 'newmenu' menus)
+	void *w_data;							// whatever the user wants (eg menu data for 'newmenu' menus)
 	struct window *prev;				// the previous window in the doubly linked list
 	struct window *next;				// the next window in the doubly linked list
 	
 public:
+	// For creating the window, there are two ways - using the (older) window_create function
+	// or using the constructor, passing an event handler that takes a subclass of window.
+	explicit window(grs_canvas *src, int x, int y, int w, int h, window_subfunction<void> event_callback, void *data, const void *createdata);
+
+	template <typename T>
+			window(grs_canvas *src, int x, int y, int w, int h, window_subclass_subfunction<T> event_callback) :
+			window(src, x, y, w, h, reinterpret_cast<window_subclass_subfunction<window>>(event_callback), NULL, NULL) {}
+
 	// Declaring as friends to keep function syntax, for historical reasons (for now at least)
-	friend window *window_create(grs_canvas *src, int x, int y, int w, int h, window_subfunction<void> event_callback, void *userdata, const void *createdata);
-	
 	friend int window_close(window *wind);
 	friend int window_exists(window *wind);
 	friend window *window_get_front();
@@ -105,7 +111,7 @@ public:
 	
 	friend window_event_result window_send_event(window &wind, const d_event &event)
 	{
-		auto r = wind.w_callback(&wind, event, wind.data);
+		auto r = wind.w_callback(&wind, event, wind.w_data);
 		if (r == window_event_result::close)
 			window_close(&wind);
 		return r;
@@ -126,7 +132,7 @@ public:
 template <typename T1, typename T2 = const void>
 static inline window *window_create(grs_canvas *src, int x, int y, int w, int h, window_subfunction<T1> event_callback, T1 *data, T2 *createdata = nullptr)
 {
-	auto win = window_create(src, x, y, w, h, reinterpret_cast<window_subfunction<void>>(event_callback), static_cast<void *>(data), static_cast<const void *>(createdata));
+	auto win = new window(src, x, y, w, h, reinterpret_cast<window_subfunction<void>>(event_callback), static_cast<void *>(data), static_cast<const void *>(createdata));
 	set_embedded_window_pointer(data, win);
 	return win;
 }
@@ -134,7 +140,7 @@ static inline window *window_create(grs_canvas *src, int x, int y, int w, int h,
 template <typename T1, typename T2 = const void>
 static inline window *window_create(grs_canvas *src, int x, int y, int w, int h, window_subfunction<const T1> event_callback, const T1 *userdata, T2 *createdata = nullptr)
 {
-	return window_create(src, x, y, w, h, reinterpret_cast<window_subfunction<void>>(event_callback), static_cast<void *>(const_cast<T1 *>(userdata)), static_cast<const void *>(createdata));
+	return new window(src, x, y, w, h, reinterpret_cast<window_subfunction<void>>(event_callback), static_cast<void *>(const_cast<T1 *>(userdata)), static_cast<const void *>(createdata));
 }
 
 static inline window_event_result (WINDOW_SEND_EVENT)(window &w, const d_event &event, const char *file, unsigned line, const char *e)


### PR DESCRIPTION
These changes are to the dcx::window struct and related functions to allow the window struct to be subclassed (see Issue #229). In particular, this would be useful for the editor, which is currently crashing when some dialogs are opened (for example Object->AI Properties dialog).

I made these changes so as not to impact the existing uses of the dcx::window system (at least at this stage).