### PR TITLE
Fix bug #293, where robots dropped by robots would be ghost-like then…

### DIFF
--- a/similar/main/fireball.cpp
+++ b/similar/main/fireball.cpp
@@ -964,7 +964,7 @@ objptridx_t drop_powerup(int type, int id, int num, const vms_vector &init_vel, 
 
 				obj->shields = Robot_info[get_robot_id(obj)].strength;
 
-				obj->ctype.ai_info.behavior = ai_behavior::AIB_NORMAL;
+				init_ai_object(obj, ai_behavior::AIB_NORMAL, segment_none);
 				ai_local		*ailp = &obj->ctype.ai_info.ail;
 				ailp->player_awareness_type = player_awareness_type_t::PA_WEAPON_ROBOT_COLLISION;
 				ailp->player_awareness_time = F1_0*3;


### PR DESCRIPTION
… explode.

Initialise the ai info for spawned robots with init_ai_object. Doesn't appear to have ever been done.