### PR TITLE
Dim the screen when cloak is picked up

### DIFF
--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -77,7 +77,6 @@
 
 using std::min;
 using std::max;
-using std::abs;
 
 namespace dcx {
 
@@ -1063,9 +1062,10 @@ void ogl_do_palfx(void)
  
 	if (do_pal_step && ((last_r <= 0) & (last_g <= 0) & (last_b <= 0))) {
 		// scale negative effect by 2.5 to match D1/D2 on GL
-		alast_r = abs(last_r) * 2.5;
-		alast_g = abs(last_g) * 2.5;
-		alast_b = abs(last_b) * 2.5;
+		// also make values positive to actually have an effect
+		alast_r = last_r * -2.5;
+		alast_g = last_g * -2.5;
+		alast_b = last_b * -2.5;
 
 		color_array[ 0] = color_array[ 4] = alast_r;
 		color_array[ 8] = color_array[12] = alast_r;

--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -1049,16 +1049,11 @@ static int do_pal_step;
 
 void ogl_do_palfx(void)
 {
-	// scale negative effect by 2.5 to match D1/D2 on GL
-	alast_r = abs(last_r) * (last_r < 0 ? 2.5 : 1.0);
-	alast_g = abs(last_g) * (last_g < 0 ? 2.5 : 1.0);
-	alast_b = abs(last_b) * (last_b < 0 ? 2.5 : 1.0);
-
 	GLfloat color_array[] = { 
-		alast_r, alast_g, alast_b, 1.0,
-		alast_r, alast_g, alast_b, 1.0,
-		alast_r, alast_g, alast_b, 1.0,
-		alast_r, alast_g, alast_b, 1.0
+		last_r, last_g, last_b, 1.0,
+		last_r, last_g, last_b, 1.0,
+		last_r, last_g, last_b, 1.0,
+		last_r, last_g, last_b, 1.0
 	};
 
 	OGL_DISABLE(TEXTURE_2D);
@@ -1066,13 +1061,26 @@ void ogl_do_palfx(void)
 	glEnableClientState(GL_VERTEX_ARRAY);
 	glEnableClientState(GL_COLOR_ARRAY);
  
-	if (do_pal_step)
+	if (do_pal_step && ((last_r <= 0) & (last_g <= 0) & (last_b <= 0))) {
+		// scale negative effect by 2.5 to match D1/D2 on GL
+		alast_r = abs(last_r) * 2.5;
+		alast_g = abs(last_g) * 2.5;
+		alast_b = abs(last_b) * 2.5;
+
+		color_array[ 0] = color_array[ 4] = alast_r;
+		color_array[ 8] = color_array[12] = alast_r;
+		color_array[ 1] = color_array[ 5] = alast_g;
+		color_array[ 9] = color_array[13] = alast_g;
+		color_array[ 2] = color_array[ 6] = alast_b;
+		color_array[10] = color_array[14] = alast_b;
+
+		glEnable(GL_BLEND);
+		glBlendFunc(GL_ZERO,GL_ONE_MINUS_SRC_COLOR);
+	} 
+	else if (do_pal_step)
 	{
 		glEnable(GL_BLEND);
-		if ((last_r <= 0) & (last_g <= 0) & (last_b <= 0))
-			glBlendFunc(GL_ZERO,GL_ONE_MINUS_SRC_COLOR);
-		else
-			glBlendFunc(GL_ONE,GL_ONE);
+		glBlendFunc(GL_ONE,GL_ONE);
 	}
 	else
 		return;

--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -1043,7 +1043,6 @@ void ogl_ulinec(grs_canvas &canvas, const int left, const int top, const int rig
 }
 
 static GLfloat last_r, last_g, last_b;
-static GLfloat alast_r, alast_g, alast_b;
 static int do_pal_step;
 
 void ogl_do_palfx(void)
@@ -1063,9 +1062,9 @@ void ogl_do_palfx(void)
 	if (do_pal_step && ((last_r <= 0) & (last_g <= 0) & (last_b <= 0))) {
 		// scale negative effect by 2.5 to match D1/D2 on GL
 		// also make values positive to actually have an effect
-		alast_r = last_r * -2.5;
-		alast_g = last_g * -2.5;
-		alast_b = last_b * -2.5;
+		GLfloat alast_r = last_r * -2.5;
+		GLfloat alast_g = last_g * -2.5;
+		GLfloat alast_b = last_b * -2.5;
 
 		color_array[ 0] = color_array[ 4] = alast_r;
 		color_array[ 8] = color_array[12] = alast_r;

--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -1047,42 +1047,41 @@ static int do_pal_step;
 
 void ogl_do_palfx(void)
 {
-	GLfloat color_array[] = { 
-		last_r, last_g, last_b, 1.0,
-		last_r, last_g, last_b, 1.0,
-		last_r, last_g, last_b, 1.0,
-		last_r, last_g, last_b, 1.0
-	};
-
 	OGL_DISABLE(TEXTURE_2D);
 
 	glEnableClientState(GL_VERTEX_ARRAY);
 	glEnableClientState(GL_COLOR_ARRAY);
- 
-	if (do_pal_step && ((last_r <= 0) & (last_g <= 0) & (last_b <= 0))) {
+
+	GLfloat alast_r = last_r;
+	GLfloat alast_g = last_g;
+	GLfloat alast_b = last_b;
+	
+	if (!do_pal_step) {
+		return;
+	}
+	else if (last_r <= 0 && last_g <= 0 && last_b <= 0) 
+	{
 		// scale negative effect by 2.5 to match D1/D2 on GL
 		// also make values positive to actually have an effect
-		GLfloat alast_r = last_r * -2.5;
-		GLfloat alast_g = last_g * -2.5;
-		GLfloat alast_b = last_b * -2.5;
-
-		color_array[ 0] = color_array[ 4] = alast_r;
-		color_array[ 8] = color_array[12] = alast_r;
-		color_array[ 1] = color_array[ 5] = alast_g;
-		color_array[ 9] = color_array[13] = alast_g;
-		color_array[ 2] = color_array[ 6] = alast_b;
-		color_array[10] = color_array[14] = alast_b;
-
+		alast_r = last_r * -2.5;
+		alast_g = last_g * -2.5;
+		alast_b = last_b * -2.5;
+		
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_ZERO,GL_ONE_MINUS_SRC_COLOR);
 	} 
-	else if (do_pal_step)
+	else
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_ONE,GL_ONE);
 	}
-	else
-		return;
+
+	GLfloat color_array[] = { 
+		alast_r, alast_g, alast_b, 1.0,
+		alast_r, alast_g, alast_b, 1.0,
+		alast_r, alast_g, alast_b, 1.0,
+		alast_r, alast_g, alast_b, 1.0
+	};
 
 	array<GLfloat, 8> vertices = {{
 		0, 0, 0, 1, 1, 1, 1, 0
@@ -1099,26 +1098,23 @@ void ogl_do_palfx(void)
 static int ogl_brightness_ok;
 static int old_b_r, old_b_g, old_b_b;
 
+inline int gr_apply_gamma_clamp(int v)
+{
+	if (v >= 0)
+		return max(v + gr_palette_gamma, 0);
+	else
+		return min(v + gr_palette_gamma, 0);
+}
+
 void gr_palette_step_up(int r, int g, int b)
 {
 	old_b_r = ogl_brightness_r;
 	old_b_g = ogl_brightness_g;
 	old_b_b = ogl_brightness_b;
 
-	if (r >= 0)
-		ogl_brightness_r = max(r + gr_palette_gamma, 0);
-	else
-		ogl_brightness_r = min(r + gr_palette_gamma, 0);
-	
-	if (g >= 0)
-		ogl_brightness_g = max(g + gr_palette_gamma, 0);
-	else
-		ogl_brightness_g = min(g + gr_palette_gamma, 0);
-
-	if (b >= 0)
-		ogl_brightness_b = max(b + gr_palette_gamma, 0);
-	else
-		ogl_brightness_b = min(b + gr_palette_gamma, 0);
+	ogl_brightness_r = gr_apply_gamma_clamp(r);
+	ogl_brightness_g = gr_apply_gamma_clamp(g);
+	ogl_brightness_b = gr_apply_gamma_clamp(b);
 
 	if (!ogl_brightness_ok)
 	{


### PR DESCRIPTION
When picking up a cloaking device in Descent 1 or 2 on DOS, the screen dims briefly. This was not present on Rebirth after conversion to OpenGL because of how the palette effect is applied; any negative values, if even given, would simply get clamped by GL, preventing them from having any effect.

Testing this can be done on any Descent level with a cloaking device, such as level 5 in Descent 1 (a cloak is present in the reactor room). On the DOS version, the screen noticeably dims when it is picked up, while this does not happen on Rebirth, giving the player fewer visual cues that they have activated a cloaking device.

This PR re-introduces the effect by modifying the OpenGL code. First, gr_palette_step_up is modified to accept negative values and pass them to GL via ogl_do_palfx, which is itself modified to handle the cloak special case when all of the overlaid RGB values are negative. This requires changing the GL filter to GL_ONE_MINUS_SRC_COLOR, which effectively subtracts the color from the screen instead of adding it in.

This did have one drawback - the dimming effect was considerably fainter than on the DOS version, so I added a magic number by multiplying the values by 2.5, which makes the intensity of the effect now match the DOS version.

Note that getting damage also calls gr_palette_step_up with negative values, but not solely negative values, in which case the code changes included by this PR should have no effect. Only positive values, such as those applied by most powerups, should also be unaffected.
