### PR TITLE
Fixes freeze when starting new game or editor

### DIFF
--- a/common/arch/sdl/event.cpp
+++ b/common/arch/sdl/event.cpp
@@ -179,6 +179,8 @@ window_event_result event_process(void)
 
 			highest_result = std::max(result, highest_result);
 		}
+		else
+			wind = window_get_next(*wind);
 	}
 
 	gr_flip();


### PR DESCRIPTION
Fixes freeze introduced by 9511f65a901fbbe7cc3724a99fb742ef3159d177 where `event_process` wouldn't go to the next window if it's hidden.