### PR TITLE
Allow UI_DIALOG to be subclassed

### DIFF
--- a/common/include/ui.h
+++ b/common/include/ui.h
@@ -241,6 +241,8 @@ public:
 	template <typename T>
 	UI_DIALOG(short x, short y, short w, short h, enum dialog_flags flags, ui_subclass_subfunction_t<T> callback) :
 	UI_DIALOG(x, y, w, h, flags, reinterpret_cast<ui_subclass_subfunction_t<UI_DIALOG>>(callback), nullptr, nullptr) {}
+	
+	~UI_DIALOG();
 };
 
 #define B1_JUST_PRESSED     (event.type == EVENT_MOUSE_BUTTON_DOWN && event_mouse_get_button(event) == 0)

--- a/common/include/ui.h
+++ b/common/include/ui.h
@@ -216,10 +216,10 @@ enum dialog_flags
 };
 
 template <typename T>
-using ui_subfunction_t = int (*)(struct UI_DIALOG *,const d_event &, T *);
+using ui_subfunction_t = window_event_result (*)(struct UI_DIALOG *,const d_event &, T *);
 
 template <typename T>
-using ui_subclass_subfunction_t = int (*)(T *,const d_event &, void *);
+using ui_subclass_subfunction_t = window_event_result (*)(T *,const d_event &, void *);
 
 struct UI_DIALOG : embed_window_pointer_t
 {

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -30,6 +30,8 @@ enum class window_event_result : uint8_t
 	// Window handled event.
 	handled,
 	close,
+	// Window handler already deleted window (most likely because it was subclassed), don't attempt to re-delete
+	deleted,
 };
 
 constexpr const unused_window_userdata_t *unused_window_userdata = nullptr;

--- a/common/ui/dialog.cpp
+++ b/common/ui/dialog.cpp
@@ -134,7 +134,6 @@ static window_event_result ui_dialog_handler(window *wind,const d_event &event, 
 			ui_gadget_delete_all(dlg);
 			selected_gadget = NULL;
 			delete dlg;
-			delete wind;
 			return window_event_result::ignored;
 		default:
 			return window_event_result::ignored;

--- a/common/ui/dialog.cpp
+++ b/common/ui/dialog.cpp
@@ -133,10 +133,9 @@ static window_event_result ui_dialog_handler(window *wind,const d_event &event, 
 		}
 
 		case EVENT_WINDOW_CLOSE:
-			ui_gadget_delete_all(dlg);
-			selected_gadget = NULL;
-			delete dlg;
-			return window_event_result::ignored;
+			if (rval != window_event_result::deleted)	// check if handler already deleted dialog (e.g. if UI_DIALOG was subclassed)
+				delete dlg;
+			return window_event_result::ignored;	// free the window in any case (until UI_DIALOG is subclass of window)
 		default:
 			return window_event_result::ignored;
 	}
@@ -192,6 +191,12 @@ window *ui_dialog_get_window(UI_DIALOG *dlg)
 void ui_dialog_set_current_canvas(UI_DIALOG *dlg)
 {
 	gr_set_current_canvas(window_get_canvas(*dlg->wind));
+}
+
+UI_DIALOG::~UI_DIALOG()
+{
+	ui_gadget_delete_all(this);
+	selected_gadget = NULL;
 }
 
 void ui_close_dialog( UI_DIALOG * dlg )

--- a/common/ui/dialog.cpp
+++ b/common/ui/dialog.cpp
@@ -91,14 +91,16 @@ static void ui_dialog_draw(UI_DIALOG *dlg)
 // The dialog handler borrows heavily from the newmenu_handler
 static window_event_result ui_dialog_handler(window *wind,const d_event &event, UI_DIALOG *dlg)
 {
+	window_event_result rval{window_event_result::ignored};
+
 	if (event.type == EVENT_WINDOW_CLOSED ||
 		event.type == EVENT_WINDOW_ACTIVATED ||
 		event.type == EVENT_WINDOW_DEACTIVATED)
 		return window_event_result::ignored;
 	
 	if (dlg->d_callback)
-		if ((*dlg->d_callback)(dlg, event, dlg->d_userdata))
-			return window_event_result::handled;		// event handled
+		if ((rval = (*dlg->d_callback)(dlg, event, dlg->d_userdata)) == window_event_result::handled)
+			return rval;		// event handled
 
 	if (!window_exists(wind))
 		return window_event_result::handled;
@@ -121,7 +123,7 @@ static window_event_result ui_dialog_handler(window *wind,const d_event &event, 
 		case EVENT_WINDOW_DRAW:
 		{
 			ui_dialog_draw(dlg);
-			window_event_result rval = ui_dialog_do_gadgets(dlg, event);
+			rval = ui_dialog_do_gadgets(dlg, event);
 			if (rval != window_event_result::close)
 			{
 				d_event event2 = { EVENT_UI_DIALOG_DRAW };

--- a/common/ui/file.cpp
+++ b/common/ui/file.cpp
@@ -114,9 +114,9 @@ struct ui_file_browser
 
 }
 
-static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_browser *const b)
+static window_event_result browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_browser *const b)
 {
-	int rval = 0;
+	window_event_result rval = window_event_result::ignored;
 
 	if (event.type == EVENT_UI_DIALOG_DRAW)
 	{
@@ -129,7 +129,7 @@ static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_b
 		ui_dputs_at(dlg, 20, 60, b->spaces.data());
 		ui_dputs_at( dlg, 20, 60, b->view_dir );
 		
-		return 1;
+		return window_event_result::handled;
 	}
 
 	if (GADGET_PRESSED(b->button2.get()))
@@ -137,13 +137,13 @@ static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_b
 		b->filename_list.reset();
 		b->directory_list.reset();
 		ui_close_dialog(dlg);
-		return 1;
+		return window_event_result::handled;
 	}
 	
 	if (GADGET_PRESSED(b->help_button.get()))
 	{
 		ui_messagebox( -1, -1, 1, "Sorry, no help is available!", "Ok" );
-		rval = 1;
+		rval = window_event_result::handled;
 	}
 	
 	if (event.type == EVENT_UI_LISTBOX_MOVED)
@@ -154,7 +154,7 @@ static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_b
 		if ((ui_event_get_gadget(event) == b->listbox2.get()) && (b->listbox2->current_item >= 0) && b->directory_list[b->listbox2->current_item])
 			ui_inputbox_set_text(b->user_file.get(), b->directory_list[b->listbox2->current_item]);
 
-		rval = 1;
+		rval = window_event_result::handled;
 	}
 	
 	if (GADGET_PRESSED(b->button1.get()) || GADGET_PRESSED(b->user_file.get()) || event.type == EVENT_UI_LISTBOX_SELECTED)
@@ -190,7 +190,7 @@ static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_b
 			{
 				// Looks like a valid filename that already exists!
 				ui_close_dialog(dlg);
-				return 1;
+				return window_event_result::handled;
 			}
 			
 			// File doesn't exist, but can we create it?
@@ -200,7 +200,7 @@ static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_b
 				// Looks like a valid filename!
 				PHYSFS_delete(b->filename);
 				ui_close_dialog(dlg);
-				return 1;
+				return window_event_result::handled;
 			}
 		}
 		else
@@ -214,7 +214,7 @@ static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_b
 			{
 				b->directory_list.reset();
 				ui_close_dialog(dlg);
-				return 1;
+				return window_event_result::handled;
 			}
 			
 			ui_inputbox_set_text(b->user_file.get(), b->filespec);
@@ -223,7 +223,7 @@ static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_b
 			{
 				b->filename_list.reset();
 				ui_close_dialog(dlg);
-				return 1;
+				return window_event_result::handled;
 			}
 			
 			ui_listbox_change(dlg, b->listbox1.get(), b->filename_list.get_count(), b->filename_list.get());
@@ -234,7 +234,7 @@ static int browser_handler(UI_DIALOG *const dlg, const d_event &event, ui_file_b
 			
 		}
 		
-		rval = 1;
+		rval = window_event_result::handled;
 	}
 	
 	return rval;

--- a/common/ui/menu.cpp
+++ b/common/ui/menu.cpp
@@ -49,24 +49,24 @@ struct menu
 
 }
 
-static int menu_handler(UI_DIALOG *,const d_event &event, menu *m)
+static window_event_result menu_handler(UI_DIALOG *,const d_event &event, menu *m)
 {
 	for (int i=0; i<m->num_buttons; i++ )
 	{
 		if (GADGET_PRESSED(m->button_g[i].get()))
 		{
 			*(m->choice) = i+1;
-			return 1;
+			return window_event_result::handled;
 		}
 	}
 	
 	if ( (*(m->choice)==0) && B1_JUST_RELEASED )
 	{
 		*(m->choice) = -1;
-		return 1;
+		return window_event_result::handled;
 	}
 	
-	return 0;
+	return window_event_result::ignored;
 }
 
 int MenuX( int x, int y, int NumButtons, const char *const text[] )

--- a/common/ui/menubar.cpp
+++ b/common/ui/menubar.cpp
@@ -510,7 +510,7 @@ static window_event_result do_state_2(const d_event &event)
 
 
 
-static window_event_result menu_handler(window *wind, const d_event &event, MENU *menu)
+static window_event_result menu_handler(window *, const d_event &event, MENU *menu)
 {
 	int i;
 	int keypress = 0;
@@ -524,7 +524,6 @@ static window_event_result menu_handler(window *wind, const d_event &event, MENU
 	{
 		state = 0;
 		menu_hide_all();
-		delete wind;
 		menu->wind = nullptr;
 		return window_event_result::ignored;
 	}
@@ -665,7 +664,7 @@ static window_event_result menu_handler(window *wind, const d_event &event, MENU
 	return rval;
 }
 
-static window_event_result menubar_handler(window *wind, const d_event &event, MENU *)
+static window_event_result menubar_handler(window *, const d_event &event, MENU *)
 {
 	if (event.type == EVENT_WINDOW_DRAW)
 	{
@@ -685,7 +684,6 @@ static window_event_result menubar_handler(window *wind, const d_event &event, M
 			}
 		}
 		
-		delete wind;
 		Menu[0].wind = nullptr;
 	}
 

--- a/common/ui/message.cpp
+++ b/common/ui/message.cpp
@@ -61,7 +61,7 @@ struct messagebox
 
 }
 
-static int messagebox_handler(UI_DIALOG *dlg,const d_event &event, messagebox *m)
+static window_event_result messagebox_handler(UI_DIALOG *dlg,const d_event &event, messagebox *m)
 {
 	if (event.type == EVENT_UI_DIALOG_DRAW)
 	{
@@ -83,7 +83,7 @@ static int messagebox_handler(UI_DIALOG *dlg,const d_event &event, messagebox *m
 
 		grd_curscreen->sc_canvas.cv_font = temp_font;
 		
-		return 1;
+		return window_event_result::handled;
 	}
 
 	for (uint_fast32_t i=0; i < m->button->count(); i++ )
@@ -91,11 +91,11 @@ static int messagebox_handler(UI_DIALOG *dlg,const d_event &event, messagebox *m
 		if (GADGET_PRESSED(m->button_g[i].get()))
 		{
 			*(m->choice) = i+1;
-			return 1;
+			return window_event_result::handled;
 		}
 	}
 	
-	return 0;
+	return window_event_result::ignored;
 }
 
 int (ui_messagebox)( short xc, short yc, const char * text, const ui_messagebox_tie &Button )

--- a/d2x-rebirth/main/escort.cpp
+++ b/d2x-rebirth/main/escort.cpp
@@ -1690,7 +1690,6 @@ static window_event_result escort_menu_handler(window *wind,const d_event &event
 			
 		case EVENT_WINDOW_CLOSE:
 			d_free(menu);
-			delete wind;
 			return window_event_result::ignored;	// continue closing
 		default:
 			return window_event_result::ignored;

--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -274,7 +274,7 @@ struct movie : ignore_window_pointer_t
 
 }
 
-static window_event_result show_pause_message(window *wind, const d_event &event, const unused_window_userdata_t *)
+static window_event_result show_pause_message(window *, const d_event &event, const unused_window_userdata_t *)
 {
 	switch (event.type)
 	{
@@ -309,17 +309,13 @@ static window_event_result show_pause_message(window *wind, const d_event &event
 			break;
 		}
 
-		case EVENT_WINDOW_CLOSE:
-			delete wind;
-			break;
-
 		default:
 			break;
 	}
 	return window_event_result::ignored;
 }
 
-static window_event_result MovieHandler(window *wind, const d_event &event, movie *m)
+static window_event_result MovieHandler(window *, const d_event &event, movie *m)
 {
 	int key;
 
@@ -373,7 +369,6 @@ static window_event_result MovieHandler(window *wind, const d_event &event, movi
 		case EVENT_WINDOW_CLOSE:
 			if (Quitting)
 				m->result = m->aborted = 1;
-			delete wind;
 			break;
 			
 		default:

--- a/similar/editor/centers.cpp
+++ b/similar/editor/centers.cpp
@@ -76,7 +76,7 @@ struct centers_dialog
 
 }
 
-static int centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, centers_dialog *c);
+static window_event_result centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, centers_dialog *c);
 
 //-------------------------------------------------------------------------
 // Called from the editor... does one instance of the centers dialog box
@@ -108,7 +108,7 @@ int do_centers_dialog()
 }
 
 namespace dsx {
-static int centers_dialog_created(UI_DIALOG *const w, centers_dialog *const c)
+static window_event_result centers_dialog_created(UI_DIALOG *const w, centers_dialog *const c)
 {
 #if defined(DXX_BUILD_DESCENT_I)
 	int i = 80;
@@ -135,7 +135,7 @@ static int centers_dialog_created(UI_DIALOG *const w, centers_dialog *const c)
 	for (i=0; i < N_robot_types; i++)
 		c->robotMatFlag[i] = ui_add_gadget_checkbox( w, 128 + (i%d)*92, 20+(i/d)*24, 16, 16, 0, Robot_names[i].data());
 	c->old_seg_num = -2;		// Set to some dummy value so everything works ok on the first frame.
-	return 1;
+	return window_event_result::handled;
 }
 }
 
@@ -147,7 +147,7 @@ void close_centers_window()
 	}
 }
 
-int centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, centers_dialog *c)
+window_event_result centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, centers_dialog *c)
 {
 	switch(event.type)
 	{
@@ -156,13 +156,13 @@ int centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, centers_dialog *
 		case EVENT_WINDOW_CLOSE:
 			std::default_delete<centers_dialog>()(c);
 			MainWindow = NULL;
-			return 0;
+			return window_event_result::ignored;
 		default:
 			break;
 	}
 //	int robot_flags;
 	int keypress = 0;
-	int rval = 0;
+	window_event_result rval = window_event_result::ignored;
 
 	Assert(MainWindow != NULL);
 
@@ -208,7 +208,7 @@ int centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, centers_dialog *
 				Update_flags |= UF_WORLD_CHANGED;
 				fuelcen_activate( Cursegp, i );
 			}
-			rval = 1;
+			rval = window_event_result::handled;
 		}
 	}
 
@@ -222,7 +222,7 @@ int centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, centers_dialog *
 				f |= mask;
 			else
 				f &= ~mask;
-			rval = 1;
+			rval = window_event_result::handled;
 		}
 	}
 	
@@ -242,7 +242,7 @@ int centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, centers_dialog *
 	if (GADGET_PRESSED(c->quitButton.get()) || keypress==KEY_ESC)
 	{
 		close_centers_window();
-		return 1;
+		return window_event_result::handled;
 	}		
 
 	c->old_seg_num = Cursegp;

--- a/similar/editor/eswitch.cpp
+++ b/similar/editor/eswitch.cpp
@@ -281,7 +281,7 @@ static int trigger_turn_all_ON()
 	return 1;
 }
 
-static int trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, trigger_dialog *t);
+static window_event_result trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, trigger_dialog *t);
 
 //-------------------------------------------------------------------------
 // Called from the editor... does one instance of the trigger dialog box
@@ -308,7 +308,7 @@ int do_trigger_dialog()
 	return 1;
 }
 
-static int trigger_dialog_created(UI_DIALOG *const w, trigger_dialog *const t)
+static window_event_result trigger_dialog_created(UI_DIALOG *const w, trigger_dialog *const t)
 {
 	// These are the checkboxes for each door flag.
 	int i = 44;
@@ -336,7 +336,7 @@ static int trigger_dialog_created(UI_DIALOG *const w, trigger_dialog *const t)
 	t->enable_all_triggers = ui_add_gadget_button(w, 155, i, 140, 26, "All Triggers ON", trigger_turn_all_ON); i += 29;
 
 	t->old_trigger_num = -2;		// Set to some dummy value so everything works ok on the first frame.
-	return 1;
+	return window_event_result::handled;
 }
 
 void close_trigger_window()
@@ -347,7 +347,7 @@ void close_trigger_window()
 	}
 }
 
-int trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, trigger_dialog *t)
+window_event_result trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, trigger_dialog *t)
 {
 	switch(event.type)
 	{
@@ -356,17 +356,17 @@ int trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, trigger_dialog *
 		case EVENT_WINDOW_CLOSE:
 			std::default_delete<trigger_dialog>()(t);
 			MainWindow = NULL;
-			return 0;
+			return window_event_result::ignored;
 		default:
 			break;
 	}
 	int keypress = 0;
-	int rval = 0;
+	window_event_result rval = window_event_result::ignored;
 
 	Assert(MainWindow != NULL);
 	if (!Markedsegp) {
 		close_trigger_window();
-		return 0;
+		return window_event_result::ignored;
 	}
 
 	//------------------------------------------------------------
@@ -409,7 +409,7 @@ int trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, trigger_dialog *
 	//------------------------------------------------------------
 	if (IS_CHILD(Markedsegp->children[Markedside]))
 	{
-		rval = 1;
+		rval = window_event_result::handled;
 		
 		if (GADGET_PRESSED(t->triggerFlag[0].get())) 
 			trigger_flag_Markedside(TRIGGER_CONTROL_DOORS, t->triggerFlag[0]->flag); 
@@ -432,7 +432,7 @@ int trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, trigger_dialog *
 		else if (GADGET_PRESSED(t->triggerFlag[9].get())) 
 			trigger_flag_Markedside(TRIGGER_SECRET_EXIT, t->triggerFlag[9]->flag);
 		else
-			rval = 0;
+			rval = window_event_result::ignored;
 
 	} else
 		range_for (auto &i, t->triggerFlag)
@@ -478,7 +478,7 @@ int trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, trigger_dialog *
 	if (GADGET_PRESSED(t->quitButton.get()) || keypress == KEY_ESC)
 	{
 		close_trigger_window();
-		return 1;
+		return window_event_result::handled;
 	}		
 
 	t->old_trigger_num = trigger_num;

--- a/similar/editor/info.cpp
+++ b/similar/editor/info.cpp
@@ -334,7 +334,6 @@ static window_event_result info_display_all(window *wind,const d_event &event, c
 			return window_event_result::handled;
 		case EVENT_WINDOW_CLOSE:
 			Pad_info = NULL;
-			delete wind;
 			break;
 			
 		default:

--- a/similar/editor/med.cpp
+++ b/similar/editor/med.cpp
@@ -318,7 +318,7 @@ static int padnum=0;
 
 static void init_editor_screen();
 static void gamestate_restore_check();
-static int editor_handler(UI_DIALOG *dlg,const d_event &event, unused_ui_userdata_t *data);
+static window_event_result editor_handler(UI_DIALOG *dlg,const d_event &event, unused_ui_userdata_t *data);
 
 namespace dsx {
 void init_editor()
@@ -957,14 +957,14 @@ int RestoreGameState() {
 }
 
 // Handler for the main editor dialog
-int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
+window_event_result editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 {
 	editor_view *new_cv;
 	int keypress = 0;
-	int rval = 0;
+	window_event_result rval = window_event_result::ignored;
 
 	if (event.type == EVENT_WINDOW_CREATED)
-		return 0;
+		return window_event_result::ignored;
 
 	if (event.type == EVENT_KEY_COMMAND)
 		keypress = event_key_get(event);
@@ -972,7 +972,7 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 	{
 		close_editor();
 		EditorWindow = NULL;
-		return 0;
+		return window_event_result::ignored;
 	}
 	
 	// Update the windows
@@ -994,7 +994,7 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 		print_status_bar(status_line);
 		TimedAutosave(mine_filename);	// shows the time, hence here
 		set_editor_time_of_day();
-		return 1;
+		return window_event_result::handled;
 	}
 	
 	if ((selected_gadget == GameViewBox.get() && !render_3d_in_big_window) ||
@@ -1025,7 +1025,7 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 						Update_flags |= UF_ED_STATE_CHANGED;
 					}
 
-					rval = 1;
+					rval = window_event_result::handled;
 				}
 				break;
 				
@@ -1093,7 +1093,7 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 	{
 		KeyFunction[keypress]();
 		keypress = 0;
-		rval = 1;
+		rval = window_event_result::handled;
 	}
 
 	switch (keypress)
@@ -1111,15 +1111,15 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 			break;
 		case KEY_SHIFTED + KEY_L:
 			ToggleLighting();
-			rval = 1;
+			rval = window_event_result::handled;
 			break;
 		case KEY_F1:
 			render_3d_in_big_window = !render_3d_in_big_window;
 			Update_flags |= UF_ALL;
-			rval = 1;
+			rval = window_event_result::handled;
 			break;			
 		default:
-			if (!rval)
+			if (rval == window_event_result::ignored)
 			{
 				char kdesc[100];
 				GetKeyDescription( kdesc, keypress );
@@ -1132,7 +1132,7 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 	if (ModeFlag)
 	{
 		ui_close_dialog(EditorWindow);
-		return 0;
+		return window_event_result::ignored;
 	}
 
 //		if (EditorWindow->keyboard_focus_gadget == GameViewBox) current_view=NULL;
@@ -1154,10 +1154,10 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 
 	// DO TEXTURE STUFF
 	if (texpage_do(event))
-		rval = 1;
+		rval = window_event_result::handled;
 	
 	if (objpage_do(event))
-		rval = 1;
+		rval = window_event_result::handled;
 
 
 	// Process selection of Cursegp using mouse.
@@ -1274,7 +1274,7 @@ int editor_handler(UI_DIALOG *, const d_event &event, unused_ui_userdata_t *)
 			LargeView.ev_matrix = vm_matrix_x_matrix(LargeView.ev_matrix,MouseRotMat);
 			LargeView.ev_changed = 1;
 			Large_view_index = -1;			// say not one of the orthogonal views
-			rval = 1;
+			rval = window_event_result::handled;
 		}
 	}
 

--- a/similar/editor/medrobot.cpp
+++ b/similar/editor/medrobot.cpp
@@ -84,7 +84,7 @@ struct robot_dialog
 }
 
 namespace dsx {
-static int robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, robot_dialog *r);
+static window_event_result robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, robot_dialog *r);
 
 }
 static void call_init_ai_object(object &objp, ai_behavior behavior)
@@ -482,7 +482,7 @@ int do_robot_dialog()
 	return 1;
 }
 
-static int robot_dialog_created(UI_DIALOG *const w, robot_dialog *const r)
+static window_event_result robot_dialog_created(UI_DIALOG *const w, robot_dialog *const r)
 {
 	r->quitButton = ui_add_gadget_button(w, 20, 286, 40, 32, "Done", NULL);
 	r->prev_powerup_type = ui_add_gadget_button(w, GOODY_X+50, GOODY_Y-3, 25, 22, "<<", GoodyPrevType);
@@ -515,7 +515,7 @@ static int robot_dialog_created(UI_DIALOG *const w, robot_dialog *const r)
 	r->old_object = -2;		// Set to some dummy value so everything works ok on the first frame.
 	if ( Cur_object_index == object_none)
 		LocalObjectSelectNextinMine();
-	return 1;
+	return window_event_result::handled;
 }
 
 void robot_close_window()
@@ -528,7 +528,7 @@ void robot_close_window()
 }
 
 namespace dsx {
-int robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, robot_dialog *r)
+window_event_result robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, robot_dialog *r)
 {
 	switch(event.type)
 	{
@@ -537,7 +537,7 @@ int robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, robot_dialog *r)
 		case EVENT_WINDOW_CLOSE:
 			std::default_delete<robot_dialog>()(r);
 			MainWindow = NULL;
-			return 0;
+			return window_event_result::ignored;
 		default:
 			break;
 	}
@@ -545,7 +545,7 @@ int robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, robot_dialog *r)
 	fix64	Temp;
 	int	first_object_index;
 	int keypress = 0;
-	int rval = 0;
+	window_event_result rval = window_event_result::ignored;
 	
 	if (event.type == EVENT_KEY_COMMAND)
 		keypress = event_key_get(event);
@@ -611,7 +611,7 @@ int robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, robot_dialog *r)
 			if (behavior != b) {
 				behavior = b;		// Set the ai_state to the cooresponding radio button
 				call_init_ai_object(objp, b);
-				rval = 1;
+				rval = window_event_result::handled;
 			}
 		}
 	}
@@ -716,7 +716,7 @@ int robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, robot_dialog *r)
 	if (GADGET_PRESSED(r->quitButton.get()) || keypress == KEY_ESC)
 	{
 		robot_close_window();
-		return 1;
+		return window_event_result::handled;
 	}		
 
 	r->old_object = Cur_object_index;
@@ -751,7 +751,7 @@ struct object_dialog
 
 }
 
-static int object_dialog_handler(UI_DIALOG *dlg,const d_event &event, object_dialog *o);
+static window_event_result object_dialog_handler(UI_DIALOG *dlg,const d_event &event, object_dialog *o);
 
 void object_close_window()
 {
@@ -785,7 +785,7 @@ int do_object_dialog()
 	return 1;
 }
 
-static int object_dialog_created(UI_DIALOG *const w, object_dialog *const o, const object_dialog::creation_context *const c)
+static window_event_result object_dialog_created(UI_DIALOG *const w, object_dialog *const o, const object_dialog::creation_context *const c)
 {
 	o->quitButton = ui_add_gadget_button(w, 20, 286, 40, 32, "Done", NULL );
 	o->quitButton->hotkey = KEY_ENTER;
@@ -802,10 +802,11 @@ static int object_dialog_created(UI_DIALOG *const w, object_dialog *const o, con
 	o->ztext = ui_add_gadget_inputbox<MATT_LEN>(w, 30, 192, message);
 	ui_gadget_calc_keys(w);
 	w->keyboard_focus_gadget = o->initialMode[0].get();
-	return 1;
+
+	return window_event_result::handled;
 }
 
-static int object_dialog_handler(UI_DIALOG *dlg,const d_event &event, object_dialog *o)
+static window_event_result object_dialog_handler(UI_DIALOG *dlg,const d_event &event, object_dialog *o)
 {
 	switch(event.type)
 	{
@@ -814,13 +815,13 @@ static int object_dialog_handler(UI_DIALOG *dlg,const d_event &event, object_dia
 		case EVENT_WINDOW_CLOSE:
 			std::default_delete<object_dialog>()(o);
 			MattWindow = NULL;
-			return 0;
+			return window_event_result::ignored;
 		default:
 			break;
 	}
 	const auto &&obj = vobjptr(Cur_object_index);
 	int keypress = 0;
-	int rval = 0;
+	window_event_result rval = window_event_result::ignored;
 	
 	if (event.type == EVENT_KEY_COMMAND)
 		keypress = event_key_get(event);
@@ -851,7 +852,7 @@ static int object_dialog_handler(UI_DIALOG *dlg,const d_event &event, object_dia
 		obj->mtype.spin_rate.z = fl2f(atof(o->ztext->text.get()));
 
 		object_close_window();
-		return 1;
+		return window_event_result::handled;
 	}
 	
 	return rval;

--- a/similar/editor/medwall.cpp
+++ b/similar/editor/medwall.cpp
@@ -87,7 +87,7 @@ struct count_wall
 
 }
 
-static int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd);
+static window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd);
 
 //---------------------------------------------------------------------
 // Add a wall (removable 2 sided)
@@ -344,7 +344,7 @@ int do_wall_dialog()
 	return 1;
 }
 
-static int wall_dialog_created(UI_DIALOG *const w, wall_dialog *const wd)
+static window_event_result wall_dialog_created(UI_DIALOG *const w, wall_dialog *const wd)
 {
 	wd->quitButton = ui_add_gadget_button(w, 20, 252, 48, 40, "Done", NULL);
 	// These are the checkboxes for each door flag.
@@ -372,7 +372,8 @@ static int wall_dialog_created(UI_DIALOG *const w, wall_dialog *const wd)
 	wd->bind_trigger = ui_add_gadget_button(w, 155, i, 140, 22, "Bind to Trigger", bind_wall_to_trigger); i += 25;
 	wd->bind_control = ui_add_gadget_button(w, 155, i, 140, 22, "Bind to Control", bind_wall_to_control_center); i+=25;
 	wd->old_wall_num = -2;		// Set to some dummy value so everything works ok on the first frame.
-	return 1;
+
+	return window_event_result::handled;
 }
 
 void close_wall_window()
@@ -381,7 +382,7 @@ void close_wall_window()
 		ui_close_dialog(exchange(MainWindow, nullptr));
 }
 
-int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
+window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
 {
 	switch(event.type)
 	{
@@ -389,7 +390,7 @@ int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
 			return wall_dialog_created(dlg, wd);
 		case EVENT_WINDOW_CLOSE:
 			std::default_delete<wall_dialog>()(wd);
-			return 0;
+			return window_event_result::ignored;
 		default:
 			break;
 	}
@@ -397,7 +398,7 @@ int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
 	fix DeltaTime;
 	fix64 Temp;
 	int keypress = 0;
-	int rval = 0;
+	window_event_result rval = window_event_result::ignored;
 	
 	if (event.type == EVENT_KEY_COMMAND)
 		keypress = event_key_get(event);
@@ -442,7 +443,7 @@ int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
 				w->flags |= WALL_DOOR_LOCKED;
 			else
 				w->flags &= ~WALL_DOOR_LOCKED;
-			rval = 1;
+			rval = window_event_result::handled;
 		}
 		else if (GADGET_PRESSED(wd->doorFlag[1].get()))
 		{
@@ -450,7 +451,7 @@ int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
 				w->flags |= WALL_DOOR_AUTO;
 			else
 				w->flags &= ~WALL_DOOR_AUTO;
-			rval = 1;
+			rval = window_event_result::handled;
 		}
 
 		//------------------------------------------------------------
@@ -461,7 +462,7 @@ int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
 			if (GADGET_PRESSED(wd->keyFlag[i].get()))
 			{
 				w->keys = 1<<i;		// Set the ai_state to the cooresponding radio button
-				rval = 1;
+				rval = window_event_result::handled;
 			}
 		}
 	} else {
@@ -478,7 +479,7 @@ int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
 				w->flags |= WALL_ILLUSION_OFF;
 			else
 				w->flags &= ~WALL_ILLUSION_OFF;
-			rval = 1;
+			rval = window_event_result::handled;
 		}
 	} else 
 		for (	int i=2; i < 3; i++ ) 
@@ -574,7 +575,7 @@ int wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wall_dialog *wd)
 	if (GADGET_PRESSED(wd->quitButton.get()) || keypress == KEY_ESC)
 	{
 		close_wall_window();
-		return 1;
+		return window_event_result::handled;
 	}		
 
 	wd->old_wall_num = Cursegp->sides[Curside].wall_num;

--- a/similar/main/automap.cpp
+++ b/similar/main/automap.cpp
@@ -952,7 +952,6 @@ static window_event_result automap_handler(window *wind,const d_event &event, au
 			window_set_visible(Game_wind, 1);
 			Automap_active = 0;
 			multi_send_msgsend_state(msgsend_none);
-			delete wind;
 			return window_event_result::ignored;	// continue closing
 			break;
 

--- a/similar/main/console.cpp
+++ b/similar/main/console.cpp
@@ -287,7 +287,6 @@ static window_event_result con_handler(window *wind,const d_event &event, const 
 			}
 			break;
 		case EVENT_WINDOW_CLOSE:
-			delete wind;
 			break;
 		default:
 			break;

--- a/similar/main/credits.cpp
+++ b/similar/main/credits.cpp
@@ -94,7 +94,7 @@ struct credits : ignore_window_pointer_t
 }
 
 namespace dsx {
-static window_event_result credits_handler(window *wind, const d_event &event, credits *cr)
+static window_event_result credits_handler(window *, const d_event &event, credits *cr)
 {
 	int l, y;
 	switch (event.type)
@@ -217,7 +217,6 @@ static window_event_result credits_handler(window *wind, const d_event &event, c
 			songs_set_volume(GameCfg.MusicVolume);
 			songs_play_song( SONG_TITLE, 1 );
 			std::default_delete<credits>()(cr);
-			delete wind;
 			break;
 		default:
 			break;

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -1305,7 +1305,6 @@ window_event_result game_handler(window *,const d_event &event, const unused_win
 			if (!EditorWindow)		// have to do it this way because of the necessary longjmp. Yuck.
 #endif
 				show_menus();
-			delete Game_wind;
 			Game_wind = NULL;
 			event_toggle_focus(0);
 			key_toggle_repeat(1);

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -339,7 +339,7 @@ struct pause_window : ignore_window_pointer_t
 };
 
 //Process selected keys until game unpaused
-static window_event_result pause_handler(window *wind, const d_event &event, pause_window *p)
+static window_event_result pause_handler(window *, const d_event &event, pause_window *p)
 {
 	int key;
 
@@ -379,7 +379,6 @@ static window_event_result pause_handler(window *wind, const d_event &event, pau
 		case EVENT_WINDOW_CLOSE:
 			songs_resume();
 			delete p;
-			delete wind;
 			break;
 
 		default:

--- a/similar/main/kconfig.cpp
+++ b/similar/main/kconfig.cpp
@@ -1286,7 +1286,6 @@ static window_event_result kconfig_handler(window *wind,const d_event &event, kc
 			
 		case EVENT_WINDOW_CLOSE:
 			delete menu;
-			delete wind;
 			
 			// Update save values...
 			

--- a/similar/main/kmatrix.cpp
+++ b/similar/main/kmatrix.cpp
@@ -279,7 +279,7 @@ static void kmatrix_redraw_coop()
 }
 
 namespace dsx {
-static window_event_result kmatrix_handler(window *wind, const d_event &event, kmatrix_screen *km)
+static window_event_result kmatrix_handler(window *, const d_event &event, kmatrix_screen *km)
 {
 	int k = 0, choice = 0;
 	
@@ -377,7 +377,6 @@ static window_event_result kmatrix_handler(window *wind, const d_event &event, k
 		case EVENT_WINDOW_CLOSE:
 			game_flush_inputs();
 			newmenu_free_background();
-			delete wind;
 			break;
 			
 		default:

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -2285,7 +2285,7 @@ void do_options_menu()
 
 #ifndef RELEASE
 namespace dsx {
-static window_event_result polygon_models_viewer_handler(window *wind, const d_event &event, const unused_window_userdata_t *)
+static window_event_result polygon_models_viewer_handler(window *, const d_event &event, const unused_window_userdata_t *)
 {
 	static unsigned view_idx;
 	int key = 0;
@@ -2354,7 +2354,6 @@ static window_event_result polygon_models_viewer_handler(window *wind, const d_e
 		case EVENT_WINDOW_CLOSE:
 			load_palette(MENU_PALETTE,0,1);
 			key_toggle_repeat(0);
-			delete wind;
 			break;
 		default:
 			break;
@@ -2378,7 +2377,7 @@ static void polygon_models_viewer()
 }
 
 namespace dsx {
-static window_event_result gamebitmaps_viewer_handler(window *wind, const d_event &event, const unused_window_userdata_t *)
+static window_event_result gamebitmaps_viewer_handler(window *, const d_event &event, const unused_window_userdata_t *)
 {
 	static int view_idx = 0;
 	int key = 0;
@@ -2434,7 +2433,6 @@ static window_event_result gamebitmaps_viewer_handler(window *wind, const d_even
 		case EVENT_WINDOW_CLOSE:
 			load_palette(MENU_PALETTE,0,1);
 			key_toggle_repeat(0);
-			delete wind;
 			break;
 		default:
 			break;

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -1567,7 +1567,6 @@ static window_event_result newmenu_handler(window *wind,const d_event &event, ne
 			return newmenu_draw(wind, menu);
 		case EVENT_WINDOW_CLOSE:
 			delete menu;
-			delete wind;
 			break;
 
 		default:
@@ -2075,7 +2074,6 @@ static window_event_result listbox_handler(window *wind,const d_event &event, li
 			return listbox_draw(wind, lb);
 		case EVENT_WINDOW_CLOSE:
 			std::default_delete<listbox>()(lb);
-			delete wind;
 			break;
 		default:
 			break;

--- a/similar/main/scores.cpp
+++ b/similar/main/scores.cpp
@@ -446,7 +446,6 @@ static window_event_result scores_handler(window *wind,const d_event &event, sco
 			
 		case EVENT_WINDOW_CLOSE:
 			d_free(menu);
-			delete wind;
 			break;
 
 		default:

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -109,7 +109,7 @@ struct title_screen : ignore_window_pointer_t
 
 }
 
-static window_event_result title_handler(window *wind, const d_event &event, title_screen *ts)
+static window_event_result title_handler(window *, const d_event &event, title_screen *ts)
 {
 	switch (event.type)
 	{
@@ -146,7 +146,6 @@ static window_event_result title_handler(window *wind, const d_event &event, tit
 
 		case EVENT_WINDOW_CLOSE:
 			gr_free_bitmap_data(ts->title_bm);
-			delete wind;
 			break;
 
 		default:
@@ -1444,7 +1443,7 @@ static int new_briefing_screen(briefing *br, int first)
 
 //-----------------------------------------------------------------------------
 namespace dsx {
-static window_event_result briefing_handler(window *wind, const d_event &event, briefing *br)
+static window_event_result briefing_handler(window *, const d_event &event, briefing *br)
 {
 	switch (event.type)
 	{
@@ -1554,7 +1553,6 @@ static window_event_result briefing_handler(window *wind, const d_event &event, 
 #if defined(DXX_BUILD_DESCENT_II)
 			br->hum_channel.reset();
 #endif
-			delete wind;
 			break;
 
 		default:


### PR DESCRIPTION
Allow a `UI_DIALOG` to be subclassed, by adding the constructors and destructor. Doing this before attempting to make `UI_DIALOG` a subclass of window for several reasons, including because it would require its own constructor.

Also replacing the kludge of requiring all window handlers to free the window with a better solution - adding an `event_window_result::deleted`, which would be returned to `window_close` (or potentially have other uses) if the handler deleted the window.