### PR TITLE
General fixes for the Editor

### DIFF
--- a/common/arch/sdl/event.cpp
+++ b/common/arch/sdl/event.cpp
@@ -161,21 +161,14 @@ window_event_result event_process(void)
 		return highest_result;
 	
 	event.type = EVENT_WINDOW_DRAW;	// then draw all visible windows
-	wind = window_get_first();
-	while (wind != NULL)
+	for (wind = window_get_first(); wind != nullptr; wind = window_get_next(*wind))
 	{
-		window *prev = window_get_prev(*wind);
 		if (window_is_visible(wind))
 		{
+			auto prev = window_get_prev(*wind);
 			auto result = window_send_event(*wind, event);
 			if (result == window_event_result::deleted)
-			{
-				if (!prev) // well there isn't a previous window ...
-					break; // ... just bail out - we've done everything for this frame we can.
-				wind = window_get_next(*prev); // the current window seemed to be closed. so take the next one from the previous which should be able to point to the one after the current closed
-			}
-			else
-				wind = window_get_next(*wind);
+				wind = prev;	// take the previous window and get the next one from that (if prev isn't nullptr)
 
 			highest_result = std::max(result, highest_result);
 		}

--- a/common/include/ui.h
+++ b/common/include/ui.h
@@ -307,7 +307,6 @@ static std::unique_ptr<T> ui_gadget_add(UI_DIALOG *dlg, short x1, short y1, shor
 }
 __attribute_warn_unused_result
 std::unique_ptr<UI_GADGET_BUTTON> ui_add_gadget_button(UI_DIALOG * dlg, short x, short y, short w, short h, const char * text, int (*function_to_call)());
-extern void ui_gadget_delete_all( UI_DIALOG * dlg );
 window_event_result ui_gadget_send_event(UI_DIALOG *dlg, enum event_type type, UI_GADGET *gadget);
 extern UI_GADGET *ui_event_get_gadget(const d_event &event);
 window_event_result ui_dialog_do_gadgets( UI_DIALOG * dlg, const d_event &event );

--- a/common/include/ui.h
+++ b/common/include/ui.h
@@ -265,7 +265,7 @@ extern void ui_draw_line_in( short x1, short y1, short x2, short y2 );
 extern void ui_draw_frame( short x1, short y1, short x2, short y2 );
 extern void ui_draw_shad( short x1, short y1, short x2, short y2, short c1, short c2 );
 
-void ui_init();
+int ui_init();
 void ui_close();
 
 typedef cstring_tie<10> ui_messagebox_tie;
@@ -399,7 +399,7 @@ std::unique_ptr<UI_GADGET_ICON> ui_add_gadget_icon(UI_DIALOG * dlg, const char *
 int DecodeKeyText( const char * text );
 void GetKeyDescription(char (&text)[100], uint_fast32_t keypress);
 
-extern void menubar_init(const char * filename );
+extern int menubar_init(const char * filename );
 extern void menubar_close();
 extern void menubar_hide();
 extern void menubar_show();
@@ -411,7 +411,7 @@ void ui_pad_deactivate();
 void ui_pad_goto(int n);
 void ui_pad_goto_next();
 void ui_pad_goto_prev();
-void ui_pad_read( int n, const char * filename );
+int ui_pad_read( int n, const char * filename );
 int ui_pad_get_current();
 void ui_pad_draw(UI_DIALOG *dlg, int x, int y);
 

--- a/common/main/game.h
+++ b/common/main/game.h
@@ -75,7 +75,7 @@ extern array<int, 2> Marker_viewer_num;    // left & right
 #endif
 
 // The following bits define the game modes.
-#define GM_EDITOR       1       // You came into the game from the editor
+//#define GM_EDITOR       1       // You came into the game from the editor. Now obsolete - FYI only
 // #define GM_SERIAL       2       // You are in serial mode // OBSOLETE
 #define GM_NETWORK      4       // You are in network mode
 #define GM_MULTI_ROBOTS 8       // You are in a multiplayer mode with robots.

--- a/common/main/gameseq.h
+++ b/common/main/gameseq.h
@@ -123,8 +123,6 @@ namespace dsx {
 void create_player_appearance_effect(const object_base &player_obj);
 void copy_defaults_to_robot(vobjptr_t objp);
 void gameseq_remove_unused_players();
-// reset stuff so game is semi-normal when playing from editor
-void editor_reset_stuff_on_level();
 }
 #endif
 

--- a/common/ui/dialog.cpp
+++ b/common/ui/dialog.cpp
@@ -188,7 +188,6 @@ void ui_dialog_set_current_canvas(UI_DIALOG *dlg)
 
 UI_DIALOG::~UI_DIALOG()
 {
-	ui_gadget_delete_all(this);
 	selected_gadget = NULL;
 }
 

--- a/common/ui/file.cpp
+++ b/common/ui/file.cpp
@@ -41,7 +41,7 @@ static PHYSFSX_counted_list file_getdirlist(const char *dir)
 {
 	ntstring<PATH_MAX - 1> path;
 	auto dlen = path.copy_if(dir);
-	if ((!dlen && strlen(dir) > 0) || !path.copy_if(dlen, "/"))
+	if ((!dlen && dir[0] != '\0') || !path.copy_if(dlen, "/"))
 		return nullptr;
 	++ dlen;
 	PHYSFSX_counted_list list{PHYSFS_enumerateFiles(dir)};

--- a/common/ui/file.cpp
+++ b/common/ui/file.cpp
@@ -41,7 +41,7 @@ static PHYSFSX_counted_list file_getdirlist(const char *dir)
 {
 	ntstring<PATH_MAX - 1> path;
 	auto dlen = path.copy_if(dir);
-	if (!dlen || !path.copy_if(dlen, "/"))
+	if ((!dlen && strlen(dir) > 0) || !path.copy_if(dlen, "/"))
 		return nullptr;
 	++ dlen;
 	PHYSFSX_counted_list list{PHYSFS_enumerateFiles(dir)};

--- a/common/ui/gadget.cpp
+++ b/common/ui/gadget.cpp
@@ -89,40 +89,6 @@ void ui_gadget_add(UI_DIALOG * dlg, short x1, short y1, short x2, short y2, UI_G
 	gadget->hotkey = -1;
 }
 
-void ui_gadget_delete_all( UI_DIALOG * dlg )
-{
-	UI_GADGET * tmp;
-
-	while( dlg->gadget != NULL )
-	{
-		tmp = dlg->gadget;
-		if (tmp->next == tmp )
-		{
-			dlg->gadget = NULL;
-		} else {
-			tmp->next->prev = tmp->prev;
-			tmp->prev->next = tmp->next;
-			dlg->gadget = tmp->next;
-		}
-
-		switch(tmp->kind)
-		{
-			case UI_GADGET_BUTTON::s_kind:
-			case UI_GADGET_LISTBOX::s_kind:
-			case UI_GADGET_SCROLLBAR::s_kind:
-			case UI_GADGET_RADIO::s_kind:
-			case UI_GADGET_CHECKBOX::s_kind:
-			case UI_GADGET_INPUTBOX::s_kind:
-			case UI_GADGET_USERBOX::s_kind:
-			case UI_GADGET_ICON::s_kind:
-				/* Handled by returned unique_ptr */
-				break;
-			default:
-				throw std::runtime_error("unknown gadget kind");
-		}
-	}
-}
-
 
 #if 0
 int is_under_another_window( UI_DIALOG * dlg, UI_GADGET * gadget )

--- a/common/ui/keypad.cpp
+++ b/common/ui/keypad.cpp
@@ -54,7 +54,7 @@ int ui_pad_get_current()
 void ui_pad_init()
 {
 	KeyPad = {};
-	active_pad = -1;
+	active_pad = 0;
 }
 
 void ui_pad_close()
@@ -250,7 +250,7 @@ void ui_pad_activate(UI_DIALOG &dlg, uint_fast32_t x, uint_fast32_t y)
 	HotKey1[15] = KEY_SHIFTED + KEY_CTRLED + KEY_PAD0;
 	HotKey1[16] = KEY_SHIFTED + KEY_CTRLED + KEY_PADPERIOD;
 
-	active_pad = -1;
+	active_pad = 0;
 
 }
 
@@ -364,7 +364,7 @@ UI_KEYPAD::UI_KEYPAD() :
 		i[0] = 0;
 }
 
-void ui_pad_read( int n, const char * filename )
+int ui_pad_read( int n, const char * filename )
 {
 	int linenumber = 0;
 	int keycode, functionnumber;
@@ -372,7 +372,7 @@ void ui_pad_read( int n, const char * filename )
 	auto infile = PHYSFSX_openReadBuffered(filename);
 	if (!infile) {
 		Warning( "Couldn't find %s\n", filename );
-		return;
+		return 0;
 	}
 	auto &kpn = *(KeyPad[n] = make_unique<UI_KEYPAD>());
 
@@ -475,6 +475,8 @@ void ui_pad_read( int n, const char * filename )
 			kpn.numkeys++;
 		}
 	}
+
+	return 1;
 }
 
 }

--- a/common/ui/keypad.cpp
+++ b/common/ui/keypad.cpp
@@ -371,7 +371,7 @@ int ui_pad_read( int n, const char * filename )
 
 	auto infile = PHYSFSX_openReadBuffered(filename);
 	if (!infile) {
-		Warning( "Couldn't find %s\n", filename );
+		Warning( "Could not find %s\n", filename );
 		return 0;
 	}
 	auto &kpn = *(KeyPad[n] = make_unique<UI_KEYPAD>());

--- a/common/ui/menubar.cpp
+++ b/common/ui/menubar.cpp
@@ -817,7 +817,6 @@ int menubar_init( const char * file )
 			if (!item.user_function)
 			{
 				con_printf(CON_URGENT, "%s:%u: unknown function \"%s\" in \"%s\"", __FILE__, __LINE__, buf1, file);
-				break;
 			}
 		}
 				

--- a/common/ui/menubar.cpp
+++ b/common/ui/menubar.cpp
@@ -735,7 +735,7 @@ static void ul_xlate(char *s)
 }
 
 
-void menubar_init( const char * file )
+int menubar_init( const char * file )
 {
 	int np;
 	char buf1[200];
@@ -751,8 +751,12 @@ void menubar_init( const char * file )
 			j.Hotkey = -1;
 	auto infile = PHYSFSX_openReadBuffered(file);
 
-	if (!infile) return;
-		
+	if (!infile)
+	{
+		Warning("Couldn't find %s\n", file);
+		return 0;
+	}
+	
 	PHYSFSX_gets_line_t<200> buffer;
 	while ( PHYSFSX_fgets( buffer, infile) != NULL )
 	{
@@ -870,6 +874,8 @@ void menubar_init( const char * file )
 
 	}
 	Menu[0].w = 700;
+
+	return 1;
 }
 
 void menubar_hide()

--- a/common/ui/menubar.cpp
+++ b/common/ui/menubar.cpp
@@ -753,7 +753,7 @@ int menubar_init( const char * file )
 
 	if (!infile)
 	{
-		Warning("Couldn't find %s\n", file);
+		Warning("Could not find %s\n", file);
 		return 0;
 	}
 	

--- a/common/ui/ui.cpp
+++ b/common/ui/ui.cpp
@@ -41,7 +41,7 @@ static int Initialized = 0;
 
 unsigned char CBLACK,CGREY,CWHITE,CBRIGHT,CRED;
 
-grs_font_ptr ui_small_font = nullptr;
+grs_font_ptr ui_small_font;
 
 int ui_init()
 {
@@ -85,8 +85,7 @@ void ui_close()
 		menubar_close();
 		
 		ui_pad_close();
-		if (ui_small_font)
-			ui_small_font.reset();
+		ui_small_font.reset();
 	}
 
 	return;

--- a/common/ui/ui.cpp
+++ b/common/ui/ui.cpp
@@ -33,6 +33,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "key.h"
 #include "ui.h"
 #include "mouse.h"
+#include "dxxerror.h"
 
 namespace dcx {
 
@@ -40,17 +41,20 @@ static int Initialized = 0;
 
 unsigned char CBLACK,CGREY,CWHITE,CBRIGHT,CRED;
 
-grs_font_ptr ui_small_font;
+grs_font_ptr ui_small_font = nullptr;
 
-void ui_init()
+int ui_init()
 {
 
-	if (Initialized) return;
-
-	Initialized = 1;
+	if (Initialized) return 1;
 
 	const grs_font *org_font = grd_curcanv->cv_font;
 	ui_small_font = gr_init_font( "pc6x8.fnt" );
+	if (!ui_small_font)
+	{
+		Warning("Could not find pc6x8.fnt");
+		return 0;
+	}
 	grd_curcanv->cv_font =org_font;
 
 	CBLACK = gr_find_closest_color( 1, 1, 1 );
@@ -67,6 +71,9 @@ void ui_init()
 	
 	atexit(ui_close );
 
+	Initialized = 1;
+
+	return 1;
 }
 
 void ui_close()
@@ -78,7 +85,8 @@ void ui_close()
 		menubar_close();
 		
 		ui_pad_close();
-		ui_small_font.reset();
+		if (ui_small_font)
+			ui_small_font.reset();
 	}
 
 	return;

--- a/d1x-rebirth/editor/ehostage.cpp
+++ b/d1x-rebirth/editor/ehostage.cpp
@@ -305,6 +305,7 @@ static window_event_result hostage_dialog_handler(UI_DIALOG *dlg,const d_event &
 			return hostage_dialog_created(dlg, h);
 		case EVENT_WINDOW_CLOSE:
 			std::default_delete<hostage_dialog>()(h);
+			MainWindow = nullptr;
 			return window_event_result::ignored;
 		default:
 			break;

--- a/d2x-rebirth/libmve/mve_main.c
+++ b/d2x-rebirth/libmve/mve_main.c
@@ -37,7 +37,7 @@ int main(int c, char **v)
 
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0)
 	{
-		fprintf(stderr, "Couldn't initialize SDL: %s\n",SDL_GetError());
+		fprintf(stderr, "Could not initialize SDL: %s\n",SDL_GetError());
 		exit(1);
 	}
 	atexit(SDL_Quit);

--- a/similar/2d/font.cpp
+++ b/similar/2d/font.cpp
@@ -498,7 +498,7 @@ static void ogl_font_choose_size(grs_font * font,int gap,int *rw,int *rh){
 		}
 	}
 	if (smallr<=0)
-		Error("couldn't fit font?\n");
+		Error("Could not fit font?\n");
 }
 
 static void ogl_init_font(grs_font * font)

--- a/similar/2d/pcx.cpp
+++ b/similar/2d/pcx.cpp
@@ -428,10 +428,10 @@ int pcx_encode_byte(ubyte byt, ubyte cnt, PHYSFS_File *fid)
 constexpr char pcx_error_messages[] = {
 	"No error.\0"
 	"Error opening file.\0"
-	"Couldn't read PCX header.\0"
+	"Could not read PCX header.\0"
 	"Unsupported PCX version.\0"
 	"Error reading data.\0"
-	"Couldn't find palette information.\0"
+	"Could not find palette information.\0"
 	"Error writing data.\0"
 };
 

--- a/similar/editor/kbuild.cpp
+++ b/similar/editor/kbuild.cpp
@@ -35,6 +35,11 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 //  ---------- Create a bridge segment between current segment/side and marked segment/side ----------
 int CreateBridge()
 {
+	if (!Markedsegp) {
+		editor_status("No marked side.");
+		return 0;
+	}
+	
     if (!med_form_bridge_segment(Cursegp,Curside,Markedsegp,Markedside)) {
 		Update_flags |= UF_WORLD_CHANGED;
 		mine_changed = 1;

--- a/similar/editor/kbuild.cpp
+++ b/similar/editor/kbuild.cpp
@@ -115,7 +115,7 @@ int CreateSloppyAdjacentJoint()
 				undo_status[Autosave_count] = "Sloppy Joint segment undone.";
 	    		warn_if_concave_segments();
 				}
-			else editor_status("Couldn't form sloppy joint.\n");
+			else editor_status("Could not form sloppy joint.\n");
 		} else
 			editor_status("Attempted to form sloppy joint through connected side -- joint segment not formed (you bozo).");
 	} else

--- a/similar/editor/med.cpp
+++ b/similar/editor/med.cpp
@@ -329,7 +329,7 @@ static void close_editor();
 namespace dsx {
 void init_editor()
 {
-	const char *const pads[] = {
+	static const char pads[][13] = {
 		"segmove.pad",
 		"segsize.pad",
 		"curve.pad",

--- a/similar/editor/med.cpp
+++ b/similar/editor/med.cpp
@@ -1113,6 +1113,8 @@ window_event_result editor_handler(UI_DIALOG *, const d_event &event, unused_ui_
 	if ((keypress&0xff)==KEY_RSHIFT) keypress=0;
 	if ((keypress&0xff)==KEY_LCTRL) keypress=0;
 	if ((keypress&0xff)==KEY_RCTRL) keypress=0;
+	if ((keypress&0xff)==KEY_LMETA) keypress=0;
+	if ((keypress&0xff)==KEY_RMETA) keypress=0;
 //		if ((keypress&0xff)==KEY_LALT) keypress=0;
 //		if ((keypress&0xff)==KEY_RALT) keypress=0;
 

--- a/similar/editor/med.cpp
+++ b/similar/editor/med.cpp
@@ -117,7 +117,7 @@ grs_canvas *Canv_editor_game=&_canv_editor_game; //the game on the editor screen
 
 window *Pad_info;		// Keypad text
 
-grs_font_ptr editor_font = nullptr;
+grs_font_ptr editor_font;
 
 //where the editor is looking
 vms_vector Ed_view_target;
@@ -885,8 +885,7 @@ static void close_editor()
 
 	ui_close();
 
-	if (editor_font)
-		editor_font.reset();
+	editor_font.reset();
 
 	PHYSFSX_removeRelFromSearchPath("editor/data");
 	PHYSFSX_removeRelFromSearchPath("editor");

--- a/similar/editor/med.cpp
+++ b/similar/editor/med.cpp
@@ -87,6 +87,7 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 #include "fuelcen.h"
 #include "gameseq.h"
+#include "mission.h"
 #include "newmenu.h"
 
 #if defined(DXX_BUILD_DESCENT_II)
@@ -257,11 +258,15 @@ int	GotoGameScreen()
 //@@	Player_init.pos = Player->pos;
 //@@	Player_init.orient = Player->orient;
 //@@	Player_init.segnum = Player->segnum;	
-	
+
+	// Always use the simple dummy mission (for now at least)
+	create_new_mission();
+	Current_level_num = 1;
+
 // -- must always save gamesave.sav because the restore-objects code relies on it
 // -- that code could be made smarter and use the original file, if appropriate.
 //	if (mine_changed) 
-	if (gamestate_not_restored == 0) {
+	/*if (gamestate_not_restored == 0)*/ {
 		gamestate_not_restored = 1;
 		save_level("GAMESAVE.LVL");
 		editor_status("Gamestate saved.\n");
@@ -905,10 +910,7 @@ static void close_editor()
 		case 3:
 			if (!Game_wind)	// if we're already playing a game, don't touch!
 			{
-				set_screen_mode(SCREEN_GAME);		//put up game screen
-				Game_mode = GM_EDITOR;
-				editor_reset_stuff_on_level();
-				N_players = 1;
+				StartNewGame(Current_level_num);
 			}
 			break;
 	}

--- a/similar/editor/meddraw.cpp
+++ b/similar/editor/meddraw.cpp
@@ -294,7 +294,7 @@ static int find_edge_num(int v0,int v1)
 		if (*edgep++ == vv)
 			return (N_EDGES_PER_SEGMENT-i);
 
-	Error("couldn't find edge for %d,%d",v0,v1);
+	Error("Could not find edge for %d,%d",v0,v1);
 
 	//return -1;
 }

--- a/similar/editor/medrobot.cpp
+++ b/similar/editor/medrobot.cpp
@@ -767,6 +767,10 @@ void object_close_window()
 //-------------------------------------------------------------------------
 int do_object_dialog()
 {
+	if (Cur_object_index == object_none)
+		Cur_object_index = object_first;
+	Assert(Cur_object_index != object_guidebot_cannot_reach);	// not supposed to be this one
+
 	auto obj = vobjptr(Cur_object_index);
 	if (obj->type == OBJ_ROBOT)		//don't do this for robots
 		return 0;

--- a/similar/editor/medrobot.cpp
+++ b/similar/editor/medrobot.cpp
@@ -769,7 +769,6 @@ int do_object_dialog()
 {
 	if (Cur_object_index == object_none)
 		Cur_object_index = object_first;
-	Assert(Cur_object_index != object_guidebot_cannot_reach);	// not supposed to be this one
 
 	auto obj = vobjptr(Cur_object_index);
 	if (obj->type == OBJ_ROBOT)		//don't do this for robots

--- a/similar/editor/medwall.cpp
+++ b/similar/editor/medwall.cpp
@@ -860,6 +860,11 @@ int wall_link_doors()
 		return 0;
 	}
 
+	if (!Markedsegp) {
+		editor_status("No marked side.");
+		return 0;
+	}
+	
 	const auto mwall_num = Markedsegp->sides[Markedside].wall_num;
 	const auto &&w2 = wallptr(mwall_num);
 

--- a/similar/editor/medwall.cpp
+++ b/similar/editor/medwall.cpp
@@ -410,14 +410,15 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 	//------------------------------------------------------------
 	ui_button_any_drawn = 0;
 
-	const auto &&w = vwallptr(Cursegp->sides[Curside].wall_num);
+	const auto wn = Cursegp->sides[Curside].wall_num;
+	const auto &&w = wn == wall_none ? nullptr : vwallptr(wn);
 	//------------------------------------------------------------
 	// If we change walls, we need to reset the ui code for all
 	// of the checkboxes that control the wall flags.  
 	//------------------------------------------------------------
-	if (wd->old_wall_num != Cursegp->sides[Curside].wall_num)
+	if (wd->old_wall_num != wn)
 	{
-		if ( Cursegp->sides[Curside].wall_num != wall_none)
+		if (w)
 		{
 			ui_checkbox_check(wd->doorFlag[0].get(), w->flags & WALL_DOOR_LOCKED);
 			ui_checkbox_check(wd->doorFlag[1].get(), w->flags & WALL_DOOR_AUTO);
@@ -435,7 +436,7 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 	// update the corresponding wall flag.
 	//------------------------------------------------------------
 
-	if (w->type == WALL_DOOR)
+	if (w && w->type == WALL_DOOR)
 	{
 		if (GADGET_PRESSED(wd->doorFlag[0].get()))
 		{
@@ -472,7 +473,7 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 			ui_radio_set_value(i.get(), 0);
 	}
 
-	if (w->type == WALL_ILLUSION) {
+	if (w && w->type == WALL_ILLUSION) {
 		if (GADGET_PRESSED(wd->doorFlag[2].get()))
 		{
 			if ( wd->doorFlag[2]->flag == 1 )	
@@ -498,7 +499,7 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 		DeltaTime = Temp - wd->time;
 
 		gr_set_current_canvas( wd->wallViewBox->canvas );
-		if (Cursegp->sides[Curside].wall_num != wall_none) {
+		if (w) {
 			type = w->type;
 			if ((type == WALL_DOOR) || (type == WALL_BLASTABLE)) {
 				if (DeltaTime > ((F1_0*200)/1000)) {
@@ -531,8 +532,8 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 	//------------------------------------------------------------
 	if (event.type == EVENT_UI_DIALOG_DRAW)
 	{
-		if ( Cursegp->sides[Curside].wall_num != wall_none )	{
-			ui_dprintf_at( MainWindow, 12, 6, "Wall: %hi    ", static_cast<int16_t>(Cursegp->sides[Curside].wall_num));
+		if (w)	{
+			ui_dprintf_at( MainWindow, 12, 6, "Wall: %hi    ", static_cast<int16_t>(wn));
 			switch (w->type) {
 				case WALL_NORMAL:
 					ui_dprintf_at( MainWindow, 12, 23, " Type: Normal   " );
@@ -570,14 +571,14 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 		}
 	}
 	
-	if (ui_button_any_drawn || (wd->old_wall_num != Cursegp->sides[Curside].wall_num) )
+	if (ui_button_any_drawn || (wd->old_wall_num != wn) )
 		Update_flags |= UF_WORLD_CHANGED;
 	if (GADGET_PRESSED(wd->quitButton.get()) || keypress == KEY_ESC)
 	{
 		return window_event_result::close;
 	}		
 
-	wd->old_wall_num = Cursegp->sides[Curside].wall_num;
+	wd->old_wall_num = wn;
 	
 	return rval;
 }

--- a/similar/editor/medwall.cpp
+++ b/similar/editor/medwall.cpp
@@ -896,7 +896,10 @@ int wall_unlink_door()
 	}
 
 	if (w1->linked_wall == wall_none)
+	{
 		editor_status("Curseg/curside is not linked");
+		return 0;
+	}
 
 	auto &w2 = *vwallptr(w1->linked_wall);
 	Assert(w2.linked_wall == cwall_num);

--- a/similar/editor/medwall.cpp
+++ b/similar/editor/medwall.cpp
@@ -411,13 +411,12 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 	//------------------------------------------------------------
 	ui_button_any_drawn = 0;
 
-	const auto wn = Cursegp->sides[Curside].wall_num;
-	const auto &&w = wn == wall_none ? nullptr : vwallptr(wn);
+	const auto &&w = wallptridx(Cursegp->sides[Curside].wall_num);
 	//------------------------------------------------------------
 	// If we change walls, we need to reset the ui code for all
 	// of the checkboxes that control the wall flags.  
 	//------------------------------------------------------------
-	if (wd->old_wall_num != wn)
+	if (wd->old_wall_num != w)
 	{
 		if (w)
 		{
@@ -534,7 +533,7 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 	if (event.type == EVENT_UI_DIALOG_DRAW)
 	{
 		if (w)	{
-			ui_dprintf_at( MainWindow, 12, 6, "Wall: %hi    ", static_cast<int16_t>(wn));
+			ui_dprintf_at( MainWindow, 12, 6, "Wall: %hi    ", static_cast<int16_t>(w));
 			switch (w->type) {
 				case WALL_NORMAL:
 					ui_dprintf_at( MainWindow, 12, 23, " Type: Normal   " );
@@ -572,14 +571,14 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 		}
 	}
 	
-	if (ui_button_any_drawn || (wd->old_wall_num != wn) )
+	if (ui_button_any_drawn || (wd->old_wall_num != w) )
 		Update_flags |= UF_WORLD_CHANGED;
 	if (GADGET_PRESSED(wd->quitButton.get()) || keypress == KEY_ESC)
 	{
 		return window_event_result::close;
 	}		
 
-	wd->old_wall_num = wn;
+	wd->old_wall_num = w;
 	
 	return rval;
 }

--- a/similar/editor/medwall.cpp
+++ b/similar/editor/medwall.cpp
@@ -663,7 +663,7 @@ int wall_remove_side(const vsegptridx_t seg, short side)
 		{
 			if (segp->segnum != segment_none)
 				range_for (auto &w, segp->sides)
-					if (w.wall_num > lower_wallnum+1)
+					if (w.wall_num != wall_none && w.wall_num > lower_wallnum+1)
 						w.wall_num -= 2;
 		}
 

--- a/similar/editor/medwall.cpp
+++ b/similar/editor/medwall.cpp
@@ -390,6 +390,7 @@ window_event_result wall_dialog_handler(UI_DIALOG *dlg,const d_event &event, wal
 			return wall_dialog_created(dlg, wd);
 		case EVENT_WINDOW_CLOSE:
 			std::default_delete<wall_dialog>()(wd);
+			MainWindow = nullptr;
 			return window_event_result::ignored;
 		default:
 			break;

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -1281,6 +1281,7 @@ window_event_result game_handler(window *,const d_event &event, const unused_win
 			break;
 
 		case EVENT_WINDOW_CLOSE:
+			Game_wind = nullptr;	// Don't let any of the code below close Game_wind - it's already being done!
 			digi_stop_digi_sounds();
 
 			if ( (Newdemo_state == ND_STATE_RECORDING) || (Newdemo_state == ND_STATE_PAUSED) )
@@ -1299,7 +1300,6 @@ window_event_result game_handler(window *,const d_event &event, const unused_win
 			if (!EditorWindow)		// have to do it this way because of the necessary longjmp. Yuck.
 #endif
 				show_menus();
-			Game_wind = NULL;
 			event_toggle_focus(0);
 			key_toggle_repeat(1);
 			return window_event_result::ignored;

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -1304,7 +1304,10 @@ static window_event_result HandleTestKey(int key)
 		case KEY_E + KEY_DEBUGGED:
 			window_set_visible(Game_wind, 0);	// don't let the game do anything while we set the editor up
 			init_editor();
-			return window_event_result::close;
+			// If editor failed to load, carry on playing
+			if (!EditorWindow)
+				window_set_visible(Game_wind, 1);
+			return EditorWindow ? window_event_result::close : window_event_result::handled;
 #if defined(DXX_BUILD_DESCENT_II)
 	case KEY_Q + KEY_SHIFTED + KEY_DEBUGGED:
 		{

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -1306,8 +1306,11 @@ static window_event_result HandleTestKey(int key)
 			init_editor();
 			// If editor failed to load, carry on playing
 			if (!EditorWindow)
+			{
 				window_set_visible(Game_wind, 1);
-			return EditorWindow ? window_event_result::close : window_event_result::handled;
+				return window_event_result::handled;
+			}
+			return window_event_result::close;
 #if defined(DXX_BUILD_DESCENT_II)
 	case KEY_Q + KEY_SHIFTED + KEY_DEBUGGED:
 		{

--- a/similar/main/gameseg.cpp
+++ b/similar/main/gameseg.cpp
@@ -1277,7 +1277,8 @@ static void get_verts_for_normal(int va, int vb, int vc, int vd, int *v0, int *v
 				swap(w[j], w[i]);
 			}
 
-	Assert((v[0] < v[1]) && (v[1] < v[2]) && (v[2] < v[3]));
+	if (!((v[0] < v[1]) && (v[1] < v[2]) && (v[2] < v[3])))
+		LevelError("Level contains malformed geometry.");
 
 	//	Now, if for any w[i] & w[i+1]: w[i+1] = (w[i]+3)%4, then must swap
 	*v0 = v[0];

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -744,7 +744,7 @@ void LoadLevel(int level_num,int page_in_textures)
 	int load_ret = load_level(level_name);		//actually load the data from disk!
 
 	if (load_ret)
-		Error("Couldn't load level file <%s>, error = %d",static_cast<const char *>(level_name),load_ret);
+		Error("Could not load level file <%s>, error = %d",static_cast<const char *>(level_name),load_ret);
 
 	Current_level_num=level_num;
 

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -508,40 +508,6 @@ void init_player_stats_new_ship(ubyte pnum)
 	digi_kill_sound_linked_to_object(plrobj);
 }
 
-#if DXX_USE_EDITOR
-//reset stuff so game is semi-normal when playing from editor
-void editor_reset_stuff_on_level()
-{
-	gameseq_init_network_players();
-	init_player_stats_level(secret_restore::none);
-	const auto &&console = vobjptr(get_local_player().objnum);
-	ConsoleObject = Viewer = console;
-	set_player_id(console, Player_num);
-	console->control_type = CT_FLYING;
-	console->movement_type = MT_PHYSICS;
-	Game_suspended = 0;
-	verify_console_object();
-	Control_center_destroyed = 0;
-	if (Newdemo_state != ND_STATE_PLAYBACK)
-		gameseq_remove_unused_players();
-	init_cockpit();
-	init_robots_for_level();
-	init_ai_objects();
-	init_morphs();
-	init_all_matcens();
-	init_player_stats_new_ship(Player_num);
-	init_stuck_objects();
-#if defined(DXX_BUILD_DESCENT_II)
-	init_controlcen_for_level();
-	automap_clear_visited();
-	init_thief_for_level();
-	compute_slide_segs();
-#endif
-	if (!Game_wind)
-		Game_wind = window_create(grd_curscreen->sc_canvas, 0, 0, SWIDTH, SHEIGHT, game_handler, unused_window_userdata);
-}
-#endif
-
 }
 
 //do whatever needs to be done when a player dies in multiplayer
@@ -1481,20 +1447,6 @@ void DoPlayerDead()
 	gr_palette_load (gr_palette);
 
 	dead_player_end();		//terminate death sequence (if playing)
-
-#if DXX_USE_EDITOR
-	if (Game_mode == GM_EDITOR) {			//test mine, not real level
-		const auto playerobj = &get_local_plrobj();
-		//nm_messagebox( "You're Dead!", 1, "Continue", "Not a real game, though." );
-		if (Game_wind)
-			window_set_visible(Game_wind, 1);
-		load_level("gamesave.lvl");
-		init_player_stats_new_ship(Player_num);
-		playerobj->flags &= ~OF_SHOULD_BE_DEAD;
-		StartLevel(0);
-		return;
-	}
-	#endif
 
 	if ( Game_mode&GM_MULTI )
 	{

--- a/similar/main/mission.cpp
+++ b/similar/main/mission.cpp
@@ -1088,13 +1088,87 @@ int select_mission(int anarchy_mode, const char *message, window_event_result (*
 }
 
 #if DXX_USE_EDITOR
+int write_mission(void)
+{
+	auto &msn_extension =
+#if defined(DXX_BUILD_DESCENT_II)
+	(Current_mission->descent_version == Mission::descent_version_type::descent2) ? MISSION_EXTENSION_DESCENT_II :
+#endif
+	MISSION_EXTENSION_DESCENT_I;
+	array<char, PATH_MAX> mission_filename;
+	snprintf(mission_filename.data(), mission_filename.size(), "%s%s", Current_mission->path.c_str(), msn_extension);
+	
+	auto &&mfile = PHYSFSX_openWriteBuffered(mission_filename.data());
+	if (!mfile)
+	{
+		PHYSFS_mkdir(MISSION_DIR);	//try making directory - in *write* path
+		mfile = PHYSFSX_openWriteBuffered(mission_filename.data());
+		if (!mfile)
+			return 0;
+	}
+
+#if defined(DXX_BUILD_DESCENT_II)
+	switch (Current_mission->descent_version)
+	{
+		case Mission::descent_version_type::descent2x:
+			PHYSFSX_printf(mfile, "x");
+			break;
+
+		case Mission::descent_version_type::descent2z:
+			PHYSFSX_printf(mfile, "z");
+			break;
+			
+		case Mission::descent_version_type::descent2a:
+			PHYSFSX_printf(mfile, "!");
+			break;
+
+		default:
+			break;
+	}
+#endif
+
+	PHYSFSX_printf(mfile, "name = %s\n", static_cast<const char *>(Current_mission->mission_name));
+
+	PHYSFSX_printf(mfile, "type = %s\n", Current_mission->anarchy_only_flag ? "anarchy" : "normal");
+
+	if (Briefing_text_filename[0])
+		PHYSFSX_printf(mfile, "briefing = %s\n", static_cast<const char *>(Briefing_text_filename));
+
+	if (Ending_text_filename[0])
+		PHYSFSX_printf(mfile, "ending = %s\n", static_cast<const char *>(Ending_text_filename));
+
+	PHYSFSX_printf(mfile, "num_levels = %i\n", Last_level);
+
+	range_for (auto &i, unchecked_partial_range(Level_names.get(), Last_level))
+		PHYSFSX_printf(mfile, "%s\n", static_cast<const char *>(i));
+
+	if (N_secret_levels)
+	{
+		PHYSFSX_printf(mfile, "num_secrets = %i\n", N_secret_levels);
+
+		for (int i = 0; i < N_secret_levels; i++)
+			PHYSFSX_printf(mfile, "%s,%i\n", static_cast<const char *>(Secret_level_names[i]), Secret_level_table[i]);
+	}
+
+#if defined(DXX_BUILD_DESCENT_II)
+	if (Current_mission->alternate_ham_file)
+		PHYSFSX_printf(mfile, "ham = %s\n", static_cast<const char *>(*Current_mission->alternate_ham_file.get()));
+#endif
+
+	mfile.reset();
+
+	return 1;
+}
+
 void create_new_mission(void)
 {
 	Current_mission = make_unique<Mission>();
 	*Current_mission = {};
-	Current_mission->path = "new_miss";		// limited to eight characters because of savegame format
-	Current_mission->filename = begin(Current_mission->path);
+	Current_mission->mission_name.copy_if("Untitled");
+	Current_mission->path = MISSION_DIR "new_miss";		// limited to eight characters because of savegame format
+	Current_mission->filename = next(begin(Current_mission->path), sizeof(MISSION_DIR) - 1);
 	Current_mission->builtin_hogsize = 0;
+	Current_mission->anarchy_only_flag = 0;
 	
 	Level_names = make_unique<d_fname[]>(1);
 	if (!Level_names)
@@ -1105,11 +1179,22 @@ void create_new_mission(void)
 
 	Level_names[0] = "GAMESAVE.LVL";
 	Last_level = 1;
+	N_secret_levels = 0;
+	Last_secret_level = 0;
+	Briefing_text_filename = {};
+	Ending_text_filename = {};
+	Secret_level_table.reset();
+	Secret_level_names.reset();
+
 #if defined(DXX_BUILD_DESCENT_II)
 	if (Gamesave_current_version > 3)
 		Current_mission->descent_version = Mission::descent_version_type::descent2;	// custom ham not supported in editor (yet)
 	else
 		Current_mission->descent_version = Mission::descent_version_type::descent1;
+
+	Current_mission->alternate_ham_file = nullptr;
 #endif
+
+	write_mission();
 }
 #endif

--- a/similar/main/mission.cpp
+++ b/similar/main/mission.cpp
@@ -1092,7 +1092,7 @@ void create_new_mission(void)
 {
 	Current_mission = make_unique<Mission>();
 	*Current_mission = {};
-	Current_mission->path = "new_mission";
+	Current_mission->path = "new_miss";		// limited to eight characters because of savegame format
 	Current_mission->filename = begin(Current_mission->path);
 	Current_mission->builtin_hogsize = 0;
 	

--- a/similar/main/mission.cpp
+++ b/similar/main/mission.cpp
@@ -1088,11 +1088,11 @@ int select_mission(int anarchy_mode, const char *message, window_event_result (*
 }
 
 #if DXX_USE_EDITOR
-int write_mission(void)
+static int write_mission(void)
 {
 	auto &msn_extension =
 #if defined(DXX_BUILD_DESCENT_II)
-	(Current_mission->descent_version == Mission::descent_version_type::descent2) ? MISSION_EXTENSION_DESCENT_II :
+	(Current_mission->descent_version != Mission::descent_version_type::descent1) ? MISSION_EXTENSION_DESCENT_II :
 #endif
 	MISSION_EXTENSION_DESCENT_I;
 	array<char, PATH_MAX> mission_filename;
@@ -1107,19 +1107,20 @@ int write_mission(void)
 			return 0;
 	}
 
+	const char *prefix = "";
 #if defined(DXX_BUILD_DESCENT_II)
 	switch (Current_mission->descent_version)
 	{
 		case Mission::descent_version_type::descent2x:
-			PHYSFSX_printf(mfile, "x");
+			prefix = "x";
 			break;
 
 		case Mission::descent_version_type::descent2z:
-			PHYSFSX_printf(mfile, "z");
+			prefix = "z";
 			break;
 			
 		case Mission::descent_version_type::descent2a:
-			PHYSFSX_printf(mfile, "!");
+			prefix = "!";
 			break;
 
 		default:
@@ -1127,7 +1128,7 @@ int write_mission(void)
 	}
 #endif
 
-	PHYSFSX_printf(mfile, "name = %s\n", static_cast<const char *>(Current_mission->mission_name));
+	PHYSFSX_printf(mfile, "%sname = %s\n", prefix, static_cast<const char *>(Current_mission->mission_name));
 
 	PHYSFSX_printf(mfile, "type = %s\n", Current_mission->anarchy_only_flag ? "anarchy" : "normal");
 
@@ -1154,8 +1155,6 @@ int write_mission(void)
 	if (Current_mission->alternate_ham_file)
 		PHYSFSX_printf(mfile, "ham = %s\n", static_cast<const char *>(*Current_mission->alternate_ham_file.get()));
 #endif
-
-	mfile.reset();
 
 	return 1;
 }

--- a/similar/main/mission.cpp
+++ b/similar/main/mission.cpp
@@ -37,6 +37,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "window.h"
 #include "mission.h"
 #include "gameseq.h"
+#include "gamesave.h"
 #include "titles.h"
 #include "piggy.h"
 #include "console.h"
@@ -1093,6 +1094,7 @@ void create_new_mission(void)
 	*Current_mission = {};
 	Current_mission->path = "new_mission";
 	Current_mission->filename = begin(Current_mission->path);
+	Current_mission->builtin_hogsize = 0;
 	
 	Level_names = make_unique<d_fname[]>(1);
 	if (!Level_names)
@@ -1102,5 +1104,12 @@ void create_new_mission(void)
 	}
 
 	Level_names[0] = "GAMESAVE.LVL";
+	Last_level = 1;
+#if defined(DXX_BUILD_DESCENT_II)
+	if (Gamesave_current_version > 3)
+		Current_mission->descent_version = Mission::descent_version_type::descent2;	// custom ham not supported in editor (yet)
+	else
+		Current_mission->descent_version = Mission::descent_version_type::descent1;
+#endif
 }
 #endif

--- a/similar/main/object.cpp
+++ b/similar/main/object.cpp
@@ -131,7 +131,7 @@ void object_goto_next_viewer()
 		}
 	}
 
-	Error( "Couldn't find a viewer object!" );
+	Error( "Could not find a viewer object!" );
 
 }
 #endif

--- a/similar/main/render.cpp
+++ b/similar/main/render.cpp
@@ -1455,9 +1455,9 @@ void render_mine(segnum_t start_seg_num,fix eye_offset, window_rendered_data &wi
 	{
 		first_terminal_seg = 0;
 	}
-	else
+	//else
 	#endif
-		//NOTE LINK TO ABOVE!!
+		//NOTE LINK TO ABOVE!!	-Link killed by kreatordxx to get editor selection working again
 		build_segment_list(rstate, visited, first_terminal_seg, start_seg_num);		//fills in Render_list & N_render_segs
 
 	const auto &&render_range = partial_const_range(rstate.Render_list, rstate.N_render_segs);
@@ -1483,7 +1483,7 @@ void render_mine(segnum_t start_seg_num,fix eye_offset, window_rendered_data &wi
 	}
 	#endif
 
-	if (!(_search_mode))
+	//if (!(_search_mode))
 		build_object_lists(rstate);
 
 	if (eye_offset<=0) // Do for left eye or zero.

--- a/similar/main/state.cpp
+++ b/similar/main/state.cpp
@@ -1431,19 +1431,11 @@ int state_restore_all_sub(const char *filename, const secret_restore secret)
 // Read the mission info...
 	PHYSFS_read(fp, mission, sizeof(char) * 9, 1);
 
-	if (!load_mission_by_name( mission )
-#if DXX_USE_EDITOR
-		&& strcmp(mission, "new_miss")
-#endif
-		)
+	if (!load_mission_by_name(mission))
 	{
 		nm_messagebox( NULL, 1, "Ok", "Error!\nUnable to load mission\n'%s'\n", mission );
 		return 0;
 	}
-#if DXX_USE_EDITOR
-	else if (!strcmp(mission, "new_miss"))
-		create_new_mission();	// use simple dummy mission
-#endif
 
 //Read level info
 	current_level = PHYSFSX_readSXE32(fp, swap);

--- a/similar/main/state.cpp
+++ b/similar/main/state.cpp
@@ -1431,10 +1431,19 @@ int state_restore_all_sub(const char *filename, const secret_restore secret)
 // Read the mission info...
 	PHYSFS_read(fp, mission, sizeof(char) * 9, 1);
 
-	if (!load_mission_by_name( mission ))	{
+	if (!load_mission_by_name( mission )
+#if DXX_USE_EDITOR
+		&& strcmp(mission, "new_miss")
+#endif
+		)
+	{
 		nm_messagebox( NULL, 1, "Ok", "Error!\nUnable to load mission\n'%s'\n", mission );
 		return 0;
 	}
+#if DXX_USE_EDITOR
+	else if (!strcmp(mission, "new_miss"))
+		create_new_mission();	// use simple dummy mission
+#endif
 
 //Read level info
 	current_level = PHYSFSX_readSXE32(fp, swap);


### PR DESCRIPTION
Fixes a bunch of bugs that existed with the editor, including:
- Crash when closing a dialog
- Crash when loading Object Properties dialog with no object selected
- File load/save not working
- Crash when loading Do Wall Dialog with no wall selected
- Stability issues after closing wall or hostage dialog
- Crash when loading editor (via delete-E) when playing a demo
- Crash when any of the required files (*.pad, *.fnt and *.mnu) are missing
- Clicking in the game view box always reporting "Click on non-texture ignored"

Note this pull request depends on #264 (as that is a much higher priority).