### PR TITLE
Fix Blocky Filtered option.

### DIFF
--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1713,10 +1713,6 @@ static int ogl_loadtexture(const palette_array_t &pal, const uint8_t *data, cons
 			}
 			break;
 		case OGL_TEXFILT_UPSCALE: // Upscaled - i.e. Blocky Filtered (Bilinear)
-			gl_mag_filter_int = GL_LINEAR_MIPMAP_LINEAR;
-			gl_min_filter_int = GL_LINEAR_MIPMAP_LINEAR;
-			buildmipmap = true;
-			break;
 		case OGL_TEXFILT_TRLINEAR: // Smooth - Trilinear
 			gl_mag_filter_int = GL_LINEAR;
 			gl_min_filter_int = GL_LINEAR_MIPMAP_LINEAR;


### PR DESCRIPTION
I initially found there was a problem with Blocky Filtered in this line of code:

```gl_mag_filter_int = GL_LINEAR_MIPMAP_LINEAR;```

The problem with this code is that this is an invalid value for magnifying filters, because mipmaps don't make sense for magnifying filters, only minifying filters.  In fact, this is probably creating an OpenGL error, but Rebirth does not appear to catch any OpenGL errors, so the program will just skip over setting that value and either use the default, `GL_LINEAR`, or whatever was last used, which most likely will be `GL_NEAREST`.

The solution was not obvious... was this a typo or a copy/paste error from the patch?  So I went to the source, the original patch found at https://forum.dxx-rebirth.com/showthread.php?tid=874.  To quote forum user beware:

> a feature i call "blocky filtered". textures are upscaled 4x, and then rendered trilinear/anisotropic. so the textures have square pixels, but the image has no aliasing artefacts, regardless of if textures are nearby or far away or at a steep angle.

Based on this, it appears the correct course of action is to use the same filters for Blocky Filtered as are used for Trilinear.  In the code, this essentially means to use the same code block for the two rendering modes, and that is the solution used for the PR.