### PR TITLE
Make sure player file is read before set_highest_level

### DIFF
--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -1934,9 +1934,10 @@ window_event_result StartNewLevelSub(const int level_num, const int page_in_text
 		filter_objects_from_level(vmobjptr);
 #endif
 
-	read_player_file();		//get window sizes and highest level data
 	if (!(Game_mode & GM_MULTI) && !cheats.enabled)
 		set_highest_level(Current_level_num);
+	else
+		read_player_file();		//get window sizes
 
 	reset_special_effects();
 

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -1934,10 +1934,9 @@ window_event_result StartNewLevelSub(const int level_num, const int page_in_text
 		filter_objects_from_level(vmobjptr);
 #endif
 
+	read_player_file();		//get window sizes and highest level data
 	if (!(Game_mode & GM_MULTI) && !cheats.enabled)
 		set_highest_level(Current_level_num);
-	else
-		read_player_file();		//get window sizes
 
 	reset_special_effects();
 

--- a/similar/main/playsave.cpp
+++ b/similar/main/playsave.cpp
@@ -1264,6 +1264,7 @@ void set_highest_level(int levelnum)
 		/* If this mission is not the most recently used, reorder the
 		 * list so that it becomes the most recently used.
 		 */
+		previous_best_levelnum = ii->LevelNum;
 		std::rotate(ii, std::next(ii), ie);
 		ii = ie - 1;
 	}


### PR DESCRIPTION
This is a simple change that should hopefully fix an elusive issue regarding the highest level info being set to wrong values. I haven't been able to come up with a reproducible list of steps to get this to occur on Rebirth as it is right now (but I have encountered it while testing my mission in progress), so I chose to instead make this simple solution for what seems to be the issue.

Up to this point, it seems there was no guarantee that the player file would be read before set_highest_level was called, which could cause the highest level info to reset for a mission if it wasn't read. It also seems generally weird to read the player file only if we're **not** doing set_highest_level.

Edit: added a second fix and noticed that set_highest_level calls read_player_file anyway... oops.