### PR TITLE
fix a `-Wunused-parameter` warning in the DXX_USE_OGLES code path

### DIFF
--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1691,7 +1691,9 @@ static int ogl_loadtexture (const uint8_t *data, int dxo, int dyo, ogl_texture &
 		default:
 		case OGL_TEXFILT_CLASSIC: // Classic - Nearest
 			gl_mag_filter_int = GL_NEAREST;
-#if !DXX_USE_OGLES
+#if DXX_USE_OGLES
+			static_cast<void>(texanis);
+#else
 			if (texanis && ogl_maxanisotropy > 1.0)
 			{
 				// looks nicer if anisotropy is applied.


### PR DESCRIPTION
The `texanis` parameter is not used in OpenGL ES, but in desktop GL. I don't know what your preferred idiom for silencing this kind of warning is. You might not want to directly merge this commit, but use something else instead. However, the classical cast-to-void works well in practice.