### PR TITLE
Replace window_exists function calls with checking for window_event_result::deleted

### DIFF
--- a/common/arch/sdl/event.cpp
+++ b/common/arch/sdl/event.cpp
@@ -116,7 +116,7 @@ int event_init()
 	return 0;
 }
 
-int call_default_handler(const d_event &event)
+window_event_result call_default_handler(const d_event &event)
 {
 	return standard_handler(event);
 }

--- a/common/arch/sdl/event.cpp
+++ b/common/arch/sdl/event.cpp
@@ -131,7 +131,7 @@ void event_send(const d_event &event)
 		{
 			handled = window_send_event(*wind, event);
 
-			if (!window_exists(wind)) // break away if necessary: window_send_event() could have closed wind by now
+			if (handled == window_event_result::deleted) // break away if necessary: window_send_event() could have closed wind by now
 				break;
 			if (window_is_modal(*wind))
 				break;

--- a/common/arch/sdl/event.cpp
+++ b/common/arch/sdl/event.cpp
@@ -165,19 +165,20 @@ window_event_result event_process(void)
 	while (wind != NULL)
 	{
 		window *prev = window_get_prev(*wind);
-		window_event_result result(window_event_result::ignored);
 		if (window_is_visible(wind))
-			result = window_send_event(*wind, event);
-		if (result == window_event_result::deleted)
 		{
-			if (!prev) // well there isn't a previous window ...
-				break; // ... just bail out - we've done everything for this frame we can.
-			wind = window_get_next(*prev); // the current window seemed to be closed. so take the next one from the previous which should be able to point to the one after the current closed
-		}
-		else
-			wind = window_get_next(*wind);
+			auto result = window_send_event(*wind, event);
+			if (result == window_event_result::deleted)
+			{
+				if (!prev) // well there isn't a previous window ...
+					break; // ... just bail out - we've done everything for this frame we can.
+				wind = window_get_next(*prev); // the current window seemed to be closed. so take the next one from the previous which should be able to point to the one after the current closed
+			}
+			else
+				wind = window_get_next(*wind);
 
-		highest_result = std::max(result, highest_result);
+			highest_result = std::max(result, highest_result);
+		}
 	}
 
 	gr_flip();

--- a/common/arch/sdl/event.cpp
+++ b/common/arch/sdl/event.cpp
@@ -165,9 +165,10 @@ void event_process(void)
 	while (wind != NULL)
 	{
 		window *prev = window_get_prev(*wind);
+		window_event_result result(window_event_result::ignored);
 		if (window_is_visible(wind))
-			window_send_event(*wind, event);
-		if (!window_exists(wind))
+			result = window_send_event(*wind, event);
+		if (result == window_event_result::deleted)
 		{
 			if (!prev) // well there isn't a previous window ...
 				break; // ... just bail out - we've done everything for this frame we can.

--- a/common/arch/sdl/key.cpp
+++ b/common/arch/sdl/key.cpp
@@ -393,14 +393,14 @@ void pressed_keys::update(const std::size_t keycode, const uint8_t down)
 		modifier_cache &= ~mask;
 }
 
-void key_handler(SDL_KeyboardEvent *kevent)
+window_event_result key_handler(SDL_KeyboardEvent *kevent)
 {
 	int event_keysym=-1;
 
 	// Read SDLK symbol and state
         event_keysym = kevent->keysym.sym;
 		if (event_keysym == SDLK_UNKNOWN)
-			return;
+			return window_event_result::ignored;
 	const auto key_state = (kevent->state != SDL_RELEASED);
 
 	// fill the unicode frame-related unicode buffer 
@@ -418,10 +418,10 @@ void key_handler(SDL_KeyboardEvent *kevent)
 	auto re = key_properties.rend();
 	auto fi = std::find_if(key_properties.rbegin(), re, [event_keysym](const key_props &k) { return k.sym == event_keysym; });
 	if (fi == re)
-		return;
+		return window_event_result::ignored;
 	unsigned keycode = std::distance(key_properties.begin(), std::next(fi).base());
 	if (keycode == 0)
-		return;
+		return window_event_result::ignored;
 
 	/* 
 	 * process the key if:
@@ -450,8 +450,10 @@ void key_handler(SDL_KeyboardEvent *kevent)
 				(keycode & KEY_SHIFTED)	? "SHIFT" : "",
 				key_properties[keycode & 0xff].key_text
 				);
-		event_send(event);
+		return event_send(event);
 	}
+
+	return window_event_result::ignored;
 }
 
 void key_init()

--- a/common/arch/sdl/window.cpp
+++ b/common/arch/sdl/window.cpp
@@ -27,7 +27,7 @@ static window *FirstWindow = nullptr;
 
 window::window(grs_canvas &src, const int x, const int y, const int w, const int h, const window_subfunction<void> event_callback, void *const data) :
 	// Default to visible and modal
-	w_callback(event_callback), w_visible(1), w_modal(1), w_data(data), prev(FrontWindow), next(nullptr)
+	w_callback(event_callback), w_visible(1), w_modal(1), w_data(data), prev(FrontWindow), next(nullptr), w_exists(nullptr)
 {
 	Assert(event_callback != nullptr);
 	gr_init_sub_canvas(w_canv, src, x, y, w, h);
@@ -60,6 +60,8 @@ void window::send_creation_events(const void *const createdata)
 
 window::~window()
 {
+	if (w_exists)
+		*w_exists = false;
 	if (this == FrontWindow)
 		FrontWindow = this->prev;
 	if (this == FirstWindow)

--- a/common/arch/sdl/window.cpp
+++ b/common/arch/sdl/window.cpp
@@ -100,20 +100,6 @@ int window_close(window *wind)
 	return 1;
 }
 
-#if 0
-// This function is problematic in that another window could open with the same pointer value,
-// causing a false positive to be returned.
-// Could use w_exists, but that would mean filling it out with some bool stored elsewhere for every window (yuck)
-int window_exists(window *wind)
-{
-	window *w;
-
-	for (w = FirstWindow; w && w != wind; w = w->next) {}
-	
-	return w && w == wind;
-}
-#endif
-
 // Get the top window that's visible
 window *window_get_front(void)
 {

--- a/common/arch/sdl/window.cpp
+++ b/common/arch/sdl/window.cpp
@@ -100,6 +100,10 @@ int window_close(window *wind)
 	return 1;
 }
 
+#if 0
+// This function is problematic in that another window could open with the same pointer value,
+// causing a false positive to be returned.
+// Could use w_exists, but that would mean filling it out with some bool stored elsewhere for every window (yuck)
 int window_exists(window *wind)
 {
 	window *w;
@@ -108,6 +112,7 @@ int window_exists(window *wind)
 	
 	return w && w == wind;
 }
+#endif
 
 // Get the top window that's visible
 window *window_get_front(void)

--- a/common/include/event.h
+++ b/common/include/event.h
@@ -48,6 +48,17 @@ enum event_type : unsigned
 	EVENT_UI_USERBOX_DRAGGED
 };
 
+enum class window_event_result : unsigned
+{
+	// Window ignored event.  Bubble up.
+	ignored,
+	// Window handled event.
+	handled,
+	close,
+	// Window handler already deleted window (most likely because it was subclassed), don't attempt to re-delete
+	deleted,
+};
+
 // A vanilla event. Cast to the correct type of event according to 'type'.
 struct d_event
 {

--- a/common/include/event.h
+++ b/common/include/event.h
@@ -48,7 +48,7 @@ enum event_type : unsigned
 	EVENT_UI_USERBOX_DRAGGED
 };
 
-enum class window_event_result : unsigned
+enum class window_event_result : uint8_t
 {
 	// Window ignored event.  Bubble up.
 	ignored,

--- a/common/include/event.h
+++ b/common/include/event.h
@@ -90,5 +90,13 @@ struct d_select_event : d_event
 
 fix event_get_idle_seconds();
 
+// Process all events until the front window is deleted
+// Won't work if there's the possibility of another window on top
+// without its own event loop
+static inline void event_process_all(void)
+{
+	while (event_process() != window_event_result::deleted) {}
+}
+
 }
 #endif

--- a/common/include/fwd-event.h
+++ b/common/include/fwd-event.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "pstypes.h"
+
 namespace dcx {
 
 struct d_event;
@@ -15,7 +17,7 @@ struct d_change_event;
 struct d_select_event;
 
 enum event_type : unsigned;
-enum class window_event_result : unsigned;
+enum class window_event_result : uint8_t;
 
 int event_init();
 

--- a/common/include/fwd-event.h
+++ b/common/include/fwd-event.h
@@ -15,6 +15,7 @@ struct d_change_event;
 struct d_select_event;
 
 enum event_type : unsigned;
+enum class window_event_result : unsigned;
 
 int event_init();
 
@@ -23,7 +24,7 @@ void event_poll();
 void event_flush();
 
 // Set and call the default event handler
-int call_default_handler(const d_event &event);
+window_event_result call_default_handler(const d_event &event);
 
 // Send an event to the front window as first priority, then to the windows behind if it's not modal (editor), then the default handler
 void event_send(const d_event &event);

--- a/common/include/fwd-event.h
+++ b/common/include/fwd-event.h
@@ -20,17 +20,17 @@ enum class window_event_result : unsigned;
 int event_init();
 
 // Sends input events to event handlers
-void event_poll();
+window_event_result event_poll();
 void event_flush();
 
 // Set and call the default event handler
 window_event_result call_default_handler(const d_event &event);
 
 // Send an event to the front window as first priority, then to the windows behind if it's not modal (editor), then the default handler
-void event_send(const d_event &event);
+window_event_result event_send(const d_event &event);
 
 // Sends input, idle and draw events to event handlers
-void event_process();
+window_event_result event_process();
 
 void event_enable_focus();
 void event_disable_focus();

--- a/common/include/fwd-event.h
+++ b/common/include/fwd-event.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "pstypes.h"
+#include <cstdint>
 
 namespace dcx {
 

--- a/common/include/fwd-window.h
+++ b/common/include/fwd-window.h
@@ -19,7 +19,7 @@ void arch_init();
 namespace dcx {
 
 class window;
-enum class window_event_result : uint8_t;
+enum class window_event_result : unsigned;
 
 template <typename T>
 using window_subfunction = window_event_result (*)(window *menu,const d_event &event, T *userdata);

--- a/common/include/fwd-window.h
+++ b/common/include/fwd-window.h
@@ -19,7 +19,6 @@ void arch_init();
 namespace dcx {
 
 class window;
-enum class window_event_result : unsigned;
 
 template <typename T>
 using window_subfunction = window_event_result (*)(window *menu,const d_event &event, T *userdata);

--- a/common/include/fwd-window.h
+++ b/common/include/fwd-window.h
@@ -33,7 +33,7 @@ class unused_window_userdata_t;
  */
 
 int window_close(window *wind);
-int window_exists(window *wind);
+//int window_exists(window *wind);
 window *window_get_front();
 window *window_get_first();
 window *window_get_next(window &wind);

--- a/common/include/fwd-window.h
+++ b/common/include/fwd-window.h
@@ -33,7 +33,6 @@ class unused_window_userdata_t;
  */
 
 int window_close(window *wind);
-//int window_exists(window *wind);
 window *window_get_front();
 window *window_get_first();
 window *window_get_next(window &wind);

--- a/common/include/joy.h
+++ b/common/include/joy.h
@@ -50,28 +50,19 @@ namespace dcx {
 #if DXX_MAX_BUTTONS_PER_JOYSTICK
 extern window_event_result joy_button_handler(SDL_JoyButtonEvent *jbe);
 #else
-static inline window_event_result joy_button_handler(void *)
-{
-	return window_event_result::ignored;
-}
+#define joy_button_handler(jbe) (static_cast<SDL_JoyButtonEvent *const &>(jbe), window_event_result::ignored)
 #endif
 
 #if DXX_MAX_HATS_PER_JOYSTICK
 extern window_event_result joy_hat_handler(SDL_JoyHatEvent *jhe);
 #else
-static inline window_event_result joy_hat_handler(void *)
-{
-	return window_event_result::ignored;
-}
+#define joy_hat_handler(jbe) (static_cast<SDL_JoyHatEvent *const &>(jbe), window_event_result::ignored)
 #endif
 
 #if DXX_MAX_AXES_PER_JOYSTICK
 extern window_event_result joy_axis_handler(SDL_JoyAxisEvent *jae);
 #else
-static inline window_event_result joy_axis_handler(void *)
-{
-	return window_event_result::ignored;
-}
+#define joy_axis_handler(jbe) (static_cast<SDL_JoyAxisEvent *const &>(jbe), window_event_result::ignored)
 #endif
 
 }

--- a/common/include/joy.h
+++ b/common/include/joy.h
@@ -16,14 +16,12 @@
 #include "dsx-ns.h"
 
 #if DXX_MAX_JOYSTICKS
+#include "fwd-event.h"
 #include "pstypes.h"
 #include "maths.h"
 #include <SDL.h>
 
 namespace dcx {
-
-struct d_event;
-enum class window_event_result : unsigned;
 
 #define JOY_MAX_AXES				(DXX_MAX_AXES_PER_JOYSTICK * DXX_MAX_JOYSTICKS)
 #define JOY_MAX_BUTTONS				(DXX_MAX_BUTTONS_PER_JOYSTICK * DXX_MAX_JOYSTICKS)

--- a/common/include/joy.h
+++ b/common/include/joy.h
@@ -23,6 +23,7 @@
 namespace dcx {
 
 struct d_event;
+enum class window_event_result : unsigned;
 
 #define JOY_MAX_AXES				(DXX_MAX_AXES_PER_JOYSTICK * DXX_MAX_JOYSTICKS)
 #define JOY_MAX_BUTTONS				(DXX_MAX_BUTTONS_PER_JOYSTICK * DXX_MAX_JOYSTICKS)
@@ -49,19 +50,19 @@ extern int event_joystick_get_button(const d_event &event);
 namespace dcx {
 
 #if DXX_MAX_BUTTONS_PER_JOYSTICK
-extern void joy_button_handler(SDL_JoyButtonEvent *jbe);
+extern window_event_result joy_button_handler(SDL_JoyButtonEvent *jbe);
 #else
 #define joy_button_handler(jbe)	static_cast<void>(static_cast<SDL_JoyButtonEvent *const &>(jbe))
 #endif
 
 #if DXX_MAX_HATS_PER_JOYSTICK
-extern void joy_hat_handler(SDL_JoyHatEvent *jhe);
+extern window_event_result joy_hat_handler(SDL_JoyHatEvent *jhe);
 #else
 #define joy_hat_handler(jhe)	static_cast<void>(static_cast<SDL_JoyHatEvent *const &>(jhe))
 #endif
 
 #if DXX_MAX_AXES_PER_JOYSTICK
-extern int joy_axis_handler(SDL_JoyAxisEvent *jae);
+extern window_event_result joy_axis_handler(SDL_JoyAxisEvent *jae);
 #else
 #define joy_axis_handler(jae)	(static_cast<void>(static_cast<SDL_JoyAxisEvent *const &>(jae)), 1)
 #endif

--- a/common/include/joy.h
+++ b/common/include/joy.h
@@ -14,9 +14,9 @@
 
 #include "dxxsconf.h"
 #include "dsx-ns.h"
+#include "event.h"
 
 #if DXX_MAX_JOYSTICKS
-#include "fwd-event.h"
 #include "pstypes.h"
 #include "maths.h"
 #include <SDL.h>
@@ -50,19 +50,28 @@ namespace dcx {
 #if DXX_MAX_BUTTONS_PER_JOYSTICK
 extern window_event_result joy_button_handler(SDL_JoyButtonEvent *jbe);
 #else
-#define joy_button_handler(jbe)	static_cast<void>(static_cast<SDL_JoyButtonEvent *const &>(jbe))
+static inline window_event_result joy_button_handler(void *)
+{
+	return window_event_result::ignored;
+}
 #endif
 
 #if DXX_MAX_HATS_PER_JOYSTICK
 extern window_event_result joy_hat_handler(SDL_JoyHatEvent *jhe);
 #else
-#define joy_hat_handler(jhe)	static_cast<void>(static_cast<SDL_JoyHatEvent *const &>(jhe))
+static inline window_event_result joy_hat_handler(void *)
+{
+	return window_event_result::ignored;
+}
 #endif
 
 #if DXX_MAX_AXES_PER_JOYSTICK
 extern window_event_result joy_axis_handler(SDL_JoyAxisEvent *jae);
 #else
-#define joy_axis_handler(jae)	(static_cast<void>(static_cast<SDL_JoyAxisEvent *const &>(jae)), 1)
+static inline window_event_result joy_axis_handler(void *)
+{
+	return window_event_result::ignored;
+}
 #endif
 
 }

--- a/common/include/key.h
+++ b/common/include/key.h
@@ -87,7 +87,7 @@ extern pressed_keys keyd_pressed;
 #define key_toggle_repeat(E)	key_toggle_repeat##E()
 void key_toggle_repeat0();
 void key_toggle_repeat1();
-void key_handler(struct SDL_KeyboardEvent *kevent);
+window_event_result key_handler(struct SDL_KeyboardEvent *kevent);
 
 // for key_ismodlck
 #define KEY_ISMOD	1

--- a/common/include/mouse.h
+++ b/common/include/mouse.h
@@ -56,8 +56,8 @@ window_event_result mouse_in_window(class window *wind);
 extern void mouse_get_delta( int *dx, int *dy, int *dz );
 void mouse_enable_cursor();
 void mouse_disable_cursor();
-void mouse_button_handler(struct SDL_MouseButtonEvent *mbe);
-void mouse_motion_handler(struct SDL_MouseMotionEvent *mme);
+window_event_result mouse_button_handler(struct SDL_MouseButtonEvent *mbe);
+window_event_result mouse_motion_handler(struct SDL_MouseMotionEvent *mme);
 void mouse_cursor_autohide();
 
 class d_event_mousebutton : public d_event

--- a/common/include/pstypes.h
+++ b/common/include/pstypes.h
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #endif
 
+#include <cstdint>
 #include <limits.h>
 
 //define a signed byte

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -72,7 +72,7 @@ public:
 	friend window *window_create(grs_canvas &src, int x, int y, int w, int h, window_subfunction<void> event_callback, void *userdata, const void *createdata);
 	
 	friend int window_close(window *wind);
-	friend int window_exists(window *wind);
+	//friend int window_exists(window *wind);
 	friend window *window_get_front();
 	friend window *window_get_first();
 	friend void window_select(window &wind);

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -74,7 +74,6 @@ public:
 	friend window *window_create(grs_canvas &src, int x, int y, int w, int h, window_subfunction<void> event_callback, void *userdata, const void *createdata);
 	
 	friend int window_close(window *wind);
-	//friend int window_exists(window *wind);
 	friend window *window_get_front();
 	friend window *window_get_first();
 	friend void window_select(window &wind);

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -129,7 +129,9 @@ public:
 	{
 		auto r = wind.w_callback(&wind, event, wind.w_data);
 		if (r == window_event_result::close)
-			window_close(&wind);
+			if (window_close(&wind))
+				return window_event_result::deleted;
+
 		return r;
 	}
 	

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -51,6 +51,7 @@ class window
 	void *w_data;						// whatever the user wants (eg menu data for 'newmenu' menus)
 	class window *prev;				// the previous window in the doubly linked list
 	class window *next;				// the next window in the doubly linked list
+	bool *w_exists;					// optional pointer to a tracking variable
 	
 public:
 	// For creating the window, there are two ways - using the (older) window_create function
@@ -134,7 +135,14 @@ public:
 	{
 		return wind.prev;
 	}
-	
+
+	bool track(bool *exists)
+	{
+		if (w_exists)
+			return false;	// whoops - already have a tracking variable
+		w_exists = exists;
+		return true;
+	}
 };
 
 template <typename T1, typename T2 = const void>

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -21,18 +21,8 @@
 
 #ifdef __cplusplus
 #include "fwd-window.h"
+#include "event.h"
 namespace dcx {
-
-enum class window_event_result : unsigned
-{
-	// Window ignored event.  Bubble up.
-	ignored,
-	// Window handled event.
-	handled,
-	close,
-	// Window handler already deleted window (most likely because it was subclassed), don't attempt to re-delete
-	deleted,
-};
 
 constexpr const unused_window_userdata_t *unused_window_userdata = nullptr;
 

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -23,7 +23,7 @@
 #include "fwd-window.h"
 namespace dcx {
 
-enum class window_event_result : uint8_t
+enum class window_event_result : unsigned
 {
 	// Window ignored event.  Bubble up.
 	ignored,

--- a/common/include/window.h
+++ b/common/include/window.h
@@ -20,6 +20,8 @@
 #include "console.h"
 
 #ifdef __cplusplus
+#include <assert.h>
+
 #include "fwd-window.h"
 #include "event.h"
 namespace dcx {
@@ -136,12 +138,10 @@ public:
 		return wind.prev;
 	}
 
-	bool track(bool *exists)
+	void track(bool *exists)
 	{
-		if (w_exists)
-			return false;	// whoops - already have a tracking variable
+		assert(w_exists == nullptr);
 		w_exists = exists;
-		return true;
 	}
 };
 

--- a/common/main/inferno.h
+++ b/common/main/inferno.h
@@ -49,7 +49,7 @@ namespace dcx {
 constexpr std::size_t FILENAME_LEN = 13;
 
 // Default event handler for everything except the editor
-int standard_handler(const d_event &event);
+window_event_result standard_handler(const d_event &event);
 
 // a filename, useful for declaring arrays of filenames
 struct d_fname : ntstring<FILENAME_LEN - 1>

--- a/common/main/mission.h
+++ b/common/main/mission.h
@@ -32,6 +32,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "inferno.h"
 #include "dxxsconf.h"
 #include "dsx-ns.h"
+#include "fwd-window.h"
 
 #ifdef __cplusplus
 #include "ntstring.h"
@@ -224,7 +225,7 @@ int load_mission_by_name (const char *mission_name);
 
 //Handles creating and selecting from the mission list.
 //Returns 1 if a mission was loaded.
-int select_mission (int anarchy_mode, const char *message, int (*when_selected)(void));
+int select_mission (int anarchy_mode, const char *message, window_event_result (*when_selected)(void));
 
 #if DXX_USE_EDITOR
 void create_new_mission(void);

--- a/common/main/net_udp.h
+++ b/common/main/net_udp.h
@@ -17,11 +17,12 @@
 #include "pack.h"
 #include "compiler-array.h"
 #include "ntstring.h"
+#include "fwd-window.h"
 
 // Exported functions
 #ifdef dsx
 namespace dsx {
-int net_udp_setup_game(void);
+window_event_result net_udp_setup_game(void);
 }
 #endif
 void net_udp_manual_join_game();

--- a/common/main/newmenu.h
+++ b/common/main/newmenu.h
@@ -35,9 +35,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#ifdef _WIN32
 #include "fwd-window.h"
-#endif
 #include "varutil.h"
 #include "dxxsconf.h"
 #include "dsx-ns.h"
@@ -323,7 +321,7 @@ extern void listbox_delete_item(listbox *lb, int item);
 
 namespace dcx {
 template <typename T>
-using listbox_subfunction_t = int (*)(listbox *menu,const d_event &event, T *userdata);
+using listbox_subfunction_t = window_event_result (*)(listbox *menu,const d_event &event, T *userdata);
 
 class unused_listbox_userdata_t;
 constexpr listbox_subfunction_t<const unused_listbox_userdata_t> *unused_listbox_subfunction = nullptr;

--- a/common/ui/button.cpp
+++ b/common/ui/button.cpp
@@ -192,8 +192,9 @@ window_event_result ui_button_do(UI_DIALOG *dlg, UI_GADGET_BUTTON * button,const
 	}
 	else if (button->pressed)
 	{
-		ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, button);
-		return window_event_result::handled;
+		rval = ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, button);
+		if (rval == window_event_result::ignored)
+			rval = window_event_result::handled;
 	}
 	
 	return rval;

--- a/common/ui/checkbox.cpp
+++ b/common/ui/checkbox.cpp
@@ -138,9 +138,13 @@ window_event_result ui_checkbox_do( UI_DIALOG *dlg, UI_GADGET_CHECKBOX * checkbo
 		
 	if (checkbox->pressed == 1)
 	{
+		window_event_result rval;
+
 		checkbox->flag ^= 1;
-		ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, checkbox);
-		return window_event_result::handled;
+		rval = ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, checkbox);
+		if (rval == window_event_result::ignored)
+			rval = window_event_result::handled;
+		return rval;
 	}
 
 	if (event.type == EVENT_WINDOW_DRAW)

--- a/common/ui/checkbox.cpp
+++ b/common/ui/checkbox.cpp
@@ -138,10 +138,8 @@ window_event_result ui_checkbox_do( UI_DIALOG *dlg, UI_GADGET_CHECKBOX * checkbo
 		
 	if (checkbox->pressed == 1)
 	{
-		window_event_result rval;
-
 		checkbox->flag ^= 1;
-		rval = ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, checkbox);
+		auto rval = ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, checkbox);
 		if (rval == window_event_result::ignored)
 			rval = window_event_result::handled;
 		return rval;

--- a/common/ui/dialog.cpp
+++ b/common/ui/dialog.cpp
@@ -101,18 +101,12 @@ static window_event_result ui_dialog_handler(window *wind,const d_event &event, 
 		if ((rval = (*dlg->d_callback)(dlg, event, dlg->d_userdata)) != window_event_result::ignored)
 			return rval;		// event handled
 
-	if (!window_exists(wind))
-		return window_event_result::handled;
-
 	switch (event.type)
 	{
 		case EVENT_MOUSE_BUTTON_DOWN:
 		case EVENT_MOUSE_BUTTON_UP:
 		case EVENT_MOUSE_MOVED:
-			/*return*/ ui_dialog_do_gadgets(dlg, event);
-			if (!window_exists(wind))
-				return window_event_result::handled;
-			return mouse_in_window(dlg->wind);
+			return ui_dialog_do_gadgets(dlg, event);
 		case EVENT_KEY_COMMAND:
 		case EVENT_KEY_RELEASE:
 			return ui_dialog_do_gadgets(dlg, event);

--- a/common/ui/dialog.cpp
+++ b/common/ui/dialog.cpp
@@ -98,7 +98,7 @@ static window_event_result ui_dialog_handler(window *wind,const d_event &event, 
 		return window_event_result::ignored;
 	
 	if (dlg->d_callback)
-		if ((rval = (*dlg->d_callback)(dlg, event, dlg->d_userdata)) == window_event_result::handled)
+		if ((rval = (*dlg->d_callback)(dlg, event, dlg->d_userdata)) != window_event_result::ignored)
 			return rval;		// event handled
 
 	if (!window_exists(wind))

--- a/common/ui/file.cpp
+++ b/common/ui/file.cpp
@@ -301,8 +301,7 @@ int ui_get_filename(char (&filename)[PATH_MAX], const char *const filespec, cons
 	
 	wind = ui_dialog_get_window(dlg);
 	
-	while (window_exists(wind))
-		event_process();
+	while (event_process() != window_event_result::deleted) {}
 
 	//key_flush();
 

--- a/common/ui/file.cpp
+++ b/common/ui/file.cpp
@@ -301,7 +301,7 @@ int ui_get_filename(char (&filename)[PATH_MAX], const char *const filespec, cons
 	
 	wind = ui_dialog_get_window(dlg);
 	
-	while (event_process() != window_event_result::deleted) {}
+	event_process_all();
 
 	//key_flush();
 

--- a/common/ui/file.cpp
+++ b/common/ui/file.cpp
@@ -136,8 +136,7 @@ static window_event_result browser_handler(UI_DIALOG *const dlg, const d_event &
 	{
 		b->filename_list.reset();
 		b->directory_list.reset();
-		ui_close_dialog(dlg);
-		return window_event_result::handled;
+		return window_event_result::close;
 	}
 	
 	if (GADGET_PRESSED(b->help_button.get()))
@@ -189,8 +188,7 @@ static window_event_result browser_handler(UI_DIALOG *const dlg, const d_event &
 			if (RAIIPHYSFS_File{PHYSFS_openRead(b->filename)})
 			{
 				// Looks like a valid filename that already exists!
-				ui_close_dialog(dlg);
-				return window_event_result::handled;
+				return window_event_result::close;
 			}
 			
 			// File doesn't exist, but can we create it?
@@ -199,8 +197,7 @@ static window_event_result browser_handler(UI_DIALOG *const dlg, const d_event &
 				TempFile.reset();
 				// Looks like a valid filename!
 				PHYSFS_delete(b->filename);
-				ui_close_dialog(dlg);
-				return window_event_result::handled;
+				return window_event_result::close;
 			}
 		}
 		else
@@ -213,8 +210,7 @@ static window_event_result browser_handler(UI_DIALOG *const dlg, const d_event &
 			if (!b->filename_list)
 			{
 				b->directory_list.reset();
-				ui_close_dialog(dlg);
-				return window_event_result::handled;
+				return window_event_result::close;
 			}
 			
 			ui_inputbox_set_text(b->user_file.get(), b->filespec);
@@ -222,8 +218,7 @@ static window_event_result browser_handler(UI_DIALOG *const dlg, const d_event &
 			if (!b->directory_list)
 			{
 				b->filename_list.reset();
-				ui_close_dialog(dlg);
-				return window_event_result::handled;
+				return window_event_result::close;
 			}
 			
 			ui_listbox_change(dlg, b->listbox1.get(), b->filename_list.get_count(), b->filename_list.get());

--- a/common/ui/gadget.cpp
+++ b/common/ui/gadget.cpp
@@ -318,7 +318,7 @@ window_event_result ui_dialog_do_gadgets(UI_DIALOG * dlg,const d_event &event)
 		//if (!is_under_another_window( dlg, tmp ))
 			rval = ui_gadget_do(dlg, tmp, event);
 		
-		if (!window_exists(wind))
+		if (rval == window_event_result::deleted)
 			break;
 
 		tmp = tmp->next;

--- a/common/ui/icon.cpp
+++ b/common/ui/icon.cpp
@@ -165,8 +165,9 @@ window_event_result ui_icon_do( UI_DIALOG *dlg, UI_GADGET_ICON * icon,const d_ev
 	{
 		icon->status = 1;
 		icon->flag = static_cast<int8_t>(icon->user_function());
-		ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, icon);
-		rval = window_event_result::handled;
+		rval = ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, icon);
+		if (rval == window_event_result::ignored)
+			rval = window_event_result::handled;
 	}
 
 	if (event.type == EVENT_WINDOW_DRAW)

--- a/common/ui/inputbox.cpp
+++ b/common/ui/inputbox.cpp
@@ -143,8 +143,9 @@ window_event_result ui_inputbox_do( UI_DIALOG *dlg, UI_GADGET_INPUTBOX * inputbo
 	
 	if (inputbox->pressed)
 	{
-		ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, inputbox);
-		rval = window_event_result::handled;
+		rval = ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, inputbox);
+		if (rval == window_event_result::ignored)
+			rval = window_event_result::handled;
 	}
 		
 	if (event.type == EVENT_WINDOW_DRAW)

--- a/common/ui/listbox.cpp
+++ b/common/ui/listbox.cpp
@@ -363,8 +363,9 @@ window_event_result ui_listbox_do( UI_DIALOG *dlg, UI_GADGET_LISTBOX * listbox,c
 	
 	if (listbox->moved || (listbox->selected_item > 0))
 	{
-		ui_gadget_send_event(dlg, (listbox->selected_item > 0) ? EVENT_UI_LISTBOX_SELECTED : EVENT_UI_LISTBOX_MOVED, listbox);
-		return window_event_result::handled;
+		rval = ui_gadget_send_event(dlg, (listbox->selected_item > 0) ? EVENT_UI_LISTBOX_SELECTED : EVENT_UI_LISTBOX_MOVED, listbox);
+		if (rval == window_event_result::ignored)
+			rval = window_event_result::handled;
 	}
 
 	return rval;

--- a/common/ui/radio.cpp
+++ b/common/ui/radio.cpp
@@ -159,8 +159,9 @@ window_event_result ui_radio_do( UI_DIALOG *dlg, UI_GADGET_RADIO * radio,const d
 			tmp = tmp->next;
 		}
 		radio->flag = 1;
-		ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, radio);
-		rval = window_event_result::handled;
+		rval = ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, radio);
+		if (rval == window_event_result::ignored)
+			rval = window_event_result::handled;
 	}
 
 	if (event.type == EVENT_WINDOW_DRAW)

--- a/common/ui/scroll.cpp
+++ b/common/ui/scroll.cpp
@@ -282,8 +282,9 @@ window_event_result ui_scrollbar_do( UI_DIALOG *dlg, UI_GADGET_SCROLLBAR * scrol
 		scrollbar->moved = 1;
 	if (scrollbar->moved)
 	{
-		ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, scrollbar);
-		rval = window_event_result::handled;
+		rval = ui_gadget_send_event(dlg, EVENT_UI_GADGET_PRESSED, scrollbar);
+		if (rval == window_event_result::ignored)
+			rval = window_event_result::handled;
 	}
 
 	if (oldpos != scrollbar->fake_position)

--- a/common/ui/userbox.cpp
+++ b/common/ui/userbox.cpp
@@ -149,8 +149,9 @@ window_event_result ui_userbox_do( UI_DIALOG *dlg, UI_GADGET_USERBOX * userbox,c
 	
 	if (userbox->b1_clicked || userbox->b1_dragging)
 	{
-		ui_gadget_send_event(dlg, userbox->b1_clicked ? EVENT_UI_GADGET_PRESSED : EVENT_UI_USERBOX_DRAGGED, userbox);
-		rval = window_event_result::handled;
+		rval = ui_gadget_send_event(dlg, userbox->b1_clicked ? EVENT_UI_GADGET_PRESSED : EVENT_UI_USERBOX_DRAGGED, userbox);
+		if (rval == window_event_result::ignored)
+			rval = window_event_result::handled;
 	}
 
 	return rval;

--- a/d1x-rebirth/editor/ehostage.cpp
+++ b/d1x-rebirth/editor/ehostage.cpp
@@ -375,8 +375,7 @@ static window_event_result hostage_dialog_handler(UI_DIALOG *dlg,const d_event &
 		Update_flags |= UF_WORLD_CHANGED;
 	if (GADGET_PRESSED(h->quitButton.get()) || keypress==KEY_ESC)
 	{
-		hostage_close_window();
-		return window_event_result::handled;
+		return window_event_result::close;
 	}		
 
 	LastHostageIndex = CurrentHostageIndex;

--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -437,8 +437,7 @@ int RunMovie(char *filename, int hires_flag, int must_have,int dx,int dy)
 	MVE_sfCallbacks(MovieShowFrame);
 	MVE_palCallbacks(MovieSetPalette);
 
-	while (window_exists(wind))
-		event_process();
+	while (event_process() != window_event_result::deleted) {}
 
 	Assert(m.aborted || m.result == MVE_ERR_EOF);	 ///movie should be over
 

--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -437,7 +437,7 @@ int RunMovie(char *filename, int hires_flag, int must_have,int dx,int dy)
 	MVE_sfCallbacks(MovieShowFrame);
 	MVE_palCallbacks(MovieSetPalette);
 
-	while (event_process() != window_event_result::deleted) {}
+	event_process_all();
 
 	Assert(m.aborted || m.result == MVE_ERR_EOF);	 ///movie should be over
 

--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -276,6 +276,8 @@ struct movie : ignore_window_pointer_t
 
 static window_event_result show_pause_message(window *, const d_event &event, const unused_window_userdata_t *)
 {
+	window_event_result result;
+
 	switch (event.type)
 	{
 		case EVENT_MOUSE_BUTTON_DOWN:
@@ -284,11 +286,11 @@ static window_event_result show_pause_message(window *, const d_event &event, co
 			// else fall through
 
 		case EVENT_KEY_COMMAND:
-			if (!call_default_handler(event))
+			if ((result = call_default_handler(event)) == window_event_result::ignored)
 			{
 				return window_event_result::close;
 			}
-			return window_event_result::handled;
+			return result;
 
 		case EVENT_WINDOW_DRAW:
 		{

--- a/similar/editor/centers.cpp
+++ b/similar/editor/centers.cpp
@@ -241,8 +241,7 @@ window_event_result centers_dialog_handler(UI_DIALOG *dlg,const d_event &event, 
 		Update_flags |= UF_WORLD_CHANGED;
 	if (GADGET_PRESSED(c->quitButton.get()) || keypress==KEY_ESC)
 	{
-		close_centers_window();
-		return window_event_result::handled;
+		return window_event_result::close;
 	}		
 
 	c->old_seg_num = Cursegp;

--- a/similar/editor/eswitch.cpp
+++ b/similar/editor/eswitch.cpp
@@ -365,8 +365,7 @@ window_event_result trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, 
 
 	Assert(MainWindow != NULL);
 	if (!Markedsegp) {
-		close_trigger_window();
-		return window_event_result::ignored;
+		return window_event_result::close;
 	}
 
 	//------------------------------------------------------------
@@ -477,8 +476,7 @@ window_event_result trigger_dialog_handler(UI_DIALOG *dlg,const d_event &event, 
 		Update_flags |= UF_WORLD_CHANGED;
 	if (GADGET_PRESSED(t->quitButton.get()) || keypress == KEY_ESC)
 	{
-		close_trigger_window();
-		return window_event_result::handled;
+		return window_event_result::close;
 	}		
 
 	t->old_trigger_num = trigger_num;

--- a/similar/editor/med.cpp
+++ b/similar/editor/med.cpp
@@ -1131,8 +1131,7 @@ window_event_result editor_handler(UI_DIALOG *, const d_event &event, unused_ui_
 
 	if (ModeFlag)
 	{
-		ui_close_dialog(EditorWindow);
-		return window_event_result::ignored;
+		return window_event_result::close;
 	}
 
 //		if (EditorWindow->keyboard_focus_gadget == GameViewBox) current_view=NULL;

--- a/similar/editor/medrobot.cpp
+++ b/similar/editor/medrobot.cpp
@@ -850,8 +850,7 @@ static window_event_result object_dialog_handler(UI_DIALOG *dlg,const d_event &e
 		obj->mtype.spin_rate.y = fl2f(atof(o->ytext->text.get()));
 		obj->mtype.spin_rate.z = fl2f(atof(o->ztext->text.get()));
 
-		object_close_window();
-		return window_event_result::handled;
+		return window_event_result::close;
 	}
 	
 	return rval;

--- a/similar/editor/medrobot.cpp
+++ b/similar/editor/medrobot.cpp
@@ -715,8 +715,7 @@ window_event_result robot_dialog_handler(UI_DIALOG *dlg,const d_event &event, ro
 		Update_flags |= UF_WORLD_CHANGED;
 	if (GADGET_PRESSED(r->quitButton.get()) || keypress == KEY_ESC)
 	{
-		robot_close_window();
-		return window_event_result::handled;
+		return window_event_result::close;
 	}		
 
 	r->old_object = Cur_object_index;

--- a/similar/editor/medwall.cpp
+++ b/similar/editor/medwall.cpp
@@ -378,7 +378,7 @@ static window_event_result wall_dialog_created(UI_DIALOG *const w, wall_dialog *
 
 void close_wall_window()
 {
-	if (likely(MainWindow))
+	if (MainWindow)
 		ui_close_dialog(exchange(MainWindow, nullptr));
 }
 
@@ -574,8 +574,7 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 		Update_flags |= UF_WORLD_CHANGED;
 	if (GADGET_PRESSED(wd->quitButton.get()) || keypress == KEY_ESC)
 	{
-		close_wall_window();
-		return window_event_result::handled;
+		return window_event_result::close;
 	}		
 
 	wd->old_wall_num = Cursegp->sides[Curside].wall_num;

--- a/similar/main/credits.cpp
+++ b/similar/main/credits.cpp
@@ -267,8 +267,7 @@ static void credits_show_common(RAIIPHYSFS_File file, const int have_bin_file)
 		return;
 	}
 
-	while (window_exists(wind))
-		event_process();
+	while (event_process() != window_event_result::deleted) {}
 }
 
 void credits_show(const char *const filename)

--- a/similar/main/credits.cpp
+++ b/similar/main/credits.cpp
@@ -97,14 +97,16 @@ namespace dsx {
 static window_event_result credits_handler(window *, const d_event &event, credits *cr)
 {
 	int l, y;
+	window_event_result result;
+
 	switch (event.type)
 	{
 		case EVENT_KEY_COMMAND:
-			if (!call_default_handler(event))	// if not print screen, debug etc
+			if ((result = call_default_handler(event)) == window_event_result::ignored)	// if not print screen, debug etc
 			{
 				return window_event_result::close;
 			}
-			return window_event_result::handled;
+			return result;
 
 		case EVENT_MOUSE_BUTTON_DOWN:
 		case EVENT_MOUSE_BUTTON_UP:

--- a/similar/main/credits.cpp
+++ b/similar/main/credits.cpp
@@ -267,7 +267,7 @@ static void credits_show_common(RAIIPHYSFS_File file, const int have_bin_file)
 		return;
 	}
 
-	while (event_process() != window_event_result::deleted) {}
+	event_process_all();
 }
 
 void credits_show(const char *const filename)

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -1307,12 +1307,15 @@ window_event_result game_handler(window *,const d_event &event, const unused_win
 			Game_wind = NULL;
 			event_toggle_focus(0);
 			key_toggle_repeat(1);
+			return window_event_result::ignored;
 			break;
 
 		default:
 			break;
 	}
-	return window_event_result::ignored;
+	
+	// If we deleted the window, tell the event loop
+	return Game_wind ? window_event_result::ignored : window_event_result::deleted;
 }
 
 // Initialise game, actually runs in main event loop

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -1937,8 +1937,6 @@ window_event_result ReadControls(const d_event &event)
 
 	if (event.type == EVENT_KEY_COMMAND)
 	{
-		window_event_result result;
-
 		key = event_key_get(event);
 #if defined(DXX_BUILD_DESCENT_II)
 		if (DefiningMarkerMessage)
@@ -1987,7 +1985,8 @@ window_event_result ReadControls(const d_event &event)
 		}
 #endif
 
-		if ((result = call_default_handler(event)) != window_event_result::ignored)
+		auto result = call_default_handler(event);
+		if (result != window_event_result::ignored)
 			return result;
 	}
 

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -1937,6 +1937,8 @@ window_event_result ReadControls(const d_event &event)
 
 	if (event.type == EVENT_KEY_COMMAND)
 	{
+		window_event_result result;
+
 		key = event_key_get(event);
 #if defined(DXX_BUILD_DESCENT_II)
 		if (DefiningMarkerMessage)
@@ -1985,8 +1987,8 @@ window_event_result ReadControls(const d_event &event)
 		}
 #endif
 
-		if (call_default_handler(event))
-			return window_event_result::handled;
+		if ((result = call_default_handler(event)) != window_event_result::ignored)
+			return result;
 	}
 
 	if (!Endlevel_sequence && Newdemo_state != ND_STATE_PLAYBACK)

--- a/similar/main/kmatrix.cpp
+++ b/similar/main/kmatrix.cpp
@@ -413,8 +413,8 @@ kmatrix_result kmatrix_view(int network)
 		return kmatrix_result::abort;
 	}
 	
-	while (window_exists(wind))
-		event_process();
+	while (event_process() != window_event_result::deleted) {}
+
 	gr_free_bitmap_data(km.background);
 	return (km.aborted ? kmatrix_result::abort : kmatrix_result::proceed);
 }

--- a/similar/main/kmatrix.cpp
+++ b/similar/main/kmatrix.cpp
@@ -413,7 +413,7 @@ kmatrix_result kmatrix_view(int network)
 		return kmatrix_result::abort;
 	}
 	
-	while (event_process() != window_event_result::deleted) {}
+	event_process_all();
 
 	gr_free_bitmap_data(km.background);
 	return (km.aborted ? kmatrix_result::abort : kmatrix_result::proceed);

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -2380,8 +2380,7 @@ static void polygon_models_viewer()
 		return;
 	}
 
-	while (window_exists(wind))
-		event_process();
+	while (event_process() != window_event_result::deleted) {}
 }
 
 namespace dsx {

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -2458,8 +2458,7 @@ static void gamebitmaps_viewer()
 		return;
 	}
 
-	while (window_exists(wind))
-		event_process();
+	while (event_process() != window_event_result::deleted) {}
 }
 
 #define DXX_SANDBOX_MENU(VERB)	\

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -192,7 +192,12 @@ void show_menus(void)
 	{
 		if (!i)
 			break;
-		if (window_exists(i))
+		
+		// Hidden windows don't receive events, so the only way to close is outside its handler
+		// Which there should be no cases of here
+		// window_exists could return a false positive if a new window was created
+		// with the same pointer value as the deleted one, so killing window_exists (call and function)
+		// if (window_exists(i))
 			window_set_visible(i, 1);
 	}
 	menus[0] = NULL;

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -2380,7 +2380,7 @@ static void polygon_models_viewer()
 		return;
 	}
 
-	while (event_process() != window_event_result::deleted) {}
+	event_process_all();
 }
 
 namespace dsx {
@@ -2458,7 +2458,7 @@ static void gamebitmaps_viewer()
 		return;
 	}
 
-	while (event_process() != window_event_result::deleted) {}
+	event_process_all();
 }
 
 #define DXX_SANDBOX_MENU(VERB)	\

--- a/similar/main/mission.cpp
+++ b/similar/main/mission.cpp
@@ -34,6 +34,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "pstypes.h"
 #include "strutil.h"
 #include "inferno.h"
+#include "window.h"
 #include "mission.h"
 #include "gameseq.h"
 #include "titles.h"
@@ -1009,10 +1010,10 @@ int load_mission_by_name(const char *mission_name)
 struct mission_menu
 {
 	mission_list_type ml;
-	int (*when_selected)(void);
+	window_event_result (*when_selected)(void);
 };
 
-static int mission_menu_handler(listbox *lb,const d_event &event, mission_menu *mm)
+static window_event_result mission_menu_handler(listbox *lb,const d_event &event, mission_menu *mm)
 {
 	const char **list = listbox_get_items(lb);
 	switch (event.type)
@@ -1027,10 +1028,10 @@ static int mission_menu_handler(listbox *lb,const d_event &event, mission_menu *
 				if (!load_mission(&mm->ml[citem]))
 				{
 					nm_messagebox( NULL, 1, TXT_OK, TXT_MISSION_ERROR);
-					return 1;	// stay in listbox so user can select another one
+					return window_event_result::handled;	// stay in listbox so user can select another one
 				}
 			}
-			return !(*mm->when_selected)();
+			return (*mm->when_selected)();
 		}
 		case EVENT_WINDOW_CLOSE:
 			d_free(list);
@@ -1041,10 +1042,10 @@ static int mission_menu_handler(listbox *lb,const d_event &event, mission_menu *
 			break;
 	}
 	
-	return 0;
+	return window_event_result::ignored;
 }
 
-int select_mission(int anarchy_mode, const char *message, int (*when_selected)(void))
+int select_mission(int anarchy_mode, const char *message, window_event_result (*when_selected)(void))
 {
 	auto mission_list = build_mission_list(anarchy_mode);
 	int new_mission_num;

--- a/similar/main/net_udp.cpp
+++ b/similar/main/net_udp.cpp
@@ -3683,7 +3683,7 @@ static int net_udp_game_param_handler( newmenu *menu,const d_event &event, param
 }
 
 namespace dsx {
-int net_udp_setup_game()
+window_event_result net_udp_setup_game()
 {
 	int optnum;
 	param_opt opt;
@@ -3820,7 +3820,7 @@ int net_udp_setup_game()
 		Netgame.Tracker = 0;
 #endif
 
-	return i >= 0;
+	return (i >= 0) ? window_event_result::close : window_event_result::handled;
 }
 }
 

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -1512,8 +1512,11 @@ static window_event_result newmenu_handler(window *wind,const d_event &event, ne
 	{
 		int rval = (*menu->subfunction)(menu, event, menu->userdata);
 
-		if (!window_exists(wind))
-			return window_event_result::handled;	// some subfunction closed the window: bail!
+#if 0	// No current instances of the subfunction closing the window itself (which is preferred)
+		// Enable when all subfunctions return a window_event_result
+		if (rval == window_event_result::deleted)
+			return rval;	// some subfunction closed the window: bail!
+#endif
 
 		if (rval)
 		{

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -1669,7 +1669,7 @@ struct listbox : embed_window_pointer_t
 	const char **item;
 	int allow_abort_flag;
 	unsigned marquee_maxchars;
-	window_event_result (*listbox_callback)(listbox *lb,const d_event &event, void *userdata);
+	listbox_subfunction_t<void> listbox_callback;
 	unsigned nitems;
 	int citem, first_item;
 	int marquee_charpos, marquee_scrollback;

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -469,7 +469,7 @@ static void strip_end_whitespace( char * text )
 int newmenu_do2(const char *const title, const char *const subtitle, const uint_fast32_t nitems, newmenu_item *const item, const newmenu_subfunction subfunction, void *const userdata, const int citem, const char *const filename)
 {
 	newmenu *menu;
-	window *wind;
+	bool exists = true;
 	int rval = -1;
 
 	menu = newmenu_do3( title, subtitle, nitems, item, subfunction, userdata, citem, filename );
@@ -477,11 +477,14 @@ int newmenu_do2(const char *const title, const char *const subtitle, const uint_
 	if (!menu)
 		return -1;
 	menu->rval = &rval;
-	wind = menu->wind;	// avoid dereferencing a freed 'menu'
+
+	// Track to see when the window is freed
+	// Doing this way in case another window is opened on top without its own polling loop
+	menu->wind->track(&exists);
 
 	// newmenu_do2 and simpler get their own event loop
 	// This is so the caller doesn't have to provide a callback that responds to EVENT_NEWMENU_SELECTED
-	while (window_exists(wind))
+	while (exists)
 		event_process();
 
 	return rval;

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -189,8 +189,7 @@ static void show_title_screen(const char * filename, int allow_keys, int from_ho
 		return;
 	}
 
-	while (window_exists(wind))
-		event_process();
+	while (event_process() != window_event_result::deleted) {}
 }
 
 #if defined(DXX_BUILD_DESCENT_II)

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -1613,8 +1613,7 @@ void do_briefing_screens(const d_fname &filename, int level_num)
 
 	// Stay where we are in the stack frame until briefing done
 	// Too complicated otherwise
-	while (window_exists(wind))
-		event_process();
+	while (event_process() != window_event_result::deleted) {}
 }
 
 void do_end_briefing_screens(const d_fname &filename)

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -111,6 +111,8 @@ struct title_screen : ignore_window_pointer_t
 
 static window_event_result title_handler(window *, const d_event &event, title_screen *ts)
 {
+	window_event_result result;
+
 	switch (event.type)
 	{
 		case EVENT_MOUSE_BUTTON_DOWN:
@@ -123,12 +125,12 @@ static window_event_result title_handler(window *, const d_event &event, title_s
 			break;
 
 		case EVENT_KEY_COMMAND:
-			if (!call_default_handler(event))
+			if ((result = call_default_handler(event)) == window_event_result::ignored)
 				if (ts->allow_keys)
 				{
 					return window_event_result::close;
 				}
-			return window_event_result::handled;
+			return result;
 
 		case EVENT_IDLE:
 			timer_delay2(50);
@@ -1445,6 +1447,8 @@ static int new_briefing_screen(briefing *br, int first)
 namespace dsx {
 static window_event_result briefing_handler(window *, const d_event &event, briefing *br)
 {
+	window_event_result result;
+
 	switch (event.type)
 	{
 		case EVENT_WINDOW_ACTIVATED:
@@ -1489,8 +1493,8 @@ static window_event_result briefing_handler(window *, const d_event &event, brie
 					// fall through
 
 				default:
-					if (call_default_handler(event))
-						return window_event_result::handled;
+					if ((result = call_default_handler(event)) != window_event_result::ignored)
+						return result;
 					else if (br->new_screen)
 					{
 						if (!new_briefing_screen(br, 0))

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -189,7 +189,7 @@ static void show_title_screen(const char * filename, int allow_keys, int from_ho
 		return;
 	}
 
-	while (event_process() != window_event_result::deleted) {}
+	event_process_all();
 }
 
 #if defined(DXX_BUILD_DESCENT_II)
@@ -1613,7 +1613,7 @@ void do_briefing_screens(const d_fname &filename, int level_num)
 
 	// Stay where we are in the stack frame until briefing done
 	// Too complicated otherwise
-	while (event_process() != window_event_result::deleted) {}
+	event_process_all();
 }
 
 void do_end_briefing_screens(const d_fname &filename)


### PR DESCRIPTION
The `window_exists` function was reported to be problematic in that another window could be created with the same pointer value as the one that was deleted, resulting in a false positive. Implement `window_event_result` return value across the entire event system and most callbacks so that a `window_event_result::deleted` can be checked for instead.

In the case of `newmenu_do2` and simpler `newmenu_do`'s, add a `track` method to the `dcx::window` class so a pointed to `bool` can be set to `false` when the window is deleted. This is in case another window is created on top without its own polling loop, so that `window_event_result::deleted` is returned for that window, not the one we're tracking. This is not expected for any other single window polling loop currently, allowing `window_event_result::deleted` to be checked for from `event_process()`.

Should this go in unification/master or a beta branch for the next version?
