### PR TITLE
libADLMIDI for synthesis of MIDI sequences on OPL3 FM

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4701,7 +4701,7 @@ class DXXProgram(DXXCommon):
 				('__STDC_FORMAT_MACROS',),
 			],
 			CPPPATH = [os.path.join(self.srcdir, 'main')],
-			LIBS = ['m'],
+			LIBS = ['ADLMIDI', 'm'],
 		)
 
 	def register_program(self):

--- a/SConstruct
+++ b/SConstruct
@@ -4254,6 +4254,7 @@ class DXXArchive(DXXCommon):
 'common/3d/points.cpp',
 'common/3d/rod.cpp',
 'common/3d/setup.cpp',
+'common/music/adlmidi_dynamic.cpp',
 'common/arch/sdl/event.cpp',
 'common/arch/sdl/joy.cpp',
 'common/arch/sdl/key.cpp',
@@ -4701,7 +4702,7 @@ class DXXProgram(DXXCommon):
 				('__STDC_FORMAT_MACROS',),
 			],
 			CPPPATH = [os.path.join(self.srcdir, 'main')],
-			LIBS = ['ADLMIDI', 'm'],
+			LIBS = ['m', 'dl'],
 		)
 
 	def register_program(self):

--- a/common/arch/sdl/digi_mixer_music.cpp
+++ b/common/arch/sdl/digi_mixer_music.cpp
@@ -116,7 +116,6 @@ static ADL_MIDIPlayer *get_adlmidi()
 		adl_setNumChips(adlmidi, 6);
 		adl_setBank(adlmidi, 31);
 		adl_setSoftPanEnabled(adlmidi, 1);
-		adl_setLoopEnabled(adlmidi, 1);
 		current_adlmidi.reset(adlmidi);
 	}
 	return adlmidi;
@@ -207,6 +206,8 @@ int mix_play_file(const char *filename, int loop, void (*hook_finished_track)())
 
 	case CurrentMusicType::ADLMIDI:
 	{
+		ADL_MIDIPlayer *adlmidi = get_adlmidi();
+		adl_setLoopEnabled(adlmidi, loop);
 		Mix_HookMusic(&mix_adlmidi, nullptr);
 		Mix_HookMusicFinished(hook_finished_track ? hook_finished_track : mix_free_music);
 		return 1;

--- a/common/include/adlmidi_dynamic.h
+++ b/common/include/adlmidi_dynamic.h
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the DXX-Rebirth project <https://www.dxx-rebirth.com/>.
+ * It is copyright by its individual contributors, as recorded in the
+ * project's Git history.  See COPYING.txt at the top level for license
+ * terms and a link to the Git history.
+ */
+/*
+ * This is a dynamic interface to libADLMIDI, the OPL3 synthesizer library.
+ */
+
+#include <memory>
+#include <stdint.h>
+
+struct ADL_MIDIPlayer;
+
+enum ADLMIDI_SampleType
+{
+	ADLMIDI_SampleType_S16 = 0
+};
+
+struct ADLMIDI_AudioFormat
+{
+	enum ADLMIDI_SampleType type;
+	unsigned containerSize;
+	unsigned sampleOffset;
+};
+
+enum ADL_Emulator
+{
+    ADLMIDI_EMU_DOSBOX = 2,
+};
+
+/*
+ * A few embedded bank numbers.
+ */
+enum class ADL_EmbeddedBank
+{
+	MILES_AIL = 0,
+	BISQWIT = 1,
+	DESCENT = 2,
+	// DESCENT_INT = 3,
+	// DESCENT_HAM = 4,
+	// DESCENT_RICK = 5,
+	// DESCENT2 = 6,
+	LBA_4OP = 31,
+	THE_FATMAN_2OP = 58,
+	THE_FATMAN_4OP = 59,
+	JAMIE_OCONNELL = 66,
+	NGUYEN_WOHLSTAND_4OP = 68,
+	DMXOPL3 = 72,
+	APOGEE_IMF90 = 74,
+};
+
+extern ADL_MIDIPlayer *(*adl_init)(long sample_rate);
+extern void (*adl_close)(ADL_MIDIPlayer *device);
+extern int (*adl_switchEmulator)(ADL_MIDIPlayer *device, int emulator);
+extern int (*adl_setNumChips)(ADL_MIDIPlayer *device, int numChips);
+extern int (*adl_setBank)(ADL_MIDIPlayer *device, int bank);
+extern int (*adl_openBankFile)(ADL_MIDIPlayer *device, const char *filePath);
+extern void (*adl_setSoftPanEnabled)(ADL_MIDIPlayer *device, int softPanEn);
+extern void (*adl_setLoopEnabled)(ADL_MIDIPlayer *device, int loopEn);
+extern int (*adl_openData)(ADL_MIDIPlayer *device, const void *mem, unsigned long size);
+extern int (*adl_openFile)(ADL_MIDIPlayer *device, const char *filePath);
+extern int (*adl_playFormat)(ADL_MIDIPlayer *device, int sampleCount, uint8_t *left, uint8_t *right, const ADLMIDI_AudioFormat *format);
+
+struct ADLMIDI_delete
+{
+	void operator()(ADL_MIDIPlayer *x)
+	{
+		adl_close(x);
+	}
+};
+
+typedef std::unique_ptr<ADL_MIDIPlayer, ADLMIDI_delete> ADL_MIDIPlayer_t;

--- a/common/music/adlmidi_dynamic.cpp
+++ b/common/music/adlmidi_dynamic.cpp
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the DXX-Rebirth project <https://www.dxx-rebirth.com/>.
+ * It is copyright by its individual contributors, as recorded in the
+ * project's Git history.  See COPYING.txt at the top level for license
+ * terms and a link to the Git history.
+ */
+/*
+ * This is a dynamic interface to libADLMIDI, the OPL3 synthesizer library.
+ */
+
+#include "adlmidi_dynamic.h"
+#include "console.h"
+#if !defined(_WIN32)
+#include <dlfcn.h>
+#else
+#include <windows.h>
+#endif
+
+#if defined(_WIN32)
+enum
+{
+	RTLD_LAZY = 1, RTLD_NOW = 2
+};
+
+void *dlopen(const char *filename, int)
+{
+	return LoadLibraryA(filename);
+}
+
+void dlclose(void *handle)
+{
+	FreeLibrary(reinterpret_cast<HMODULE>(handle));
+}
+
+void *dlsym(void *handle, const char *symbol)
+{
+	return reinterpret_cast<void *>(
+		GetProcAddress(reinterpret_cast<HMODULE>(handle), symbol));
+}
+#endif
+
+static ADL_MIDIPlayer *adl_init_failure(long)
+{
+	return nullptr;
+}
+
+template <class F>
+static bool load_function(void *handle, const char *name, F *&fptr)
+{
+	fptr = reinterpret_cast<F *>(dlsym(handle, name));
+	if (!fptr)
+		con_printf(CON_NORMAL, "ADLMIDI: failed to load the dynamic function \"%s\"", name);
+	return fptr != nullptr;
+}
+
+static ADL_MIDIPlayer *adl_init_first_call(long sample_rate)
+{
+#if defined(_WIN32)
+	const char *library_name = "libADLMIDI.dll";
+#elif defined(__APPLE__)
+	const char *library_name = "libADLMIDI.dylib";
+#else
+	const char *library_name = "libADLMIDI.so";
+#endif
+	void *handle = dlopen(library_name, RTLD_LAZY);
+	if (!handle ||
+	    !load_function(handle, "adl_init", adl_init) ||
+	    !load_function(handle, "adl_close", adl_close) ||
+	    !load_function(handle, "adl_switchEmulator", adl_switchEmulator) ||
+	    !load_function(handle, "adl_setNumChips", adl_setNumChips) ||
+	    !load_function(handle, "adl_setBank", adl_setBank) ||
+	    !load_function(handle, "adl_openBankFile", adl_openBankFile) ||
+	    !load_function(handle, "adl_setSoftPanEnabled", adl_setSoftPanEnabled) ||
+	    !load_function(handle, "adl_setLoopEnabled", adl_setLoopEnabled) ||
+	    !load_function(handle, "adl_openData", adl_openData) ||
+	    !load_function(handle, "adl_openFile", adl_openFile) ||
+	    !load_function(handle, "adl_playFormat", adl_playFormat))
+	{
+		adl_init = &adl_init_failure;
+		if (handle)
+			dlclose(handle);
+		else
+			con_printf(CON_NORMAL, "ADLMIDI: failed to load the dynamic library \"%s\"", library_name);
+	}
+	else
+		con_printf(CON_NORMAL, "ADLMIDI: loaded the dynamic OPL3 synthesizer");
+	return adl_init(sample_rate);
+}
+
+ADL_MIDIPlayer *(*adl_init)(long sample_rate) = &adl_init_first_call;
+void (*adl_close)(ADL_MIDIPlayer *device) = nullptr;
+int (*adl_switchEmulator)(ADL_MIDIPlayer *device, int emulator) = nullptr;
+int (*adl_setNumChips)(ADL_MIDIPlayer *device, int numChips) = nullptr;
+int (*adl_setBank)(ADL_MIDIPlayer *device, int bank) = nullptr;
+int (*adl_openBankFile)(ADL_MIDIPlayer *device, const char *filePath) = nullptr;
+void (*adl_setSoftPanEnabled)(ADL_MIDIPlayer *device, int softPanEn) = nullptr;
+void (*adl_setLoopEnabled)(ADL_MIDIPlayer *device, int loopEn) = nullptr;
+int (*adl_openData)(ADL_MIDIPlayer *device, const void *mem, unsigned long size) = nullptr;
+int (*adl_openFile)(ADL_MIDIPlayer *device, const char *filePath) = nullptr;
+int (*adl_playFormat)(ADL_MIDIPlayer *device, int sampleCount, uint8_t *left, uint8_t *right, const ADLMIDI_AudioFormat *format) = nullptr;


### PR DESCRIPTION
This is a starting point in order to add OPL3 FM into Rebirth.
This follows the discussion on #407 

[libADLMIDI](https://github.com/Wohlstand/libADLMIDI) is a synthesizer supporting General MIDI, it is able to take GM sequences and play them on multiple emulated chips, not necessarily FM sequences which were designed for single chip sound cards.

This adds a dynamic loader for the library, permitting to escape the licensing restriction of the GPL.
I have added support code for Windows and Mac, but not tested, maybe these platforms will need some help locating the libraries, like setting a DLL search path in the case of Windows.

I enumerated a number a embedded banks, for some quick tries on my side.
Some of embedded Descent banks seem not in usual GM format or not complete (commented), I don't know what are the secrets about these files. I guess they have their instruments numbered in a way related in some way to the FM musics or the game engine.

About the dynamic loader: it is going to search for libADLMIDI. If not found, it will replace the function pointer `adl_init` with a fake which will return NULL as the instance. This will make the engine proceed to SDL_Mixer in that case.