### PR TITLE
Fix compiler error for Clang in maximum_value() method

### DIFF
--- a/common/include/vecmat.h
+++ b/common/include/vecmat.h
@@ -163,7 +163,7 @@ public:
 	}
 	static constexpr vm_distance_squared maximum_value()
 	{
-		return vm_distance_squared{0x7fffffffffffffff};
+		return vm_distance_squared{static_cast<fix64>(0x7fffffffffffffff)};
 	}
 	static constexpr vm_distance_squared minimum_value()
 	{


### PR DESCRIPTION
Fixes this compiler error:
```
common/include/vecmat.h:166:10: error: call to constructor of 'dcx::vm_distance_squared' is ambiguous
        return vm_distance_squared{0x7fffffffffffffff};
              ^                  ~~~~~~~~~~~~~~~~~~~~

common/include/vecmat.h:130:2: note: candidate constructor has been explicitly deleted
    vm_distance_squared(const fix &) = delete;
    ^

common/include/vecmat.h:131:21: note: candidate constructor
    constexpr explicit vm_distance_squared(const fix64 &f2) :
                       ^

common/include/vecmat.h:126:7: note: candidate is the implicit move constructor
class vm_distance_squared
      ^
common/include/vecmat.h:126:7: note: candidate is the implicit copy constructor
```