### PR TITLE
Update Raspberry Pi Mesa build for Buster & Pi 4B

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3534,7 +3534,11 @@ class DXXCommon(LazyObjectConstructor):
 			return self.debug
 		# automatic setup for raspberrypi
 		def default_opengles(self):
-			if self.raspberrypi in ('yes', 'mesa'):
+			if self.raspberrypi in ('yes'):
+				return True
+			return False
+		def default_sdl2(self):
+			if self.raspberrypi in ('mesa'):
 				return True
 			return False
 		@classmethod
@@ -3698,7 +3702,7 @@ class DXXCommon(LazyObjectConstructor):
 					('opengl', True, 'build with OpenGL support'),
 					('opengles', self.default_opengles, 'build with OpenGL ES support'),
 					('editor', False, 'include editor into build (!EXPERIMENTAL!)'),
-					('sdl2', False, 'use libSDL2+SDL2_mixer (!EXPERIMENTAL!)'),
+					('sdl2', self.default_sdl2, 'use libSDL2+SDL2_mixer (!EXPERIMENTAL!)'),
 					('sdlmixer', True, 'build with SDL_Mixer support for sound and music (includes external music support)'),
 					('ipv6', False, 'enable UDP/IPv6 for multiplayer'),
 					('use_udp', True, 'enable UDP support'),

--- a/d1x-rebirth/README.RPi
+++ b/d1x-rebirth/README.RPi
@@ -25,12 +25,17 @@ scons raspberrypi=1 egl_lib=EGL opengles_lib=GLESv2
 This assumes that the development files (libs/headers) for the VideoCore APIs 
 are located in /opt/vc. You can use rpi_vc_path to specify another location.
 
-If you wish to build against the experimental Mesa VC4 driver, use:
+If you wish to build for Raspberry Pi 4B or the experimental Mesa VC4 driver:
 
 scons raspberrypi=mesa
 
-This will select the GLES interface by default, but you can select OpenGL by
-adding opengles=0. For all other options, check "scons -h".
+This will select the GL interface with SDL2 by default, but you can select
+GLES & SDL1 by adding "opengles=1 sdl2=0". Keep in mind that as of Raspbian buster,
+the Mesa packages no longer ship with GLESv1 headers, making GLES builds impossible.
+Additionally, SDL2 is highly recommended, as its KMSDRM video driver is the only
+way to run DXX-Rebirth on a Raspberry Pi 4B outside of an Xorg session.
+
+For all other options, check "scons -h".
 
 Currently, there is no direct support for crosscompiling.
 

--- a/d2x-rebirth/README.RPi
+++ b/d2x-rebirth/README.RPi
@@ -25,12 +25,17 @@ scons raspberrypi=1 egl_lib=EGL opengles_lib=GLESv2
 This assumes that the development files (libs/headers) for the VideoCore APIs 
 are located in /opt/vc. You can use rpi_vc_path to specify another location.
 
-If you wish to build against the experimental Mesa VC4 driver, use:
+If you wish to build for Raspberry Pi 4B or the experimental Mesa VC4 driver:
 
 scons raspberrypi=mesa
 
-This will select the GLES interface by default, but you can select OpenGL by
-adding opengles=0. For all other options, check "scons -h".
+This will select the GL interface with SDL2 by default, but you can select
+GLES & SDL1 by adding "opengles=1 sdl2=0". Keep in mind that as of Raspbian buster,
+the Mesa packages no longer ship with GLESv1 headers, making GLES builds impossible.
+Additionally, SDL2 is highly recommended, as its KMSDRM video driver is the only
+way to run DXX-Rebirth on a Raspberry Pi 4B outside of an Xorg session.
+
+For all other options, check "scons -h".
 
 Currently, there is no direct support for crosscompiling.
 


### PR DESCRIPTION
The new Raspberry Pi 4B revision has a minimum requirement of Raspbian
buster, and uses the Mesa V3D driver by default; in fact, the legacy
Broadcom drivers are no longer compatible with its VideoCore VC6 chip, so
building against Mesa is mandatory for this Pi revision.

Unfortunately, the Debian buster version of the Mesa packages
have intentionally dropped the GLESv1 headers, making building of GLESv1
software impractical (even though the VC4/V3D driver can still run GLESv1
applications).

The OpenGL driver in conjunction with SDL2* runs at full
speed on Raspberry Pi 3B & 4B, so it makes sense to modify the "mesa"
build to this configuration in light of these facts.

* SDL2 is highly desirable due to the availability of the KMSDRM driver, which is
the only way to run dxx-rebirth outside of X (we can no longer use
the dispmanx/rpi driver of SDL1).