### PR TITLE
Add black shape to cover exit hatch space

### DIFF
--- a/similar/main/endlevel.cpp
+++ b/similar/main/endlevel.cpp
@@ -139,6 +139,7 @@ static void draw_stars(grs_canvas &, const d_unique_endlevel_state::starfield_ty
 static int find_exit_side(const object_base &obj);
 static void generate_starfield(d_unique_endlevel_state::starfield_type &stars);
 static void start_endlevel_flythrough(flythrough_data *flydata,const vmobjptr_t obj,fix speed);
+static void draw_mine_exit_cover(grs_canvas &);
 
 #if defined(DXX_BUILD_DESCENT_II)
 constexpr array<const char, 24> movie_table{{
@@ -897,10 +898,51 @@ static int find_exit_side(const object_base &obj)
 	return best_side;
 }
 
+void draw_mine_exit_cover(grs_canvas &canvas)
+{
+	int of=10;
+	fix u=i2f(6),d=i2f(9),ur=i2f(14),dr=i2f(17);
+	const uint8_t color = BM_XRGB(0, 0, 0);
+	array<cg3s_point *, 4> pointlist;
+	vms_vector v, v0, v1, v2, v3;
+	g3s_point p0, p1, p2, p3;
+
+	vm_vec_scale_add(v,mine_exit_point,mine_exit_orient.fvec,i2f(of));
+
+	vm_vec_scale_add(v0,v,mine_exit_orient.uvec,+u);
+	vm_vec_scale_add2(v0,mine_exit_orient.rvec,+ur);
+	p0 = g3_rotate_point(v0);
+
+	vm_vec_scale_add(v1,v,mine_exit_orient.uvec,+u);
+	vm_vec_scale_add2(v1,mine_exit_orient.rvec,-ur);
+	p1 = g3_rotate_point(v1);
+
+	vm_vec_scale_add(v2,v,mine_exit_orient.uvec,-d);
+	vm_vec_scale_add2(v2,mine_exit_orient.rvec,-dr);
+	p2 = g3_rotate_point(v2);
+
+	vm_vec_scale_add(v3,v,mine_exit_orient.uvec,-d);
+	vm_vec_scale_add2(v3,mine_exit_orient.rvec,+dr);
+	p3 = g3_rotate_point(v3);
+
+	pointlist[0] = &p0;
+	pointlist[1] = &p1;
+	pointlist[2] = &p2;
+	pointlist[3] = &p3;
+
+	g3_draw_poly(canvas, pointlist.size(), pointlist, color);
+}
+
 void draw_exit_model(grs_canvas &canvas)
 {
 	int f=15,u=0;	//21;
 	g3s_lrgb lrgb = { f1_0, f1_0, f1_0 };
+
+	if (mine_destroyed)
+	{
+		// draw black shape to mask out terrain in exit hatch
+		draw_mine_exit_cover(canvas);
+	}
 
 	auto model_pos = vm_vec_scale_add(mine_exit_point,mine_exit_orient.fvec,i2f(f));
 	vm_vec_scale_add2(model_pos,mine_exit_orient.uvec,i2f(u));

--- a/similar/main/endlevel.cpp
+++ b/similar/main/endlevel.cpp
@@ -898,32 +898,29 @@ static int find_exit_side(const object_base &obj)
 	return best_side;
 }
 
+inline void prepare_mine_exit_cover_point(g3s_point& p, const vms_vector &v, fix u, fix r)
+{
+	vms_vector tv;
+	vm_vec_scale_add(tv,v,mine_exit_orient.uvec,u);
+	vm_vec_scale_add2(tv,mine_exit_orient.rvec,r);
+	p = g3_rotate_point(tv);
+}
+
 void draw_mine_exit_cover(grs_canvas &canvas)
 {
 	int of=10;
 	fix u=i2f(6),d=i2f(9),ur=i2f(14),dr=i2f(17);
 	const uint8_t color = BM_XRGB(0, 0, 0);
 	array<cg3s_point *, 4> pointlist;
-	vms_vector v, v0, v1, v2, v3;
+	vms_vector v;
 	g3s_point p0, p1, p2, p3;
 
 	vm_vec_scale_add(v,mine_exit_point,mine_exit_orient.fvec,i2f(of));
 
-	vm_vec_scale_add(v0,v,mine_exit_orient.uvec,+u);
-	vm_vec_scale_add2(v0,mine_exit_orient.rvec,+ur);
-	p0 = g3_rotate_point(v0);
-
-	vm_vec_scale_add(v1,v,mine_exit_orient.uvec,+u);
-	vm_vec_scale_add2(v1,mine_exit_orient.rvec,-ur);
-	p1 = g3_rotate_point(v1);
-
-	vm_vec_scale_add(v2,v,mine_exit_orient.uvec,-d);
-	vm_vec_scale_add2(v2,mine_exit_orient.rvec,-dr);
-	p2 = g3_rotate_point(v2);
-
-	vm_vec_scale_add(v3,v,mine_exit_orient.uvec,-d);
-	vm_vec_scale_add2(v3,mine_exit_orient.rvec,+dr);
-	p3 = g3_rotate_point(v3);
+	prepare_mine_exit_cover_point(p0,v,+u,+ur);
+	prepare_mine_exit_cover_point(p1,v,+u,-ur);
+	prepare_mine_exit_cover_point(p2,v,-d,-dr);
+	prepare_mine_exit_cover_point(p3,v,-d,+dr);
 
 	pointlist[0] = &p0;
 	pointlist[1] = &p1;


### PR DESCRIPTION
In the original DOS version, the mine keeps rendering even after the large explosion that "destroys" the exit hatch. For all well-lit mines (including all mines in Descent 1) that have a completely dark end of the exit tunnel, the level will simply show up as black.

In Rebirth however, the mine stops rendering once the large explosion happens. Therefore, currently, without this change, once the exit hatch is destroyed, the terrain texture will instead show through the hatch entrance, which looks fairly awkward. 

The mine stops rendering because the `Render_depth` is gradually decreased under `render_external_scene`. Disabling this would cause the mine to be rendered, but it would appear on top of the terrain regardless of whether it should for a given pixel. This could be addressed with more precise rendering, particularly to figure out a good Z order, but since all well-lit mines would display darkness anyway, the following solution is easier and produces a very similar result.

The solution implemented by this PR is to add a black quad which is rendered close to the exit hatch entrance instead. It is only rendered once `mine_destroyed` is true, or when the exit hatch will appear to be destroyed. I specifically set the proportions so that it would not poke past the hatch visually, but also covers its entire visual area.

While rendering a black quad is a less ideal solution than managing to make the mine render and not obstruct the terrain except for the exit hatch, this is still more ideal than how the hatch currently appears after the explosion.