### PR TITLE
Fix bugs after getting Game Over and playing a demo or saved game

### DIFF
--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -1450,6 +1450,8 @@ window_event_result GameProcessFrame()
 	result = std::max(dead_player_frame(), result);
 	if (Newdemo_state != ND_STATE_PLAYBACK)
 		result = std::max(do_controlcen_dead_frame(), result);
+	if (result == window_event_result::close)
+		return result;	// skip everything else - don't set Player_dead_state again
 
 #if defined(DXX_BUILD_DESCENT_II)
 	process_super_mines_frame();

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -1465,9 +1465,10 @@ static window_event_result AdvanceLevel(int secret_flag)
 
 window_event_result DoPlayerDead()
 {
+	const bool pause = !(((Game_mode & GM_MULTI) && (Newdemo_state != ND_STATE_PLAYBACK)) && (!Endlevel_sequence));
 	auto result = window_event_result::handled;
 
-	if (!(((Game_mode & GM_MULTI) && (Newdemo_state != ND_STATE_PLAYBACK)) && (!Endlevel_sequence)))
+	if (pause)
 		stop_time();
 
 	reset_palette_add();
@@ -1486,6 +1487,8 @@ window_event_result DoPlayerDead()
 		if (get_local_player().lives == 0)
 		{
 			DoGameOver();
+			if (pause)
+				start_time();
 			return window_event_result::close;
 		}
 	}
@@ -1560,7 +1563,7 @@ window_event_result DoPlayerDead()
 
 	digi_sync_sounds();
 
-	if (!(((Game_mode & GM_MULTI) && (Newdemo_state != ND_STATE_PLAYBACK)) && (!Endlevel_sequence)))
+	if (pause)
 		start_time();
 	reset_time();
 


### PR DESCRIPTION
After getting game over and playing a demo or a saved game, make sure time is not stopped (i.e. allow movement), don't show the 'Game Over' banner anymore and fix a failed assert when loading a saved game.