### PR TITLE
Get 'BALDGUY' easter egg to work for D1X-Rebirth (Mac data)

### DIFF
--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -1386,6 +1386,7 @@ constexpr cheat_code cheat_codes[] = {
 	{ "bruin", &game_cheats::extralife },
 	{ "porgys", &game_cheats::rapidfire },
 	{ "ahimsa", &game_cheats::robotfiringsuspended },
+	{ "baldguy", &game_cheats::baldguy },
 #elif defined(DXX_BUILD_DESCENT_II)
 	{ "gabbagabbahey", &game_cheats::lamer },
 	{ "motherlode", &game_cheats::lamer },

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -1259,13 +1259,11 @@ static int load_briefing_screen(briefing *br, const char *fname)
 	if (d_stricmp(br->background_name, fname2))
 		strncpy (br->background_name,fname2, sizeof(br->background_name));
 
-	if ((!d_stricmp(fname2, "brief02.pcx") || !d_stricmp(fname2, "brief02h.pcx")) && cheats.baldguy)
-		if (bald_guy_load("btexture.xxx", &br->background, gr_palette) == 0)
-		{
-			return 0;
-		}
-
-	if ((pcx_error = pcx_read_bitmap(fname2, br->background, gr_palette))!=PCX_ERROR_NONE)
+	if ((!d_stricmp(fname2, "brief02.pcx") || !d_stricmp(fname2, "brief02h.pcx")) && cheats.baldguy &&
+		(bald_guy_load("btexture.xxx", &br->background, gr_palette) == PCX_ERROR_NONE))
+	{
+	}
+	else if ((pcx_error = pcx_read_bitmap(fname2, br->background, gr_palette))!=PCX_ERROR_NONE)
 	{
 		Error( "Error loading briefing screen <%s>, PCX load error: %s (%i)\n",fname2, pcx_errormsg(pcx_error), pcx_error);
 	}


### PR DESCRIPTION
Pressing ALT-B while in the briefing screens will show Dravis wearing a silly hat, for D1X-Rebirth with Mac data. Also add back the 'BALDGUY' cheat code so the next briefing featuring Dravis will show the same. Fixes bug #315.