### PR TITLE
Added axis buttons

### DIFF
--- a/common/arch/sdl/event.cpp
+++ b/common/arch/sdl/event.cpp
@@ -90,6 +90,7 @@ window_event_result event_poll()
 			case SDL_JOYAXISMOTION:
 				if (CGameArg.CtlNoJoystick)
 					break;
+				highest_result = std::max(joy_axisbutton_handler(&event.jaxis), highest_result);
 				highest_result = std::max(joy_axis_handler(&event.jaxis), highest_result);
 				break;
 			case SDL_JOYHATMOTION:

--- a/common/include/joy.h
+++ b/common/include/joy.h
@@ -37,6 +37,7 @@ extern void joy_close();
 const d_event_joystick_axis_value &event_joystick_get_axis(const d_event &event);
 extern void joy_flush();
 extern int event_joystick_get_button(const d_event &event);
+extern int apply_deadzone(int value, int deadzone);
 
 }
 #else
@@ -60,9 +61,11 @@ extern window_event_result joy_hat_handler(SDL_JoyHatEvent *jhe);
 #endif
 
 #if DXX_MAX_AXES_PER_JOYSTICK
+extern window_event_result joy_axisbutton_handler(SDL_JoyAxisEvent *jae);
 extern window_event_result joy_axis_handler(SDL_JoyAxisEvent *jae);
 #else
 #define joy_axis_handler(jbe) (static_cast<SDL_JoyAxisEvent *const &>(jbe), window_event_result::ignored)
+#define joy_axisbutton_handler(jbe) (static_cast<SDL_JoyAxisEvent *const &>(jbe), window_event_result::ignored)
 #endif
 
 }

--- a/common/main/kconfig.h
+++ b/common/main/kconfig.h
@@ -169,9 +169,9 @@ using joyaxis_text_t = joystick_text_t<sizeof("J A") + joystick_text_length<DXX_
 extern joyaxis_text_t joyaxis_text;
 #endif
 
-#if DXX_MAX_BUTTONS_PER_JOYSTICK || DXX_MAX_HATS_PER_JOYSTICK
+#if DXX_MAX_BUTTONS_PER_JOYSTICK || DXX_MAX_HATS_PER_JOYSTICK || DXX_MAX_AXES_PER_JOYSTICK
 #define DXX_JOY_MAX(A,B)	((A) < (B) ? (B) : (A))
-using joybutton_text_t = joystick_text_t<joystick_text_length<DXX_MAX_JOYSTICKS>::value + DXX_JOY_MAX(sizeof("J H ") + joystick_text_length<DXX_MAX_HATS_PER_JOYSTICK>::value, sizeof("J B") + joystick_text_length<DXX_MAX_BUTTONS_PER_JOYSTICK>::value)>;
+using joybutton_text_t = joystick_text_t<joystick_text_length<DXX_MAX_JOYSTICKS>::value + DXX_JOY_MAX(DXX_JOY_MAX(sizeof("J H ") + joystick_text_length<DXX_MAX_HATS_PER_JOYSTICK>::value, sizeof("J B") + joystick_text_length<DXX_MAX_BUTTONS_PER_JOYSTICK>::value), sizeof("J -A") + joystick_text_length<DXX_MAX_AXES_PER_JOYSTICK>::value)>;
 #undef DXX_JOY_MAX
 extern joybutton_text_t joybutton_text;
 #endif

--- a/similar/main/kconfig.cpp
+++ b/similar/main/kconfig.cpp
@@ -1114,7 +1114,7 @@ void kconfig_read_controls(const d_event &event, int automap_flag)
 				}
 			}
 			break;
-#if DXX_MAX_BUTTONS_PER_JOYSTICK || DXX_MAX_HATS_PER_JOYSTICK
+#if DXX_MAX_BUTTONS_PER_JOYSTICK || DXX_MAX_HATS_PER_JOYSTICK || DXX_MAX_AXES_PER_JOYSTICK
 		case EVENT_JOYSTICK_BUTTON_DOWN:
 		case EVENT_JOYSTICK_BUTTON_UP:
 			if (!(PlayerCfg.ControlType & CONTROL_USING_JOYSTICK))
@@ -1189,13 +1189,7 @@ void kconfig_read_controls(const d_event &event, int automap_flag)
 			else if (axis == PlayerCfg.KeySettings.Joystick[dxx_kconfig_ui_kc_joystick_throttle]) // Throttle - default deadzone
 				joy_null_value = PlayerCfg.JoystickDead[5]*3;
 
-			if (value > joy_null_value)
-				value = ((value - joy_null_value) * 128) / (128 - joy_null_value);
-			else if (value < -joy_null_value)
-				value = ((value + joy_null_value) * 128) / (128 - joy_null_value);
-			else
-				value = 0;
-			Controls.raw_joy_axis[axis] = value;
+			Controls.raw_joy_axis[axis] = apply_deadzone(value, joy_null_value);
 			break;
 		}
 #endif


### PR DESCRIPTION
Each axis can act as two buttons in both ways.
For example, a player might map slide left and slide right to J1 -A1 and J1 +A1 as button presses instead of the slide L/R axis.

This is mostly to fix XBox 360 Controller Left and Right triggers. But it can work on every axis if the player wishes to bind them.