### PR TITLE
Fix FPS.

### DIFF
--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -124,6 +124,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "segiter.h"
 
 static fix64 last_timer_value=0;
+static fix64 sync_timer_value=0;
 fix ThisLevelTime=0;
 
 grs_canvas	Screen_3d_window;							// The rectangle for rendering the mine to
@@ -477,14 +478,13 @@ void calc_frame_time()
 	{
 		const auto timer_value = timer_update();
 		FrameTime = timer_value - last_timer_value;
-		if (FrameTime >= bound)
+		if (timer_value - sync_timer_value >= bound)
 		{
-			// For constant target FPS rates, we increase the last timer value by the bound.
-			last_timer_value += bound;
+			last_timer_value = timer_value;
 
-			// If this frame ran long, we're not going to meet our target FPS, so just set the last timer value to the current timer value.
-			if (last_timer_value < timer_value) {
-				last_timer_value = timer_value;
+			sync_timer_value += bound;
+			if (sync_timer_value + bound < timer_value) {
+				sync_timer_value = timer_value;
 			}
 			break;
 		}

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -478,7 +478,7 @@ void calc_frame_time()
 	{
 		const auto timer_value = timer_update();
 		FrameTime = timer_value - last_timer_value;
-		if (timer_value - sync_timer_value >= bound)
+		if (FrameTime > 0 && timer_value - sync_timer_value >= bound)
 		{
 			last_timer_value = timer_value;
 

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -479,7 +479,13 @@ void calc_frame_time()
 		FrameTime = timer_value - last_timer_value;
 		if (FrameTime >= bound)
 		{
-			last_timer_value = timer_value;
+			// For constant target FPS rates, we increase the last timer value by the bound.
+			last_timer_value += bound;
+
+			// If this frame ran long, we're not going to meet our target FPS, so just set the last timer value to the current timer value.
+			if (last_timer_value < timer_value) {
+				last_timer_value = timer_value;
+			}
 			break;
 		}
 		if (Game_mode & GM_MULTI)

--- a/similar/main/gamerend.cpp
+++ b/similar/main/gamerend.cpp
@@ -117,7 +117,7 @@ static void show_framerate(grs_canvas &canvas)
 	{
 		fps_rate = fps_count;
 		fps_count = 0;
-		fps_time = tq;
+		fps_time += F1_0;
 	}
 	const auto &&line_spacing = LINE_SPACING(canvas);
 	unsigned line_displacement;


### PR DESCRIPTION
This fixes #378.

The issue is that `last_timer_value` was getting set to the `timer_value` at the conclusion of every frame.  This made the assumption that the frame time was going to run exactly at the desired value for the target FPS, and in fact that assumption was true up until a04aa340c50456630cd8ba52774702c8c751e94f.

This fixes the issue by not making that assumption, and instead incrementing `last_timer_value` by the `bound`, which is our target frame time.  In the case where our frame actually runs over the target frame time, we revert to previous behavior of just setting the `last_timer_value` to `timer_value` since our FPS will be off anyway.