### PR TITLE
Quiet FSRef warnings

### DIFF
--- a/similar/misc/physfsx.cpp
+++ b/similar/misc/physfsx.cpp
@@ -226,20 +226,18 @@ bool PHYSFSX_init(int argc, char *argv[])
 	// For Macintosh, add the 'Resources' directory in the .app bundle to the searchpaths
 #if defined(__APPLE__) && defined(__MACH__)
 	{
-		ProcessSerialNumber psn = { 0, kCurrentProcess };
-		FSRef fsref;
-		OSStatus err;
-		
-		err = GetProcessBundleLocation(&psn, &fsref);
-		if (err == noErr)
-			err = FSRefMakePath(&fsref, reinterpret_cast<uint8_t *>(fullPath), PATH_MAX);
-		
-		if (err == noErr)
-		{
-			strncat(fullPath, "/Contents/Resources/", PATH_MAX + 4 - strlen(fullPath));
-			fullPath[PATH_MAX + 4] = '\0';
-			con_printf(CON_DEBUG, "PHYSFS: append resources directory \"%s\" to search path", fullPath);
-			PHYSFS_addToSearchPath(fullPath, 1);
+		CFBundleRef mainBundle = CFBundleGetMainBundle();
+		if (mainBundle) {
+			CFURLRef resourcesURL = CFBundleCopyResourcesDirectoryURL(mainBundle);
+			if (resourcesURL) {
+				if (CFURLGetFileSystemRepresentation(resourcesURL, TRUE, reinterpret_cast<uint8_t *>(fullPath), PATH_MAX + 5)) {
+					fullPath[PATH_MAX + 4] = '\0';
+					con_printf(CON_DEBUG, "PHYSFS: append resources directory \"%s\" to search path", fullPath);
+					PHYSFS_addToSearchPath(fullPath, 1);
+				}
+			
+				CFRelease(resourcesURL);
+			}
 		}
 	}
 #elif defined(macintosh)

--- a/similar/misc/physfsx.cpp
+++ b/similar/misc/physfsx.cpp
@@ -230,8 +230,8 @@ bool PHYSFSX_init(int argc, char *argv[])
 		if (mainBundle) {
 			CFURLRef resourcesURL = CFBundleCopyResourcesDirectoryURL(mainBundle);
 			if (resourcesURL) {
-				if (CFURLGetFileSystemRepresentation(resourcesURL, TRUE, reinterpret_cast<uint8_t *>(fullPath), PATH_MAX + 5)) {
-					fullPath[PATH_MAX + 4] = '\0';
+				if (CFURLGetFileSystemRepresentation(resourcesURL, TRUE, reinterpret_cast<uint8_t *>(fullPath), sizeof(fullPath))) {
+					fullPath[sizeof(fullPath) - 1] = '\0';
 					con_printf(CON_DEBUG, "PHYSFS: append resources directory \"%s\" to search path", fullPath);
 					PHYSFS_addToSearchPath(fullPath, 1);
 				}

--- a/similar/misc/physfsx.cpp
+++ b/similar/misc/physfsx.cpp
@@ -234,7 +234,6 @@ bool PHYSFSX_init(int argc, char *argv[])
 			{
 				if (CFURLGetFileSystemRepresentation(resourcesURL, TRUE, reinterpret_cast<uint8_t *>(fullPath), sizeof(fullPath)))
 				{
-					fullPath[sizeof(fullPath) - 1] = '\0';
 					con_printf(CON_DEBUG, "PHYSFS: append resources directory \"%s\" to search path", fullPath);
 					PHYSFS_addToSearchPath(fullPath, 1);
 				}

--- a/similar/misc/physfsx.cpp
+++ b/similar/misc/physfsx.cpp
@@ -227,10 +227,13 @@ bool PHYSFSX_init(int argc, char *argv[])
 #if defined(__APPLE__) && defined(__MACH__)
 	{
 		CFBundleRef mainBundle = CFBundleGetMainBundle();
-		if (mainBundle) {
+		if (mainBundle)
+		{
 			CFURLRef resourcesURL = CFBundleCopyResourcesDirectoryURL(mainBundle);
-			if (resourcesURL) {
-				if (CFURLGetFileSystemRepresentation(resourcesURL, TRUE, reinterpret_cast<uint8_t *>(fullPath), sizeof(fullPath))) {
+			if (resourcesURL)
+			{
+				if (CFURLGetFileSystemRepresentation(resourcesURL, TRUE, reinterpret_cast<uint8_t *>(fullPath), sizeof(fullPath)))
+				{
 					fullPath[sizeof(fullPath) - 1] = '\0';
 					con_printf(CON_DEBUG, "PHYSFS: append resources directory \"%s\" to search path", fullPath);
 					PHYSFS_addToSearchPath(fullPath, 1);


### PR DESCRIPTION
This replaces the deprecated FSRef-dependant calls to their modern CoreFoundation equivalents.