### PR TITLE
handle multiplayer network packets during SYNC_GL_FENCE_SLEEP wait loop

### DIFF
--- a/common/arch/ogl/ogl_sync.cpp
+++ b/common/arch/ogl/ogl_sync.cpp
@@ -15,7 +15,9 @@
 
 #include "args.h"
 #include "console.h"
+#include "game.h"
 #include "maths.h"
+#include "multi.h"
 #include "ogl_sync.h"
 #include "timer.h"
 
@@ -46,8 +48,13 @@ void ogl_sync::before_swap()
 		const auto waitsync = glClientWaitSyncFunc;
 		if (method == SYNC_GL_FENCE_SLEEP) {
 			const auto local_wait_timeout = wait_timeout;
+			const auto multiplayer = Game_mode & GM_MULTI;
 			while (waitsync(local_fence.get(), GL_SYNC_FLUSH_COMMANDS_BIT, 0ULL) == GL_TIMEOUT_EXPIRED) {
+				if (multiplayer) {
+					multi_do_frame(); // during long wait, keep packets flowing
+				}
 				timer_delay_ms(local_wait_timeout);
+
 			}
 		} else {
 			waitsync(local_fence.get(), GL_SYNC_FLUSH_COMMANDS_BIT, 34000000ULL);


### PR DESCRIPTION
This mirrors the logic from `calc_frame_time()`. When VSync is enabled, waiting for the previous frame to complete might induce long wait periods, up to the complete frame time, so we should also handle multiplayer there.

For the other sync modes, the GL calls will simply block, so we can't do anything about that (except going multithreaded, but that's a totally different can of worms). Note that even without sync, the `SwapBuffers() `call in `gr_flip()` may also block if VSync is on (and enough frames are queued up), so the issue is not the GL sync code itself.

`SYNC_GL_FENCE_SLEEP` is now probably the nicest mode for multiplayer with VSsync, as it is the only one which has the potential to continue handling multiplayer packets during the wait for VBlank time.