### PR TITLE
Fix bug #306 where a client in a multi game hitting a wall fails an assert

### DIFF
--- a/similar/main/multi.cpp
+++ b/similar/main/multi.cpp
@@ -2415,7 +2415,7 @@ void multi_reset_player_object(const vobjptr_t objp)
 	objp->mtype.phys_info.mass = Player_ship->mass;
 	objp->mtype.phys_info.drag = Player_ship->drag;
 	if (objp->type == OBJ_PLAYER)
-		objp->mtype.phys_info.flags |= PF_TURNROLL | PF_WIGGLE;
+		objp->mtype.phys_info.flags = PF_TURNROLL | PF_WIGGLE;
 	else
 		objp->mtype.phys_info.flags &= ~(PF_TURNROLL | PF_LEVELLING | PF_WIGGLE);
 

--- a/similar/main/object.cpp
+++ b/similar/main/object.cpp
@@ -790,7 +790,7 @@ void reset_player_object()
 	ConsoleObject->mtype.phys_info.turnroll = 0;
 	ConsoleObject->mtype.phys_info.mass = Player_ship->mass;
 	ConsoleObject->mtype.phys_info.drag = Player_ship->drag;
-	ConsoleObject->mtype.phys_info.flags |= PF_TURNROLL | PF_LEVELLING | PF_WIGGLE | PF_USES_THRUST;
+	ConsoleObject->mtype.phys_info.flags = PF_TURNROLL | PF_LEVELLING | PF_WIGGLE | PF_USES_THRUST;
 
 	//Init render info
 


### PR DESCRIPTION
Initialise ConsoleObject->mtype.phys_info.flags in reset_player_object() instead of adding flags. The only place this was initialised properly was when reading the player object from disk.