### PR TITLE
Used saved game loading/saving when switching between editor and a game

### DIFF
--- a/common/include/editor/editor.h
+++ b/common/include/editor/editor.h
@@ -155,6 +155,13 @@ struct editor_view
 	fix ev_zoom;				//zoom for this window
 };
 
+enum class editor_gamestate : uint8_t
+{
+	none,		// editing a level, not a gamestate
+	unsaved,	// just pressed delete-e from a game
+	saved		// saved state. Do we want to restore it when launching editor from menu? Ask user.
+};
+
 /*
  * Global variables
  * 
@@ -165,7 +172,7 @@ extern int N_views;
 extern int Large_view_index;
 extern std::unique_ptr<UI_GADGET_USERBOX> LargeViewBox, GameViewBox, GroupViewBox;
 extern int Found_seg_index;				// Index in Found_segs corresponding to Cursegp
-extern int gamestate_not_restored;
+extern editor_gamestate gamestate;
 extern grs_font_ptr editor_font;
 
 extern	vms_vector Ed_view_target;		// what editor is looking at

--- a/common/main/gameseq.h
+++ b/common/main/gameseq.h
@@ -40,7 +40,7 @@ constexpr unsigned LEVEL_NAME_LEN = 36;       //make sure this is multiple of 4!
 
 // Current_level_num starts at 1 for the first level
 // -1,-2,-3 are secret levels
-// 0 means not a real level loaded
+// 0 used to mean not a real level loaded (i.e. editor generated level), but this hack has been removed
 extern int Current_level_num, Next_level_num;
 extern PHYSFSX_gets_line_t<LEVEL_NAME_LEN> Current_level_name;
 extern array<obj_position, MAX_PLAYERS> Player_init;

--- a/similar/editor/kgame.cpp
+++ b/similar/editor/kgame.cpp
@@ -151,7 +151,7 @@ if (SafetyCheck())  {
 		checkforgamext(game_filename);
 		if (load_level(game_filename))
 			return 0;
-		Current_level_num = 0;			//not a real level
+		Current_level_num = 1;			// assume level 1
 		gamestate_not_restored = 0;
 		Update_flags = UF_WORLD_CHANGED;
 		Perm_player_position = ConsoleObject->pos;

--- a/similar/editor/kgame.cpp
+++ b/similar/editor/kgame.cpp
@@ -91,12 +91,12 @@ int SetPlayerPosition()
 //	returns 0 if unsuccessful
 int SaveGameData()
 {
-	if (gamestate_not_restored) {
-		if (ui_messagebox(-2, -2, 2, "Game State has not been restored...\nContinue?\n", "NO", "Yes") == 1)
+	if (gamestate == editor_gamestate::unsaved) {
+		if (ui_messagebox(-2, -2, 2, "Game State has not been saved...\nContinue?\n", "NO", "Yes") == 1)
 			return 0;
 		}
 		
-   if (ui_get_filename( game_filename, "*." DXX_LEVEL_FILE_EXTENSION, "SAVE GAME" )) {
+   if (ui_get_filename( game_filename, "*." DXX_LEVEL_FILE_EXTENSION, "Save Level" )) {
 		int saved_flag;
 		vms_vector save_pos = ConsoleObject->pos;
 		vms_matrix save_orient = ConsoleObject->orient;
@@ -137,6 +137,7 @@ int SaveGameData()
 		if (saved_flag)
 			return 0;
 		mine_changed = 0;
+		gamestate = editor_gamestate::none;
 	}
 	return 1;
 }
@@ -146,13 +147,13 @@ int SaveGameData()
 int LoadGameData()
 {
 if (SafetyCheck())  {
-	if (ui_get_filename( game_filename, "*." DXX_LEVEL_FILE_EXTENSION, "LOAD GAME" ))
+	if (ui_get_filename( game_filename, "*." DXX_LEVEL_FILE_EXTENSION, "Load Level" ))
 		{
 		checkforgamext(game_filename);
 		if (load_level(game_filename))
 			return 0;
 		Current_level_num = 1;			// assume level 1
-		gamestate_not_restored = 0;
+		gamestate = editor_gamestate::none;
 		Update_flags = UF_WORLD_CHANGED;
 		Perm_player_position = ConsoleObject->pos;
 		Perm_player_orient = ConsoleObject->orient;

--- a/similar/editor/kmine.cpp
+++ b/similar/editor/kmine.cpp
@@ -127,7 +127,7 @@ int CreateNewMine()
 		init_info = 1;
 		ResetFilename();
 		Game_mode = GM_UNKNOWN;
-		Current_level_num = 0;		//0 means not a real game
+		Current_level_num = 1;		// make level 1
 	}
 	return 1;
 }

--- a/similar/editor/kmine.cpp
+++ b/similar/editor/kmine.cpp
@@ -123,7 +123,7 @@ int CreateNewMine()
 		Found_segs.clear();
 		Selected_segs.clear();
 		med_compress_mine();
-		gamestate_not_restored = 0;
+		gamestate = editor_gamestate::none;
 		init_info = 1;
 		ResetFilename();
 		Game_mode = GM_UNKNOWN;

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -1197,13 +1197,6 @@ window *game_setup(void)
 	reset_time();
 	FrameTime = 0;			//make first frame zero
 
-#if DXX_USE_EDITOR
-	if (Current_level_num == 0) {	//not a real level
-		init_player_stats_game(Player_num);
-		init_ai_objects();
-	}
-#endif
-
 	fix_object_segs();
 	if (CGameArg.SysAutoRecordDemo && Newdemo_state == ND_STATE_NORMAL)
 		newdemo_start_recording();

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -1304,15 +1304,22 @@ static window_event_result HandleTestKey(int key)
 #if DXX_USE_EDITOR		//editor-specific functions
 
 		case KEY_E + KEY_DEBUGGED:
+		{
 			window_set_visible(Game_wind, 0);	// don't let the game do anything while we set the editor up
+			auto old_gamestate = gamestate;
+			gamestate = editor_gamestate::unsaved;	// saved game editing mode
+
 			init_editor();
 			// If editor failed to load, carry on playing
 			if (!EditorWindow)
 			{
 				window_set_visible(Game_wind, 1);
+				gamestate = old_gamestate;
 				return window_event_result::handled;
 			}
 			return window_event_result::close;
+		}
+
 #if defined(DXX_BUILD_DESCENT_II)
 	case KEY_Q + KEY_SHIFTED + KEY_DEBUGGED:
 		{

--- a/similar/main/gamesave.cpp
+++ b/similar/main/gamesave.cpp
@@ -1453,7 +1453,7 @@ int create_new_mine(void)
 	
 	init_all_vertices();
 	
-	Current_level_num = 0;		//0 means not a real level
+	Current_level_num = 1;		// make level 1 (for now)
 	Current_level_name.next()[0] = 0;
 #if defined(DXX_BUILD_DESCENT_I)
 	Gamesave_current_version = LEVEL_FILE_VERSION;

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -752,7 +752,10 @@ void LoadLevel(int level_num,int page_in_textures)
 	load_palette(Current_level_palette,1,1);		//don't change screen
 #endif
 
-	show_boxed_message(TXT_LOADING, 0);
+#if DXX_USE_EDITOR
+	if (!EditorWindow)
+#endif
+		show_boxed_message(TXT_LOADING, 0);
 #ifdef RELEASE
 	timer_delay(F1_0);
 #endif
@@ -780,7 +783,10 @@ void LoadLevel(int level_num,int page_in_textures)
 
 	set_sound_sources();
 
-	songs_play_level_song( Current_level_num, 0 );
+#if DXX_USE_EDITOR
+	if (!EditorWindow)
+#endif
+		songs_play_level_song( Current_level_num, 0 );
 
 	gr_palette_load(gr_palette);		//actually load the palette
 #if defined(DXX_BUILD_DESCENT_I)

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -173,8 +173,8 @@ static void copy_defaults_to_robot_all(void);
 namespace dcx {
 //Current_level_num starts at 1 for the first level
 //-1,-2,-3 are secret levels
-//0 means not a real level loaded
-int	Current_level_num=0,Next_level_num;
+//0 used to mean not a real level loaded (i.e. editor generated level), but this hack has been removed
+int	Current_level_num=1,Next_level_num;
 PHYSFSX_gets_line_t<LEVEL_NAME_LEN> Current_level_name;
 
 // Global variables describing the player
@@ -1376,13 +1376,6 @@ static void AdvanceLevel(int secret_flag)
 	}
 
 	Control_center_destroyed = 0;
-
-#if DXX_USE_EDITOR
-	if (Current_level_num == 0)
-	{
-		window_close(Game_wind);		//not a real level
-	}
-	#endif
 
 	if (Game_mode & GM_MULTI)	{
 		int result;

--- a/similar/main/state.cpp
+++ b/similar/main/state.cpp
@@ -77,6 +77,10 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "ogl_init.h"
 #endif
 
+#if DXX_USE_EDITOR
+#include "editor/editor.h"
+#endif
+
 #include "compiler-exchange.h"
 #include "compiler-range_for.h"
 #include "partial_range.h"
@@ -1477,7 +1481,13 @@ int state_restore_all_sub(const char *filename, const secret_restore secret)
 	player_info pl_info;
 	fix pl_shields;
 	{
-		StartNewLevelSub(current_level, 1, secret);
+#if DXX_USE_EDITOR
+		// Don't bother with the other game sequence stuff if loading saved game in editor
+		if (EditorWindow)
+			LoadLevel(current_level, 1);
+		else
+#endif
+			StartNewLevelSub(current_level, 1, secret);
 
 #if defined(DXX_BUILD_DESCENT_II)
 		if (secret != secret_restore::none) {


### PR DESCRIPTION
When going to editor mode via Delete-E, save the game to _Players/gamesave.sge_ (_sge_ short for _saved game editor_). If switching back into the game via **File->Play in 320x200** without saving the level, load that saved game. The saved game can also be loaded back into the editor if the editor was subsequently launched another way (or the level was saved) with **File->Restore Game State**.

This is primarily to provide more continuity when switching between the game and the editor. The last set of changes to the editor made the player's stats reset to starting a new game when choosing **File->Play in 320x200** (as it was calling `StartNewGame`). This also maintains the game state more accurately, preserving weapon fire and various other info, as stored in the saved game file.

May also be useful for testing, especially for finding the object number of any given object, including temporary objects. (And cheating! ;) But not for multiplayer - editor mode is disallowed!!)