### PR TITLE
Add missing glDisableClientState call

### DIFF
--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -910,6 +910,7 @@ void ogl_urect(grs_canvas &canvas, const int left, const int top, const int righ
 	glColorPointer(4, GL_FLOAT, 0, color_array.data());
 	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);//replaced GL_QUADS
 	glDisableClientState(GL_VERTEX_ARRAY);
+	glDisableClientState(GL_COLOR_ARRAY);
 }
 
 void ogl_ulinec(grs_canvas &canvas, const int left, const int top, const int right, const int bot, const int c)


### PR DESCRIPTION
Commit 449a5dffb1a376f14a6b33cb76386153dc2d3aae introduced various `glEnableClientState`/`glDisableClientState` pairs.  One of the disables got missed in `ogl_urect`.  This adds in the matching pair.

This is just an OpenGL cleanup, and should cause no visible change in game.