### PR TITLE
Reload sounds when loading D2 mission

### DIFF
--- a/common/main/piggy.h
+++ b/common/main/piggy.h
@@ -165,6 +165,7 @@ extern void remove_char( char * s, char c );	// in piggy.c
 #define REMOVE_COMMENTS(s)	remove_char((s),';')
 #define REMOVE_DOTS(s)  	remove_char((s),'.')
 
+extern int Piggy_hamfile_version;
 extern unsigned Num_bitmap_files;
 extern int Num_sound_files;
 extern ubyte bogus_bitmap_initialized;
@@ -183,6 +184,7 @@ extern array<BitmapFile, MAX_BITMAP_FILES> AllBitmaps;
 #endif
 void piggy_init_pigfile(const char *filename);
 int read_hamfile();
+int read_sndfile();
 void swap_0_255(grs_bitmap &bmp);
 
 #endif

--- a/similar/main/mission.cpp
+++ b/similar/main/mission.cpp
@@ -753,7 +753,16 @@ static mission_list_type build_mission_list(int anarchy_mode)
 
 int load_mission_ham()
 {
-	read_hamfile();
+	read_hamfile(); // intentionally can also read from the HOG
+		
+	if (Piggy_hamfile_version >= 3)
+	{
+		// re-read sounds in case mission has custom .sXX
+		Num_sound_files = 0;
+		read_sndfile();
+		piggy_read_sounds();
+	}
+
 	if (Current_mission->descent_version == Mission::descent_version_type::descent2a &&
 		Current_mission->alternate_ham_file)
 	{

--- a/similar/main/piggy.cpp
+++ b/similar/main/piggy.cpp
@@ -1045,7 +1045,7 @@ int read_hamfile()
 	return 1;
 }
 
-static int read_sndfile()
+int read_sndfile()
 {
 	int snd_id,snd_version;
 	int N_sounds;


### PR DESCRIPTION
This change causes game sounds to be reloaded and read from disk again every time a new mission is loaded when playing Descent 2 (D2X), allowing missions to have custom .s11/.s22 files within the HOG and therefore do sound changes. Granted, the s11/s22 files have to be named descent2.s11 and descent2.s22, but this is better than nothing before where the only way to change the sounds would be to use a dxa or replace the game files manually.

This change should have no effect on D1X.

Notes:
* This could be optimized by reloading the sounds only if we either detect a custom sound file or the last mission had one (so that sounds would reset when going back to the builtin D2 mission, for instance)
* I also added a comment to read_hamfile to specify that it is _meant_ to read the .HAM from the .HOG, since I assume this is the case.