### PR TITLE
Fix debugger break at draw_weapon_info_sub when multi player dumped

### DIFF
--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -1274,7 +1274,6 @@ window_event_result game_handler(window *,const d_event &event, const unused_win
 			break;
 
 		case EVENT_WINDOW_CLOSE:
-			Game_wind = nullptr;
 			digi_stop_digi_sounds();
 
 			if ( (Newdemo_state == ND_STATE_RECORDING) || (Newdemo_state == ND_STATE_PAUSED) )
@@ -1295,6 +1294,7 @@ window_event_result game_handler(window *,const d_event &event, const unused_win
 				show_menus();
 			event_toggle_focus(0);
 			key_toggle_repeat(1);
+			Game_wind = nullptr;
 			return window_event_result::ignored;
 			break;
 

--- a/similar/main/multi.cpp
+++ b/similar/main/multi.cpp
@@ -1139,6 +1139,8 @@ void multi_leave_game()
 #if defined(DXX_BUILD_DESCENT_I)
 	plyr_save_stats();
 #endif
+
+	multi_quit_game = 0;	// quit complete
 }
 
 }
@@ -2088,8 +2090,6 @@ void multi_disconnect_player(const playernum_t pnum)
 
 	if (pnum == multi_who_is_master()) // Host has left - Quit game!
 	{
-		if (Network_status==NETSTAT_PLAYING)
-			multi_leave_game();
 		if (Game_wind)
 			window_set_visible(Game_wind, 0);
 		nm_messagebox(NULL, 1, TXT_OK, "Host left the game!");
@@ -2097,7 +2097,6 @@ void multi_disconnect_player(const playernum_t pnum)
 			window_set_visible(Game_wind, 1);
 		multi_quit_game = 1;
 		game_leave_menus();
-		multi_reset_stuff();
 		return;
 	}
 

--- a/similar/main/net_udp.cpp
+++ b/similar/main/net_udp.cpp
@@ -2790,8 +2790,6 @@ static void net_udp_process_dump(ubyte *data, int, const _sockaddr &sender_addr)
 	{
 		case DUMP_PKTTIMEOUT:
 		case DUMP_KICKED:
-			if (Network_status==NETSTAT_PLAYING)
-				multi_leave_game();
 			if (Game_wind)
 				window_set_visible(Game_wind, 0);
 			if (data[1] == DUMP_PKTTIMEOUT)
@@ -2802,7 +2800,6 @@ static void net_udp_process_dump(ubyte *data, int, const _sockaddr &sender_addr)
 				window_set_visible(Game_wind, 1);
 			multi_quit_game = 1;
 			game_leave_menus();
-			multi_reset_stuff();
 			break;
 		default:
 			if (data[1] > DUMP_LEVEL) // invalid dump... heh
@@ -4770,8 +4767,6 @@ static void net_udp_noloss_add_queue_pkt(fix64 time, const ubyte *data, ushort d
 		else // I am just a client. I gotta go.
 		{
 			Netgame.PacketLossPrevention = 0; // Disable PLP - otherwise we get stuck in an infinite loop here. NOTE: We could as well clean the whole queue to continue protect our disconnect signal bit it's not that important - we just wanna leave.
-			if (Network_status==NETSTAT_PLAYING)
-				multi_leave_game();
 			if (Game_wind)
 				window_set_visible(Game_wind, 0);
 			nm_messagebox(NULL, 1, TXT_OK, "You left the game. You failed\nsending important packets.\nSorry.");
@@ -4779,7 +4774,6 @@ static void net_udp_noloss_add_queue_pkt(fix64 time, const ubyte *data, ushort d
 				window_set_visible(Game_wind, 1);
 			multi_quit_game = 1;
 			game_leave_menus();
-			multi_reset_stuff();
 		}
 		Assert(UDP_mdata_queue_highest == (UDP_MDATA_STOR_QUEUE_SIZE - 1));
 	}
@@ -4974,8 +4968,6 @@ void net_udp_noloss_process_queue(fix64 time)
 				else // We are client, so we gotta go.
 				{
 					Netgame.PacketLossPrevention = 0; // Disable PLP - otherwise we get stuck in an infinite loop here. NOTE: We could as well clean the whole queue to continue protect our disconnect signal bit it's not that important - we just wanna leave.
-					if (Network_status==NETSTAT_PLAYING)
-						multi_leave_game();
 					if (Game_wind)
 						window_set_visible(Game_wind, 0);
 					nm_messagebox(NULL, 1, TXT_OK, "You left the game. You failed\nsending important packets.\nSorry.");
@@ -4983,7 +4975,6 @@ void net_udp_noloss_process_queue(fix64 time)
 						window_set_visible(Game_wind, 1);
 					multi_quit_game = 1;
 					game_leave_menus();
-					multi_reset_stuff();
 				}
 			}
 			con_printf(CON_VERBOSE, "P#%u: Removing stored pkt_num [%i,%i,%i,%i,%i,%i,%i,%i] - missing ACKs: %i",Player_num, UDP_mdata_queue[queuec].pkt_num[0],UDP_mdata_queue[queuec].pkt_num[1],UDP_mdata_queue[queuec].pkt_num[2],UDP_mdata_queue[queuec].pkt_num[3],UDP_mdata_queue[queuec].pkt_num[4],UDP_mdata_queue[queuec].pkt_num[5],UDP_mdata_queue[queuec].pkt_num[6],UDP_mdata_queue[queuec].pkt_num[7], needack); // Just *marked* for removal. The actual process happens further below.


### PR DESCRIPTION
Fixes bug #303.

Also happened when a client to a multiplayer game dropped out due to some network error. Delay call of `multi_leave_game()` until responding to `EVENT_WINDOW_CLOSE`, so the game isn't in an unstable state between handling the network event and the game closing.