### PR TITLE
Remove remaining calls to window_close(Game_wind)

### DIFF
--- a/common/main/gameseq.h
+++ b/common/main/gameseq.h
@@ -60,7 +60,7 @@ namespace dsx {
 void StartNewGame(int start_level);
 
 // starts the next level
-void StartNewLevel(int level_num);
+window_event_result StartNewLevel(int level_num);
 
 }
 #endif

--- a/common/main/multi.h
+++ b/common/main/multi.h
@@ -559,7 +559,7 @@ void multi_add_lifetime_kills(int count);
 void multi_send_bounty( void );
 
 void multi_consistency_error(int reset);
-int multi_level_sync(void);
+window_event_result multi_level_sync();
 int multi_endlevel(int *secret);
 using multi_endlevel_poll = int(newmenu *menu,const d_event &event, const unused_newmenu_userdata_t *);
 multi_endlevel_poll *get_multi_endlevel_poll2();

--- a/common/main/multi.h
+++ b/common/main/multi.h
@@ -502,7 +502,7 @@ void multi_do_ping_frame();
 
 void multi_init_objects(void);
 void multi_do_protocol_frame(int force, int listen);
-void multi_do_frame(void);
+window_event_result multi_do_frame();
 
 #ifdef dsx
 namespace dsx {

--- a/common/main/net_udp.h
+++ b/common/main/net_udp.h
@@ -44,7 +44,7 @@ int net_udp_kmatrix_poll2( newmenu *menu,const d_event &event, const unused_newm
 void net_udp_send_endlevel_packet();
 void net_udp_dump_player(const _sockaddr &dump_addr, int why);
 void net_udp_disconnect_player(int playernum);
-int net_udp_level_sync();
+window_event_result net_udp_level_sync();
 void net_udp_send_mdata_direct(const ubyte *data, int data_len, int pnum, int priority);
 void net_udp_send_netgame_update();
 

--- a/common/main/newdemo.h
+++ b/common/main/newdemo.h
@@ -28,6 +28,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #ifdef __cplusplus
 #include "physfsx.h"
 #include "fwd-object.h"
+#include "fwd-window.h"
 
 class object_signature_t;
 
@@ -140,13 +141,13 @@ extern void newdemo_record_secret_exit_blown(int truth);
 
 // Functions called during playback process...
 extern void newdemo_object_move_all();
-extern void newdemo_playback_one_frame();
+extern window_event_result newdemo_playback_one_frame();
 #ifdef dsx
 namespace dsx {
-extern void newdemo_goto_end(int to_rewrite);
+extern window_event_result newdemo_goto_end(int to_rewrite);
 }
 #endif
-extern void newdemo_goto_beginning();
+extern window_event_result newdemo_goto_beginning();
 
 // Interactive functions to control playback/record;
 #ifdef dsx

--- a/common/main/state.h
+++ b/common/main/state.h
@@ -34,6 +34,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #ifdef __cplusplus
 #include <cstddef>
 #include "dsx-ns.h"
+#include "fwd-window.h"
 
 extern unsigned state_game_id;
 extern int state_quick_item;
@@ -101,11 +102,11 @@ static inline int state_restore_all(int in_game, secret_restore, std::nullptr_t,
 {
 	return state_restore_all(in_game, nullptr, blind);
 }
-void StartNewLevelSub(int level_num, int page_in_textures);
+window_event_result StartNewLevelSub(int level_num, int page_in_textures);
 // Actually does the work to start new level
-static inline void StartNewLevelSub(int level_num, int page_in_textures, secret_restore)
+static inline window_event_result StartNewLevelSub(int level_num, int page_in_textures, secret_restore)
 {
-	StartNewLevelSub(level_num, page_in_textures);
+	return StartNewLevelSub(level_num, page_in_textures);
 }
 void init_player_stats_level();
 static inline void init_player_stats_level(secret_restore)
@@ -117,7 +118,7 @@ int state_restore_all_sub(const char *filename, secret_restore);
 void set_pos_from_return_segment(void);
 int state_save_all(secret_save, blind_save);
 int state_restore_all(int in_game, secret_restore, const char *filename_override, blind_save);
-void StartNewLevelSub(int level_num, int page_in_textures, secret_restore);
+window_event_result StartNewLevelSub(int level_num, int page_in_textures, secret_restore);
 void init_player_stats_level(secret_restore);
 #endif
 }

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -1485,9 +1485,12 @@ window_event_result GameProcessFrame()
 
 	flash_frame();
 
-	if ( Newdemo_state == ND_STATE_PLAYBACK ) {
-		newdemo_playback_one_frame();
-		if ( Newdemo_state != ND_STATE_PLAYBACK )		{
+	if ( Newdemo_state == ND_STATE_PLAYBACK )
+	{
+		result = std::max(newdemo_playback_one_frame(), result);
+		if ( Newdemo_state != ND_STATE_PLAYBACK )
+		{
+			Assert(result == window_event_result::close);
 			return window_event_result::close;	// Go back to menu
 		}
 	}

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -1208,7 +1208,6 @@ namespace dsx {
 // Event handler for the game
 window_event_result game_handler(window *,const d_event &event, const unused_window_userdata_t *)
 {
-	const bool was_game_wind = Game_wind != nullptr;
 	auto result = window_event_result::ignored;
 
 	switch (event.type)
@@ -1275,7 +1274,7 @@ window_event_result game_handler(window *,const d_event &event, const unused_win
 			break;
 
 		case EVENT_WINDOW_CLOSE:
-			Game_wind = nullptr;	// Don't let any of the code below close Game_wind - it's already being done!
+			Game_wind = nullptr;
 			digi_stop_digi_sounds();
 
 			if ( (Newdemo_state == ND_STATE_RECORDING) || (Newdemo_state == ND_STATE_PAUSED) )
@@ -1302,11 +1301,6 @@ window_event_result game_handler(window *,const d_event &event, const unused_win
 		default:
 			break;
 	}
-
-	// If we deleted the window ***in this call of the handler***, tell the event loop
-	// Will be removed when no cases of this left
-	if (!Game_wind && was_game_wind)
-		result = window_event_result::deleted;
 
 	return result;
 }
@@ -1444,7 +1438,7 @@ window_event_result GameProcessFrame()
 
 	if (Game_mode & GM_MULTI)
 	{
-		multi_do_frame();
+		result = std::max(multi_do_frame(), result);
 		if (Netgame.PlayTimeAllowed && ThisLevelTime>=i2f((Netgame.PlayTimeAllowed*5*60)))
 			multi_check_for_killgoal_winner();
 	}

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -458,7 +458,7 @@ static int HandleDeathInput(const d_event &event)
 	return 0;
 }
 
-static int HandleDemoKey(int key)
+static window_event_result HandleDemoKey(int key)
 {
 	switch (key) {
 		KEY_MAC(case KEY_COMMAND+KEY_1:)
@@ -487,6 +487,7 @@ static int HandleDemoKey(int key)
 					break;
 			}
 			newdemo_stop_playback();
+			return window_event_result::close;
 			break;
 		case KEY_UP:
 			Newdemo_vcr_state = ND_STATE_PLAYBACK;
@@ -503,10 +504,10 @@ static int HandleDemoKey(int key)
 			Newdemo_vcr_state = ND_STATE_ONEFRAMEFORWARD;
 			break;
 		case KEY_CTRLED + KEY_RIGHT:
-			newdemo_goto_end(0);
+			return newdemo_goto_end(0);
 			break;
 		case KEY_CTRLED + KEY_LEFT:
-			newdemo_goto_beginning();
+			return newdemo_goto_beginning();
 			break;
 
 		KEY_MAC(case KEY_COMMAND+KEY_P:)
@@ -574,10 +575,10 @@ static int HandleDemoKey(int key)
 #endif
 
 		default:
-			return 0;
+			return window_event_result::ignored;
 	}
 
-	return 1;
+	return window_event_result::handled;
 }
 
 #if defined(DXX_BUILD_DESCENT_II)
@@ -1893,8 +1894,9 @@ window_event_result ReadControls(const d_event &event)
 		}
 		else if (Newdemo_state == ND_STATE_PLAYBACK )
 		{
-			if (HandleDemoKey(key))
-				return window_event_result::handled;
+			auto r = HandleDemoKey(key);
+			if (r != window_event_result::ignored)
+				return r;
 		}
 		else
 		{

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -1450,7 +1450,7 @@ static window_event_result AdvanceLevel(int secret_flag)
                 }
 		// END NMN
 #endif
-		StartNewLevel(Next_level_num);
+		rval = std::max(StartNewLevel(Next_level_num), rval);
 	}
 
 	return rval;
@@ -1563,9 +1563,9 @@ window_event_result DoPlayerDead()
 //called when the player is starting a new level for normal game mode and restore state
 //	secret_flag set if came from a secret level
 #if defined(DXX_BUILD_DESCENT_I)
-void StartNewLevelSub(const int level_num, const int page_in_textures)
+window_event_result StartNewLevelSub(const int level_num, const int page_in_textures)
 #elif defined(DXX_BUILD_DESCENT_II)
-void StartNewLevelSub(const int level_num, const int page_in_textures, const secret_restore secret_flag)
+window_event_result StartNewLevelSub(const int level_num, const int page_in_textures, const secret_restore secret_flag)
 #endif
 {
 	if (!(Game_mode & GM_MULTI)) {
@@ -1597,11 +1597,11 @@ void StartNewLevelSub(const int level_num, const int page_in_textures, const sec
 
 	if (Game_mode & GM_NETWORK)
 	{
-                multi_prep_level_objects();
-		if(multi_level_sync()) // After calling this, Player_num is set
+		multi_prep_level_objects();
+		if (multi_level_sync() == window_event_result::close) // After calling this, Player_num is set
 		{
 			songs_play_song( SONG_TITLE, 1 ); // level song already plays but we fail to start level...
-			return;
+			return window_event_result::close;
 		}
 	}
 
@@ -1690,6 +1690,8 @@ void StartNewLevelSub(const int level_num, const int page_in_textures, const sec
 
 	if (!Game_wind)
 		game();
+
+	return window_event_result::handled;
 }
 
 }
@@ -1799,7 +1801,7 @@ static void maybe_set_first_secret_visit(int level_num)
 //called when the player is starting a new level for normal game model
 //	secret_flag if came from a secret level
 namespace dsx {
-void StartNewLevel(int level_num)
+window_event_result StartNewLevel(int level_num)
 {
 	hide_menus();
 
@@ -1818,7 +1820,7 @@ void StartNewLevel(int level_num)
 	ShowLevelIntro(level_num);
 #endif
 
-	StartNewLevelSub(level_num, 1, secret_restore::none);
+	return StartNewLevelSub(level_num, 1, secret_restore::none);
 
 }
 }

--- a/similar/main/multi.cpp
+++ b/similar/main/multi.cpp
@@ -983,7 +983,7 @@ void multi_do_protocol_frame(int force, int listen)
 	}
 }
 
-void multi_do_frame(void)
+window_event_result multi_do_frame()
 {
 	static int lasttime=0;
 	static fix64 last_gmode_time = 0, last_inventory_time = 0, last_repo_time = 0;
@@ -992,7 +992,7 @@ void multi_do_frame(void)
 	if (!(Game_mode & GM_MULTI) || Newdemo_state == ND_STATE_PLAYBACK)
 	{
 		Int3();
-		return;
+		return window_event_result::ignored;
 	}
 
 	if ((Game_mode & GM_NETWORK) && Netgame.PlayTimeAllowed && lasttime!=f2i (ThisLevelTime))
@@ -1041,12 +1041,7 @@ void multi_do_frame(void)
 
 	multi_do_protocol_frame(0, 1);
 
-	if (multi_quit_game)
-	{
-		multi_quit_game = 0;
-		if (Game_wind)
-			window_close(Game_wind);
-	}
+	return multi_quit_game ? window_event_result::close : window_event_result::handled;
 }
 
 void _multi_send_data(const ubyte *buf, unsigned len, int priority)

--- a/similar/main/multi.cpp
+++ b/similar/main/multi.cpp
@@ -3445,7 +3445,7 @@ void multi_prep_level_player(void)
 
 }
 
-int multi_level_sync(void)
+window_event_result multi_level_sync(void)
 {
 	switch (multi_protocol)
 	{
@@ -3458,6 +3458,8 @@ int multi_level_sync(void)
 			Error("Protocol handling missing in multi_level_sync\n");
 			break;
 	}
+
+	return window_event_result::ignored;
 }
 
 namespace dsx {

--- a/similar/main/net_udp.cpp
+++ b/similar/main/net_udp.cpp
@@ -4330,11 +4330,8 @@ static int net_udp_start_game(void)
 
 	Netgame.protocol.udp.your_index = 0; // I am Host. I need to know that y'know? For syncing later.
 	
-	if(net_udp_select_players())
-	{
-		StartNewLevel(Netgame.levelnum);
-	}
-	else
+	if (!net_udp_select_players()
+		|| StartNewLevel(Netgame.levelnum) == window_event_result::close)
 	{
 		Game_mode = GM_GAME_OVER;
 		return 0;	// see if we want to tweak the game we setup
@@ -4447,7 +4444,7 @@ menu:
 }
 
 /* Do required syncing after each level, before starting new one */
-int net_udp_level_sync()
+window_event_result net_udp_level_sync()
 {
 	int result = 0;
 
@@ -4471,13 +4468,11 @@ int net_udp_level_sync()
 	{
 		get_local_player().connected = CONNECT_DISCONNECTED;
 		net_udp_send_endlevel_packet();
-		if (Game_wind)
-			window_close(Game_wind);
 		show_menus();
 		net_udp_close();
-		return -1;
+		return window_event_result::close;
 	}
-	return(0);
+	return window_event_result::handled;
 }
 
 namespace dsx {
@@ -4537,9 +4532,7 @@ int net_udp_do_join_game()
 
 	net_udp_set_game_mode(Netgame.gamemode);
 
-	StartNewLevel(Netgame.levelnum);
-	
-	return 1;     // look ma, we're in a game!!!
+	return StartNewLevel(Netgame.levelnum) == window_event_result::handled;     // look ma, we're in a game!!! (If level syncing didn't fail -kreatordxx)
 }
 }
 


### PR DESCRIPTION
Remove calls to `window_close(Game_wind)` as discussed in #227, replacing with returning `window_event_result::close` all the way back to `game_handler`.

There have been a number of issues picked up relating to these offending calls (e.g. #280), particularly within functions ultimately called by `game_handler`.

This removes the three cases that were left. The somewhat contentious commit is the final one 0c5a000328058e18791aabc22d055cd27b6d2f61, as potentially a lot of code can be run between receiving a network event telling us to end the game and the game actually ending, possibly leading to unintended side effects. This is the change I was talking about in #227 @zicodxx.