### PR TITLE
SConstruct: remove equals sign from RPI -isystem definitions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4362,9 +4362,9 @@ class DXXCommon(LazyObjectConstructor):
 			# are not very clean and would trigger some warnings we usually consider as
 			# errors. Using them as system headers will make gcc ignoring any warnings.
 				CPPFLAGS = [
-				'-isystem=%s/include' % rpi_vc_path,
-				'-isystem=%s/include/interface/vcos/pthreads' % rpi_vc_path,
-				'-isystem=%s/include/interface/vmcs_host/linux' % rpi_vc_path,
+				'-isystem%s/include' % rpi_vc_path,
+				'-isystem%s/include/interface/vcos/pthreads' % rpi_vc_path,
+				'-isystem%s/include/interface/vmcs_host/linux' % rpi_vc_path,
 			],
 				LIBPATH = '%s/lib' % rpi_vc_path,
 				LIBS = ['bcm_host'],


### PR DESCRIPTION
When targeting Raspberry Pi with legacy drivers, the following error
is observed on Raspbian buster with gcc 8.3.0:

cc1plus: error: =/opt/vc/include: No such file or directory [-Werror=missing-include-dirs]
cc1plus: error: =/opt/vc/include/interface/vcos/pthreads: No such file or directory [-Werror=missing-include-dirs]
cc1plus: error: =/opt/vc/include/interface/vmcs_host/linux: No such file or directory [-Werror=missing-include-dirs]

The error can be resolved by removing the equals sign from these definitions.