### PR TITLE
Don't decrement trigger in remove_trigger_num if it's trigger_none

### DIFF
--- a/similar/editor/eswitch.cpp
+++ b/similar/editor/eswitch.cpp
@@ -245,7 +245,7 @@ int remove_trigger_num(int trigger_num)
 			auto &trigger = w->trigger;
 			if (trigger == trigger_num)
 				trigger = trigger_none;	// a trigger can be shared by multiple walls
-			else if (trigger > trigger_num) 
+			else if (trigger > trigger_num && trigger != trigger_none)
 				--trigger;
 		}
 


### PR DESCRIPTION
Fixes a crash when loading a level with redundant triggers and editor enabled, e.g. Passion of Death.