### PR TITLE
Update SDLMain.m

### DIFF
--- a/common/arch/cocoa/SDLMain.m
+++ b/common/arch/cocoa/SDLMain.m
@@ -351,12 +351,43 @@ static void CustomApplicationMain (int argc, char **argv)
 #endif
 
 
+static int IsRootCwd()
+{
+    char buf[MAXPATHLEN];
+    char *cwd = getcwd(buf, sizeof (buf));
+    return (cwd && (strcmp(cwd, "/") == 0));
+}
+
+static int IsTenPointNineOrLater()
+{
+    /* Gestalt() is deprecated in 10.8, but I don't care. Stop using SDL 1.2. */
+    SInt32 major, minor;
+    Gestalt(gestaltSystemVersionMajor, &major);
+    Gestalt(gestaltSystemVersionMinor, &minor);
+    return ( ((major << 16) | minor) >= ((10 << 16) | 9) );
+}
+
+static int IsFinderLaunch(const int argc, char **argv)
+{
+    const int bIsNewerOS = IsTenPointNineOrLater();
+    /* -psn_XXX is passed if we are launched from Finder in 10.8 and earlier */
+    if ( (!bIsNewerOS) && (argc >= 2) && (strncmp(argv[1], "-psn", 4) == 0) ) {
+        return 1;
+    } else if ((bIsNewerOS) && (argc == 1) && IsRootCwd()) {
+        /* we might still be launched from the Finder; on 10.9+, you might not
+        get the -psn command line anymore. Check version, if there's no
+        command line, and if our current working directory is "/". */
+        return 1;
+    }
+    return 0;  /* not a Finder launch. */
+}
+
 /* Main entry point to executable - should *not* be SDL_main! */
 int main (int argc, char **argv)
 {
     /* Copy the arguments into a global variable */
     /* This is passed if we are launched by double-clicking */
-    if ( argc >= 2 && strncmp (argv[1], "-psn", 4) == 0 ) {
+    if ( IsFinderLaunch(argc, argv) ) {
         gArgv = (char **) SDL_malloc(sizeof (char *) * 2);
         gArgv[0] = argv[0];
         gArgv[1] = NULL;


### PR DESCRIPTION
10.9 changed how applications were launched, making the old method of detecting a Finder launch fail.