### PR TITLE
Call newmenu_free_background at exit

### DIFF
--- a/similar/main/inferno.cpp
+++ b/similar/main/inferno.cpp
@@ -502,6 +502,7 @@ static int main(int argc, char *argv[])
 	show_titles();
 
 	set_screen_mode(SCREEN_MENU);
+	atexit(newmenu_free_background);	// suppresses 'blocks were left allocated' warning at exit
 
 	con_printf( CON_DEBUG, "\nDoing gamedata_init..." );
 	gamedata_init();


### PR DESCRIPTION
Suppresses '1 blocks were left allocated' warning at exit, which is an alert box on non-Linux builds.

Only applicable when built with `debug=1` or `memdebug=1`.