### PR TITLE
Remove calls to window_close(Game_wind)

### DIFF
--- a/common/main/cntrlcen.h
+++ b/common/main/cntrlcen.h
@@ -31,6 +31,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "fwd-object.h"
 #include "pack.h"
 #include "fwd-segment.h"
+#include "fwd-window.h"
 
 #include "fwd-partial_range.h"
 
@@ -120,7 +121,7 @@ void init_controlcen_for_level();
 void calc_controlcen_gun_point(object &obj);
 
 void do_controlcen_destroyed_stuff(objptridx_t objp);
-void do_controlcen_dead_frame();
+window_event_result do_controlcen_dead_frame();
 }
 #endif
 

--- a/common/main/collide.h
+++ b/common/main/collide.h
@@ -32,10 +32,11 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "fwd-object.h"
 #include "fwd-segment.h"
 #include "fwd-vecmat.h"
+#include "fwd-window.h"
 
 #if defined(DXX_BUILD_DESCENT_I) || defined(DXX_BUILD_DESCENT_II)
 void collide_two_objects(vobjptridx_t A, vobjptridx_t B, vms_vector &collision_point);
-void collide_object_with_wall(vobjptridx_t A, fix hitspeed, vsegptridx_t hitseg, short hitwall, const vms_vector &hitpt);
+window_event_result collide_object_with_wall(vobjptridx_t A, fix hitspeed, vsegptridx_t hitseg, short hitwall, const vms_vector &hitpt);
 namespace dsx {
 void apply_damage_to_player(object &player, cobjptridx_t killer, fix damage, uint8_t possibly_friendly);
 }
@@ -84,7 +85,7 @@ void drop_player_eggs(vobjptridx_t playerobj);
 }
 #endif
 #if defined(DXX_BUILD_DESCENT_II)
-void do_final_boss_frame(void);
+window_event_result do_final_boss_frame(void);
 void do_final_boss_hacks(void);
 enum class volatile_wall_result : int8_t
 {

--- a/common/main/endlevel.h
+++ b/common/main/endlevel.h
@@ -29,17 +29,18 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "vecmat.h"
 #include "fwd-segment.h"
 #include "gr.h"
+#include "fwd-window.h"
 
 extern int Endlevel_sequence;
 #ifdef dsx
 namespace dsx {
-void do_endlevel_frame();
+window_event_result do_endlevel_frame();
 }
 #endif
-void stop_endlevel_sequence();
+window_event_result stop_endlevel_sequence();
 #ifdef dsx
 namespace dsx {
-void start_endlevel_sequence();
+window_event_result start_endlevel_sequence();
 }
 #endif
 void render_endlevel_frame(fix eye_offset);

--- a/common/main/fwd-object.h
+++ b/common/main/fwd-object.h
@@ -16,6 +16,7 @@
 #include "cpp-valptridx.h"
 #include "fwd-vecmat.h"
 #include "fwd-segment.h"
+#include "fwd-window.h"
 
 struct bitmap_index;
 
@@ -255,7 +256,7 @@ void render_object(vobjptridx_t obj);
 void draw_object_tmap_rod(vobjptridx_t obj, bitmap_index bitmap, int lighted);
 
 // move all objects for the current frame
-void object_move_all();     // moves all objects
+window_event_result object_move_all();     // moves all objects
 
 // set viewer object to next object in array
 void object_goto_next_viewer();
@@ -328,7 +329,7 @@ void special_reset_objects();
 void obj_attach(vobjptridx_t parent,vobjptridx_t sub);
 
 void create_small_fireball_on_object(vobjptridx_t objp, fix size_scale, int sound_flag);
-void dead_player_frame();
+window_event_result dead_player_frame();
 
 #if defined(DXX_BUILD_DESCENT_II)
 extern int Drop_afterburner_blob_flag;		//ugly hack

--- a/common/main/gameseq.h
+++ b/common/main/gameseq.h
@@ -28,6 +28,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include <cstddef>
 #include "fwd-player.h"
 #include "fwd-object.h"
+#include "fwd-window.h"
 
 #if defined(DXX_BUILD_DESCENT_I) || defined(DXX_BUILD_DESCENT_II)
 struct player;
@@ -72,13 +73,13 @@ void init_player_stats_game(ubyte pnum);      //clear all stats
 // if secret flag is true, advance to secret level, else next normal level
 #ifdef dsx
 namespace dsx {
-void PlayerFinishedLevel(int secret_flag);
+window_event_result PlayerFinishedLevel(int secret_flag);
 
 }
 #endif
 namespace dsx {
 // called when the player has died
-void DoPlayerDead(void);
+window_event_result DoPlayerDead(void);
 }
 
 #if defined(DXX_BUILD_DESCENT_I)
@@ -91,7 +92,7 @@ namespace dsx {
 // load just the hxm file
 void load_level_robots(int level_num);
 extern int	First_secret_visit;
-void ExitSecretLevel();
+window_event_result ExitSecretLevel();
 }
 #endif
 

--- a/common/main/physics.h
+++ b/common/main/physics.h
@@ -29,6 +29,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 #include "vecmat.h"
 #include "fvi.h"
+#include "fwd-window.h"
 
 #ifdef __cplusplus
 
@@ -46,7 +47,7 @@ extern array<segnum_t, MAX_FVI_SEGS> phys_seglist;
 #if defined(DXX_BUILD_DESCENT_I) || defined(DXX_BUILD_DESCENT_II)
 #ifdef dsx
 namespace dsx {
-void do_physics_sim(vobjptridx_t obj);
+window_event_result do_physics_sim(vobjptridx_t obj);
 
 }
 #endif

--- a/common/main/switch.h
+++ b/common/main/switch.h
@@ -37,6 +37,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "valptridx.h"
 #include "compiler-array.h"
 #include "dsx-ns.h"
+#include "fwd-window.h"
 
 constexpr std::integral_constant<std::size_t, 100> MAX_TRIGGERS{};
 #define MAX_WALLS_PER_LINK  10
@@ -172,8 +173,8 @@ constexpr uint8_t trigger_none = 0xff;
 
 extern void trigger_init();
 namespace dsx {
-void check_trigger(vcsegptridx_t seg, short side, object &plrobj, vcobjptridx_t objnum, int shot);
-int check_trigger_sub(object &, trgnum_t trigger_num, int player_num,int shot);
+window_event_result check_trigger(vcsegptridx_t seg, short side, object &plrobj, vcobjptridx_t objnum, int shot);
+window_event_result check_trigger_sub(object &, trgnum_t trigger_num, int player_num,int shot);
 
 static inline int trigger_is_exit(const trigger *t)
 {

--- a/similar/editor/med.cpp
+++ b/similar/editor/med.cpp
@@ -921,13 +921,9 @@ static void close_editor()
 	switch (ModeFlag)
 	{
 		case 1:
-			if (Game_wind)
-				window_close(Game_wind);
 			break;
 
 		case 2:
-			if (Game_wind)
-				window_close(Game_wind);
 			set_screen_mode(SCREEN_MENU);		//put up menu screen
 			show_menus();
 			break;

--- a/similar/main/cntrlcen.cpp
+++ b/similar/main/cntrlcen.cpp
@@ -77,7 +77,7 @@ int	Control_center_present;
 
 namespace dsx {
 
-static void do_countdown_frame();
+static window_event_result do_countdown_frame();
 
 //	-----------------------------------------------------------------------------
 //return the position & orientation of a gun on the control center object
@@ -154,10 +154,10 @@ constexpr int	D2_Alan_pavlish_reactor_times[NDL] = {90, 60, 45, 35, 30};
 
 //	-----------------------------------------------------------------------------
 //	Called every frame.  If control center been destroyed, then actually do something.
-void do_controlcen_dead_frame()
+window_event_result do_controlcen_dead_frame()
 {
 	if ((Game_mode & GM_MULTI) && (get_local_player().connected != CONNECT_PLAYING)) // if out of level already there's no need for this
-		return;
+		return window_event_result::ignored;
 
 	if ((Dead_controlcen_object_num != object_none) && (Countdown_seconds_left > 0))
 		if (d_rand() < FrameTime*4)
@@ -169,17 +169,19 @@ void do_controlcen_dead_frame()
 			create_small_fireball_on_object(vobjptridx(Dead_controlcen_object_num), CC_FIREBALL_SCALE, 1);
 
 	if (Control_center_destroyed && !Endlevel_sequence)
-		do_countdown_frame();
+		return do_countdown_frame();
+
+	return window_event_result::ignored;
 }
 
 #define COUNTDOWN_VOICE_TIME fl2f(12.75)
 
-void do_countdown_frame()
+window_event_result do_countdown_frame()
 {
 	fix	old_time;
 	int	fc, div_scale;
 
-	if (!Control_center_destroyed)	return;
+	if (!Control_center_destroyed)	return window_event_result::ignored;
 
 #if defined(DXX_BUILD_DESCENT_II)
 	if (!is_D2_OEM && !is_MAC_SHARE && !is_SHAREWARE)   // get countdown in OEM and SHAREWARE only
@@ -188,9 +190,9 @@ void do_countdown_frame()
 		if (PLAYING_BUILTIN_MISSION && Current_level_num == Last_level)
 		{
 			if (!(Game_mode & GM_MULTI))
-				return;
+				return window_event_result::ignored;
 			if (Game_mode & GM_MULTI_ROBOTS)
-				return;
+				return window_event_result::ignored;
 		}
 	}
 #endif
@@ -254,9 +256,11 @@ void do_countdown_frame()
 			reset_palette_add();							//restore palette for death message
 			//controlcen->MaxCapacity = Fuelcen_max_amount;
 			//gauge_message( "Control Center Reset" );
-			DoPlayerDead();		//kill_player();
+			return DoPlayerDead();		//kill_player();
 		}																				
 	}
+
+	return window_event_result::handled;
 }
 
 //	-----------------------------------------------------------------------------

--- a/similar/main/endlevel.cpp
+++ b/similar/main/endlevel.cpp
@@ -690,8 +690,7 @@ window_event_result do_endlevel_frame()
 					                    CT_NONE,MT_NONE,RT_NONE);
 
 					if (objnum == object_none) { //can't get object, so abort
-						result = std::max(stop_endlevel_sequence(), result);
-						return result;
+						return std::max(stop_endlevel_sequence(), result);
 					}
 
 					Viewer = endlevel_camera = objnum;

--- a/similar/main/endlevel.cpp
+++ b/similar/main/endlevel.cpp
@@ -281,9 +281,8 @@ vms_matrix surface_orient;
 static int endlevel_data_loaded;
 
 namespace dsx {
-void start_endlevel_sequence()
+window_event_result start_endlevel_sequence()
 {
-
 	reset_rear_view(); //turn off rear view if set - NOTE: make sure this happens before we pause demo recording!!
 
 	if (Newdemo_state == ND_STATE_RECORDING)		// stop demo recording
@@ -299,12 +298,12 @@ void start_endlevel_sequence()
 		}
 		strcpy(last_palette_loaded,"");		//force palette load next time
 #endif
-		return;
+		return window_event_result::ignored;
 	}
 
 	if (Player_dead_state != player_dead_state::no ||
 		(ConsoleObject->flags & OF_SHOULD_BE_DEAD))
-		return;				//don't start if dead!
+		return window_event_result::ignored;				//don't start if dead!
 	con_printf(CON_NORMAL, "You have escaped the mine!");
 
 #if defined(DXX_BUILD_DESCENT_II)
@@ -342,8 +341,7 @@ void start_endlevel_sequence()
 #endif
 	{
 
-		PlayerFinishedLevel(0);		//done with level
-		return;
+		return PlayerFinishedLevel(0);		//done with level
 	}
 #if defined(DXX_BUILD_DESCENT_II)
 	int exit_models_loaded = 0;
@@ -355,7 +353,7 @@ void start_endlevel_sequence()
 		exit_models_loaded = load_exit_models();
 
 	if (!exit_models_loaded)
-		return;
+		return window_event_result::ignored;
 #endif
 #ifndef NDEBUG
 	segnum_t last_segnum;
@@ -372,8 +370,7 @@ void start_endlevel_sequence()
 		{
 			if (child == segment_none)
 			{
-				PlayerFinishedLevel(0);		//don't do special sequence
-				return;
+				return PlayerFinishedLevel(0);		//don't do special sequence
 			}
 			tunnel_length++;
 			if (child == segment_exit)
@@ -441,6 +438,7 @@ void start_endlevel_sequence()
 
 	mine_destroyed=0;
 
+	return window_event_result::handled;
 }
 }
 
@@ -516,7 +514,7 @@ static int chase_angles(vms_angvec *cur_angles,vms_angvec *desired_angles)
 	return mask;
 }
 
-void stop_endlevel_sequence()
+window_event_result stop_endlevel_sequence()
 {
 #if !DXX_USE_OGL
 	Interpolation_method = 0;
@@ -526,7 +524,7 @@ void stop_endlevel_sequence()
 
 	Endlevel_sequence = EL_OFF;
 
-	PlayerFinishedLevel(0);
+	return PlayerFinishedLevel(0);
 }
 
 #define VCLIP_BIG_PLAYER_EXPLOSION	58
@@ -541,7 +539,7 @@ static void get_angs_to_object(vms_angvec &av,const vms_vector &targ_pos,const v
 }
 
 namespace dsx {
-void do_endlevel_frame()
+window_event_result do_endlevel_frame()
 {
 	static fix timer;
 	static fix bank_rate;
@@ -551,7 +549,7 @@ void do_endlevel_frame()
 	static fix ext_expl_halflife;
 
 	save_last_pos = ConsoleObject->last_pos;	//don't let move code change this
-	object_move_all();
+	auto result = object_move_all();
 	ConsoleObject->last_pos = save_last_pos;
 
 	if (ext_expl_playing) {
@@ -668,7 +666,7 @@ void do_endlevel_frame()
 
 	switch (Endlevel_sequence) {
 
-		case EL_OFF: return;
+		case EL_OFF: return result;
 
 		case EL_FLYTHROUGH: {
 
@@ -678,7 +676,7 @@ void do_endlevel_frame()
 
 #if defined(DXX_BUILD_DESCENT_II)
 				if (PLAYING_BUILTIN_MISSION && endlevel_movie_played != MOVIE_NOT_PLAYED)
-					stop_endlevel_sequence();
+					result = std::max(stop_endlevel_sequence(), result);
 				else
 #endif
 				{
@@ -692,8 +690,8 @@ void do_endlevel_frame()
 					                    CT_NONE,MT_NONE,RT_NONE);
 
 					if (objnum == object_none) { //can't get object, so abort
-						stop_endlevel_sequence();
-						return;
+						result = std::max(stop_endlevel_sequence(), result);
+						return result;
 					}
 
 					Viewer = endlevel_camera = objnum;
@@ -798,7 +796,7 @@ void do_endlevel_frame()
 
 				#ifdef SHORT_SEQUENCE
 
-				stop_endlevel_sequence();
+				result = std::max(stop_endlevel_sequence(), result);
 
 				#else
 				Endlevel_sequence = EL_PANNING;
@@ -809,8 +807,8 @@ void do_endlevel_frame()
 				timer = i2f(3);
 
 				if (Game_mode & GM_MULTI) { // try to skip part of the seq if multiplayer
-					stop_endlevel_sequence();
-					return;
+					result = std::max(stop_endlevel_sequence(), result);
+					return result;
 				}
 
 				#endif		//SHORT_SEQUENCE
@@ -883,7 +881,7 @@ void do_endlevel_frame()
 			vm_vec_scale_add2(endlevel_camera->pos,endlevel_camera->orient.fvec,fixmul(FrameTime,fixmul(speed_scale,cur_fly_speed)));
 
 			if (vm_vec_dist(ConsoleObject->pos,station_pos) < i2f(10))
-				stop_endlevel_sequence();
+				result = std::max(stop_endlevel_sequence(), result);
 			#endif
 
 			break;
@@ -892,6 +890,8 @@ void do_endlevel_frame()
 		#endif		//ifdef SHORT_SEQUENCE
 
 	}
+
+	return result;
 }
 }
 

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -413,22 +413,21 @@ static int do_game_pause()
 	return 0 /*key*/;	// Keycode returning ripped out (kreatordxx)
 }
 
-static int HandleEndlevelKey(int key)
+static window_event_result HandleEndlevelKey(int key)
 {
 	switch (key)
 	{
 		case KEY_COMMAND+KEY_P:
 		case KEY_PAUSE:
 			do_game_pause();
-			return 1;
+			return window_event_result::handled;
 
 		case KEY_ESC:
-			stop_endlevel_sequence();
 			last_drawn_cockpit=-1;
-			return 1;
+			return stop_endlevel_sequence();
 	}
 
-	return 0;
+	return window_event_result::ignored;
 }
 
 static int HandleDeathInput(const d_event &event)
@@ -1888,8 +1887,9 @@ window_event_result ReadControls(const d_event &event)
 
 		if (Endlevel_sequence)
 		{
-			if (HandleEndlevelKey(key))
-				return window_event_result::handled;
+			auto result = HandleEndlevelKey(key);
+			if (result != window_event_result::ignored)
+				return result;
 		}
 		else if (Newdemo_state == ND_STATE_PLAYBACK )
 		{

--- a/similar/main/newdemo.cpp
+++ b/similar/main/newdemo.cpp
@@ -1096,8 +1096,11 @@ void newdemo_record_start_demo()
 namespace dsx {
 void newdemo_record_start_frame(fix frame_time )
 {
-	if (nd_record_v_no_space) {
-		newdemo_stop_playback();
+	if (nd_record_v_no_space)
+	{
+		// Shouldn't happen - we should have stopped demo recording,
+		// in which case this function shouldn't have been called in the first place
+		Int3();
 		return;
 	}
 

--- a/similar/main/physics.cpp
+++ b/similar/main/physics.cpp
@@ -300,7 +300,7 @@ public:
 //	-----------------------------------------------------------------------------------------------------------
 //Simulate a physics object for this frame
 namespace dsx {
-void do_physics_sim(const vobjptridx_t obj)
+window_event_result do_physics_sim(const vobjptridx_t obj)
 {
 	ignore_objects_array_t ignore_obj_list;
 	int try_again;
@@ -320,13 +320,14 @@ void do_physics_sim(const vobjptridx_t obj)
 	auto orig_segnum = obj->segnum;
 	int bounced=0;
 	bool Player_ScrapeFrame=false;
+	auto result = window_event_result::handled;
 
 	Assert(obj->movement_type == MT_PHYSICS);
 
 #ifndef NDEBUG
 	if (Dont_move_ai_objects)
 		if (obj->control_type == CT_AI)
-			return;
+			return window_event_result::ignored;
 #endif
 
 	pi = &obj->mtype.phys_info;
@@ -334,7 +335,7 @@ void do_physics_sim(const vobjptridx_t obj)
 	do_physics_sim_rot(obj);
 
 	if (!(pi->velocity.x || pi->velocity.y || pi->velocity.z || pi->thrust.x || pi->thrust.y || pi->thrust.z))
-		return;
+		return window_event_result::ignored;
 
 	n_phys_segs = 0;
 
@@ -486,7 +487,7 @@ void do_physics_sim(const vobjptridx_t obj)
 				if (obj->type == OBJ_WEAPON)
 					obj->flags |= OF_SHOULD_BE_DEAD;
 			}
-			return;
+			return window_event_result::ignored;
 		}
 
 		//calulate new sim time
@@ -542,7 +543,7 @@ void do_physics_sim(const vobjptridx_t obj)
 				wall_part = vm_vec_dot(moved_v,hit_info.hit_wallnorm);
 
 				if ((wall_part != 0 && moved_time>0 && (hit_speed=-fixdiv(wall_part,moved_time))>0) || obj->type == OBJ_WEAPON || obj->type == OBJ_DEBRIS)
-					collide_object_with_wall(obj, hit_speed, vsegptridx(WallHitSeg), WallHitSide, hit_info.hit_pnt);
+					result = collide_object_with_wall(obj, hit_speed, vsegptridx(WallHitSeg), WallHitSide, hit_info.hit_pnt);
 				/*
 				 * Due to the nature of this loop, it's possible that a local player may receive scrape damage multiple times in one frame.
 				 * Check if we received damage and do not apply more damage (nor produce damage sounds/flashes/bumps, etc) for the rest of the loop.
@@ -770,6 +771,8 @@ void do_physics_sim(const vobjptridx_t obj)
 				obj->flags |= OF_SHOULD_BE_DEAD;
 		}
 	}
+
+	return result;
 //--WE ALWYS WANT THIS IN, MATT AND MIKE DECISION ON 12/10/94, TWO MONTHS AFTER FINAL 	#endif
 }
 }

--- a/similar/main/switch.cpp
+++ b/similar/main/switch.cpp
@@ -308,7 +308,7 @@ window_event_result check_trigger_sub(object &plrobj, const trgnum_t trigger_num
 
 		if (trigger.flags & TRIGGER_SECRET_EXIT) {
 			if (trigger.flags & TRIGGER_EXIT)
-				LevelError("Trigger %u is both a regular and secret exit! Not recommended", trigger_num);
+				LevelError("Trigger %u is both a regular and secret exit! This is not a recommended combination.", trigger_num);
 			if (Newdemo_state == ND_STATE_RECORDING)		// stop demo recording
 				Newdemo_state = ND_STATE_PAUSED;
 


### PR DESCRIPTION
Remove calls to `window_close(Game_wind)` as discussed in #227, replacing with returning `window_event_result::close` all the way back to `game_handler`.

There have been a number of issues picked up relating to these offending calls (e.g. #280), particularly within functions ultimately called by `game_handler`. This is an attempt to remove all such calls.

There are still three outstanding cases, but I thought I would get feedback first before going further.