### PR TITLE
change SYNC_GL_AUTO mode to disable GL sync if VSync is turned off

### DIFF
--- a/common/arch/ogl/ogl_sync.cpp
+++ b/common/arch/ogl/ogl_sync.cpp
@@ -14,6 +14,7 @@
 #include <SDL.h>
 
 #include "args.h"
+#include "config.h"
 #include "console.h"
 #include "maths.h"
 #include "ogl_sync.h"
@@ -86,12 +87,18 @@ void ogl_sync::init(SyncGLMethod sync_method, int wait)
 	}
 
 	if (method == SYNC_GL_AUTO) {
-		if (!ogl_have_ARB_sync) {
-			con_puts(CON_NORMAL, "DXX-Rebirth: OpenGL: GL_ARB_sync not available, disabling sync");
+		if (!CGameCfg.VSync) {
+			con_puts(CON_NORMAL, "DXX-Rebirth: OpenGL: disabling automatic GL sync since VSync is turned off");
 			method = SYNC_GL_NONE;
 			need_ARB_sync = false;
 		} else {
-			method = SYNC_GL_FENCE_SLEEP;
+			if (!ogl_have_ARB_sync) {
+				con_puts(CON_NORMAL, "DXX-Rebirth: OpenGL: GL_ARB_sync not available, disabling sync");
+				method = SYNC_GL_NONE;
+				need_ARB_sync = false;
+			} else {
+				method = SYNC_GL_FENCE_SLEEP;
+			}
 		}
 	}
 

--- a/similar/main/inferno.cpp
+++ b/similar/main/inferno.cpp
@@ -210,7 +210,7 @@ static void print_commandline_help()
 		VERB("                                    2: Like 1, but sleep during sync to reduce CPU load\n")	\
 		VERB("                                    3: Immediately sync after buffer swap\n")	\
 		VERB("                                    4: Immediately sync after buffer swap\n")	\
-		VERB("                                    5: Auto. use mode 2 if available, 0 otherwise\n")	\
+		VERB("                                    5: Auto: if VSync is enabled and ARB_sync is supported, use mode 2, otherwise mode 0\n")	\
 		VERB("  -gl_syncwait <n>              Wait interval (ms) for sync mode 2 (default: " DXX_STRINGIZE(OGL_SYNC_WAIT_DEFAULT) ")\n")	\
 		VERB("  -gl_darkedges                 Re-enable dark edges around filtered textures (as present in earlier versions of the engine)\n")	\
 	)	\


### PR DESCRIPTION
Users with disabled VSync might not expect any forced waiting on the GPU,and the GL sync methods were intented to fix issues with VSync only, so the new heuristic for `SYNC_GL_AUTO` is to enable GL sync only if VSync is enabled, too.

Users can still request to use a specific GL sync method via the `-gl_syncmethod` switch, independent of the VSync setting.