### PR TITLE
SDL2+Win32: readd Red Book support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1358,7 +1358,7 @@ static void terminate_handler()
 			('DXX_MAX_AXES_PER_JOYSTICK', user_settings.max_axes_per_joystick),
 			('DXX_MAX_BUTTONS_PER_JOYSTICK', user_settings.max_buttons_per_joystick),
 			('DXX_MAX_HATS_PER_JOYSTICK', user_settings.max_hats_per_joystick),
-			('DXX_USE_SDL_REDBOOK_AUDIO', int(not sdl2)),
+			('DXX_USE_SDL_REDBOOK_AUDIO', int(not sdl2 or sys.platform in ['win32', 'msys'])), # there is a win32 rbaudio now
 		))
 		context.Display('%s: checking whether to enable joystick support...%s\n' % (self.msgprefix, 'yes' if user_settings.max_joysticks else 'no'))
 		# SDL2 removed CD-rom support.
@@ -4512,6 +4512,7 @@ class DXXArchive(DXXCommon):
 		get_platform_objects = LazyObjectConstructor.create_lazy_object_getter((
 'common/arch/win32/except.cpp',
 'common/arch/win32/messagebox.cpp',
+'common/arch/win32/rbaudio.cpp',
 ))
 	class DarwinPlatformSettings(DXXCommon.DarwinPlatformSettings):
 		get_platform_objects = LazyObjectConstructor.create_lazy_object_getter((

--- a/SConstruct
+++ b/SConstruct
@@ -1353,12 +1353,16 @@ static void terminate_handler()
 			# inputs.
 			user_settings.max_axes_per_joystick = user_settings.max_buttons_per_joystick = user_settings.max_hats_per_joystick = 0
 		successflags['CPPDEFINES'] = CPPDEFINES = successflags.get('CPPDEFINES', [])[:]
+		# use Redbook if at least one of the following applies
+		#    1. we are on SDL1
+		#    2. we are building for a platform for which we have a custom CD implementation (currently only win32)
+		use_redbook = int(not sdl2 or user_settings.host_platform == 'win32')
 		CPPDEFINES.extend((
 			('DXX_MAX_JOYSTICKS', user_settings.max_joysticks),
 			('DXX_MAX_AXES_PER_JOYSTICK', user_settings.max_axes_per_joystick),
 			('DXX_MAX_BUTTONS_PER_JOYSTICK', user_settings.max_buttons_per_joystick),
 			('DXX_MAX_HATS_PER_JOYSTICK', user_settings.max_hats_per_joystick),
-			('DXX_USE_SDL_REDBOOK_AUDIO', int(not sdl2 or sys.platform in ['win32', 'msys'])), # there is a win32 rbaudio now
+			('DXX_USE_SDL_REDBOOK_AUDIO', use_redbook),
 		))
 		context.Display('%s: checking whether to enable joystick support...%s\n' % (self.msgprefix, 'yes' if user_settings.max_joysticks else 'no'))
 		# SDL2 removed CD-rom support.

--- a/common/arch/win32/rbaudio.cpp
+++ b/common/arch/win32/rbaudio.cpp
@@ -93,6 +93,7 @@ static unsigned mci_GetTrackOffset(const int track)
 		Warning("RBAudio win32/MCI: cannot determine track %i offset (%lx)", track, mciError);
 		return -1;
 	}
+	// dwReturn is a 32-bit value in MSF format, so DWORD_PTR > DWORD is not a problem
 	return mci_TotalFramesMsf(mciStatusParms.dwReturn);
 }
 
@@ -108,6 +109,7 @@ static unsigned mci_GetTrackLength(const int track)
 		Warning("RBAudio win32/MCI: cannot determine track %i length (%lx)", track, mciError);
 		return -1;
 	}
+	// dwReturn is a 32-bit value in MSF format, so DWORD_PTR > DWORD is not a problem
 	return mci_TotalFramesMsf(mciStatusParms.dwReturn);
 }
 
@@ -367,12 +369,13 @@ void RBACheckFinishedHook()
 		// and allow a bit of a leeway when checking if so.
 
 		DWORD checkValue = playEnd;
+		// dwReturn is a 32-bit value in MSF format, so DWORD_PTR > DWORD is not a problem
 		DWORD thisFrames = mci_TotalFramesMsf(mciStatusParms.dwReturn);
 
 		if (thisFrames == lastFrames)
 			checkValue = checkValue < 64 ? 0 : checkValue - 64; // prevent underflow
 
-		if (redbook_finished_hook && playEnd > 0 && lastFrames >= checkValue)
+		if (redbook_finished_hook && playEnd > 0 && thisFrames >= checkValue)
 		{
 			con_puts(CON_VERBOSE, "RBAudio win32/MCI: Playback done, calling finished-hook");
 			redbook_finished_hook();

--- a/common/arch/win32/rbaudio.cpp
+++ b/common/arch/win32/rbaudio.cpp
@@ -1,0 +1,540 @@
+/*
+ * This file is part of the DXX-Rebirth project <https://www.dxx-rebirth.com/>.
+ * It is copyright by its individual contributors, as recorded in the
+ * project's Git history.  See COPYING.txt at the top level for license
+ * terms and a link to the Git history.
+ */
+/*
+ *
+ * CD Audio functions for Win32
+ *
+ *
+ */
+
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <mmsystem.h>
+
+#include "pstypes.h"
+#include "dxxerror.h"
+#include "args.h"
+#include "rbaudio.h"
+#include "console.h"
+#include "fwd-gr.h"
+#include "timer.h"
+
+#if SDL_MAJOR_VERSION == 1
+// we don't want this on SDL1 because there we have common/arch/sdl/rbaudio.cpp
+// #pragma message("Skipping win32/rbaudio because of SDL1")
+
+#elif SDL_MAJOR_VERSION == 2
+
+namespace dcx {
+#define CD_FPS 75
+
+static UINT wCDDeviceID = 0U;
+static int initialised = 0;
+static DWORD playEnd;
+
+void RBAExit()
+{
+    if (wCDDeviceID)
+    {
+        initialised = 0;
+        mciSendCommand(wCDDeviceID, MCI_CLOSE, MCI_WAIT, 0);
+        wCDDeviceID = 0U;
+    }
+}
+
+static int mci_HasMedia()
+{
+    if (!wCDDeviceID) return 0;
+
+    MCIERROR mciError;
+    MCI_STATUS_PARMS mciStatusParms;
+
+    mciStatusParms.dwItem = MCI_STATUS_MEDIA_PRESENT;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+    {
+		Warning("RBAudio win32: cannot determine MCI media status (%lx)", mciError);
+        RBAExit();
+		return 0;
+    }
+    return static_cast<int>(mciStatusParms.dwReturn);
+}
+
+static int mci_enableMsf()
+{
+    if (!wCDDeviceID) return 0;
+
+    MCIERROR mciError;
+    MCI_SET_PARMS mciSetParms;
+
+    mciSetParms.dwTimeFormat = MCI_FORMAT_MSF;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_SET, MCI_SET_TIME_FORMAT, reinterpret_cast<DWORD_PTR>(&mciSetParms))))
+    {
+		con_puts(CON_NORMAL, "RBAudio win32: cannot set time format for CD to MSF (strange)");
+        return 0;
+    }
+    return 1;
+}
+
+static int mci_restoreTmsf()
+{
+    if (!wCDDeviceID) return 0;
+
+    MCIERROR mciError;
+    MCI_SET_PARMS mciSetParms;
+
+    mciSetParms.dwTimeFormat = MCI_FORMAT_TMSF;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_SET, MCI_SET_TIME_FORMAT, reinterpret_cast<DWORD_PTR>(&mciSetParms))))
+    {
+		con_puts(CON_NORMAL, "RBAudio win32: cannot set time format for CD to TMSF (strange)");
+        return 0;
+    }
+    return 1;
+}
+
+static int mci_tmsfToTrack(int track)
+{
+    return MCI_MAKE_TMSF(track, 0, 0, 0);
+}
+
+void RBAInit()
+{
+    MCIERROR mciError;
+    MCI_OPEN_PARMS mciOpenParms;
+
+    if (initialised) return;
+    
+    mciOpenParms.lpstrDeviceType = "cdaudio";
+    if ((mciError = mciSendCommand(0, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_SHAREABLE, reinterpret_cast<DWORD_PTR>(&mciOpenParms))))
+    {
+		con_puts(CON_NORMAL, "RBAudio win32: cannot find MCI cdaudio (no CD drive?)");
+		return;
+    }
+
+    wCDDeviceID = mciOpenParms.wDeviceID;
+
+    if (!mci_HasMedia())
+    {
+		con_puts(CON_NORMAL, "RBAudio win32: no media in CD drive.");
+        RBAExit();
+		return;
+    }
+
+    if (!mci_restoreTmsf())
+    {
+        RBAExit();
+		return;
+    }
+
+    initialised = 1;
+	RBAList();
+}
+
+int RBAEnabled()
+{
+    return initialised;
+}
+
+static void (*redbook_finished_hook)() = NULL;
+
+int RBAPlayTrack(int a)
+{
+	if (!wCDDeviceID)
+		return 0;
+
+	if (mci_HasMedia())
+	{
+        MCIERROR mciError;
+        MCI_PLAY_PARMS mciPlayParms;
+        int trackCount = RBAGetNumberOfTracks();
+        int flags = MCI_FROM;
+
+		con_printf(CON_VERBOSE, "RBAudio win32: Playing track %i", a);
+
+        mciPlayParms.dwFrom = mci_tmsfToTrack(a);
+        if (a < trackCount)
+        {
+            mciPlayParms.dwTo = mci_tmsfToTrack(a + 1);
+            flags |= MCI_TO;
+        }
+        else
+            mciPlayParms.dwTo = 0L;
+
+		if ((mciError = mciSendCommand(wCDDeviceID, MCI_PLAY, flags, reinterpret_cast<DWORD_PTR>(&mciPlayParms))))
+        {
+		    Warning("RBAudio win32: could not play track (%lx)", mciError);
+            return 0;
+        }
+
+        return 1;
+	}
+	return 0;
+}
+
+// plays tracks first through last, inclusive
+int RBAPlayTracks(int first, int last, void (*hook_finished)(void))
+{
+	if (!wCDDeviceID)
+		return 0;
+
+	if (mci_HasMedia())
+	{
+        MCIERROR mciError;
+        MCI_PLAY_PARMS mciPlayParms;
+        int trackCount = RBAGetNumberOfTracks();
+        int flags = MCI_FROM;
+
+		redbook_finished_hook = hook_finished;
+
+		con_printf(CON_VERBOSE, "RBAudio win32: Playing tracks %i to %i", first, last);
+
+        mciPlayParms.dwFrom = mci_tmsfToTrack(first);
+        if (last < trackCount)
+        {
+            mciPlayParms.dwTo = mci_tmsfToTrack(last + 1);
+            flags |= MCI_TO;
+        }
+        else
+            mciPlayParms.dwTo = 0L;
+
+		if ((mciError = mciSendCommand(wCDDeviceID, MCI_PLAY, flags, reinterpret_cast<DWORD_PTR>(&mciPlayParms))))
+        {
+		    Warning("RBAudio win32: could not play tracks (%lx)", mciError);
+            return 0;
+        }
+
+        return 1;
+	}
+	return 0;
+}
+
+void RBAStop()
+{
+    if (!wCDDeviceID) return;
+    
+    MCIERROR mciError;
+
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STOP, 0, 0)))
+    {
+		Warning("RBAudio win32: could not stop music (%lx)", mciError);
+    }
+	redbook_finished_hook = NULL;
+}
+
+void RBAEjectDisk()
+{
+    if (!wCDDeviceID) return;
+    
+    MCIERROR mciError;
+
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_SET, MCI_SET_DOOR_OPEN | MCI_WAIT, 0)))
+    {
+		Warning("RBAudio win32: could not open CD tray (%lx)", mciError);
+    }
+    initialised = 0;
+}
+
+void RBASetVolume(int)
+{
+    // MCI does not support this
+}
+
+void RBAPause()
+{
+    if (!wCDDeviceID) return;
+    
+    MCIERROR mciError;
+
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_PAUSE, MCI_WAIT, 0)))
+    {
+		Warning("RBAudio win32: could not pause music (%lx)", mciError);
+        return;
+    }
+	con_puts(CON_VERBOSE, "RBAudio win32: Playback paused");
+}
+
+int RBAResume()
+{
+    if (!wCDDeviceID) return -1;
+    
+    MCIERROR mciError;
+
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_RESUME, 0, 0)))
+    {
+		Warning("RBAudio win32: could not resume music (%lx)", mciError);
+        return -1;
+    }
+	con_puts(CON_VERBOSE, "RBAudio win32: Playback resumed");
+    return 1;
+}
+
+int RBAPauseResume()
+{
+    if (!wCDDeviceID) return 0;
+    
+    MCIERROR mciError;
+    MCI_STATUS_PARMS mciStatusParms;
+
+    mciStatusParms.dwItem = MCI_STATUS_MODE;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+    {
+		Warning("RBAudio win32: cannot determine MCI media status (%lx)", mciError);
+        return 0;
+    }
+
+	if (mciStatusParms.dwReturn == MCI_MODE_PLAY)
+	{
+		con_puts(CON_VERBOSE, "RBAudio win32: Toggle Playback pause");
+		RBAPause();
+	}
+	else if (mciStatusParms.dwReturn == MCI_MODE_PAUSE)
+	{
+		con_puts(CON_VERBOSE, "RBAudio win32: Toggle Playback resume");
+		return RBAResume() > 0;
+	}
+	else
+		return 0;
+
+	return 1;
+}
+
+int RBAGetNumberOfTracks()
+{
+    if (!wCDDeviceID) return -1;
+    
+    MCIERROR mciError;
+    MCI_STATUS_PARMS mciStatusParms;
+
+    mciStatusParms.dwItem = MCI_STATUS_NUMBER_OF_TRACKS;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+    {
+		Warning("RBAudio win32: could not get track count (%lx)", mciError);
+        return -1;
+    }
+
+    return static_cast<int>(mciStatusParms.dwReturn);
+}
+
+// check if we need to call the 'finished' hook
+// needs to go in all event loops
+// MCI has a hook function via Win32 messages but either it's buggy
+//   or SDL won't give it even via syswm events
+void RBACheckFinishedHook()
+{
+	static fix64 last_check_time = 0;
+	
+	if (!wCDDeviceID) return;
+
+
+	if ((timer_query() - last_check_time) >= F2_0)
+	{
+        MCIERROR mciError;
+        MCI_STATUS_PARMS mciStatusParms;
+
+        mciStatusParms.dwItem = MCI_STATUS_MODE;
+        if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+        {
+            Warning("RBAudio win32: cannot determine MCI media status (%lx)", mciError);
+            return;
+        }
+
+        // time for a hack. for some reason, MCI sometimes stops
+        // from around a few to few dozen frames before it should,
+        // so we will check if we haven't moved from the last check
+        // and allow a bit of a leeway when checking if so.
+
+        int checkValue = playEnd;
+        int thisFrames = mci_TotalFramesMsf(mciStatusParms.dwReturn);
+
+        if (thisFrames == lastFrames)
+            checkValue -= 64;
+
+        if (redbook_finished_hook && playEnd >= 0 && lastFrames >= checkValue)
+        {
+            con_puts(CON_VERBOSE, "RBAudio win32/MCI: Playback done, calling finished-hook");
+            redbook_finished_hook();
+        }
+        lastFrames = thisFrames;
+        last_check_time = timer_query();
+    }
+}
+
+// return the track number currently playing.  Useful if RBAPlayTracks()
+// is called.  Returns 0 if no track playing, else track number
+int RBAGetTrackNum()
+{
+    if (!wCDDeviceID) return 0;
+    
+    MCIERROR mciError;
+    MCI_STATUS_PARMS mciStatusParms;
+
+    mciStatusParms.dwItem = MCI_STATUS_MODE;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+    {
+		Warning("RBAudio win32: cannot determine MCI media status (%lx)", mciError);
+        return 0;
+    }
+
+	if (mciStatusParms.dwReturn != MCI_MODE_PLAY)
+        return 0;
+
+    mciStatusParms.dwItem = MCI_STATUS_CURRENT_TRACK;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+    {
+		Warning("RBAudio win32: cannot determine MCI media status (%lx)", mciError);
+        return 0;
+    }
+
+    return static_cast<int>(mciStatusParms.dwReturn);
+}
+
+int RBAPeekPlayStatus()
+{
+    if (!wCDDeviceID) return 0;
+    
+    MCIERROR mciError;
+    MCI_STATUS_PARMS mciStatusParms;
+
+    mciStatusParms.dwItem = MCI_STATUS_MODE;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+    {
+		Warning("RBAudio win32: cannot determine MCI media status (%lx)", mciError);
+        return 0;
+    }
+
+	if (mciStatusParms.dwReturn == MCI_MODE_PLAY)
+        return 1;
+	else if (mciStatusParms.dwReturn == MCI_MODE_PAUSE)
+		return -1; // hack so it doesn't keep restarting paused music
+	else
+		return 0;
+}
+
+static int cddb_sum(int n)
+{
+	int ret;
+
+	/* For backward compatibility this algorithm must not change */
+
+	ret = 0;
+
+	while (n > 0) {
+		ret = ret + (n % 10);
+		n = n / 10;
+	}
+
+	return (ret);
+}
+
+static int mci_msf_totalSeconds(int msf)
+{
+    return MCI_MSF_MINUTE(msf) * 60 + MCI_MSF_SECOND(msf);
+}
+
+static int mci_msf_totalFrames(int msf)
+{
+    return mci_msf_totalSeconds(msf) * CD_FPS + MCI_MSF_FRAME(msf);
+}
+
+
+unsigned long RBAGetDiscID()
+{
+	int i, t = 0, n = 0, trackCount, totalLength;
+
+	if (!wCDDeviceID)
+		return 0;
+
+    MCIERROR mciError;
+    MCI_STATUS_PARMS mciStatusParms;
+    trackCount = RBAGetNumberOfTracks();
+
+    mciStatusParms.dwItem = MCI_STATUS_LENGTH;
+    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+    {
+        Warning("RBAudio win32: cannot determine total length (%lx)", mciError);
+        return 0;
+    }
+    totalLength = static_cast<int>(mciStatusParms.dwReturn);
+
+    // we must switch to MSF to actually get starting times
+    if (!mci_enableMsf())
+    {
+        return 0;
+    }
+
+	/* For backward compatibility this algorithm must not change */
+
+	i = 1;
+
+	while (i <= trackCount)
+    {
+        mciStatusParms.dwItem = MCI_STATUS_POSITION;
+        mciStatusParms.dwTrack = i;
+        if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+        {
+            Warning("RBAudio win32: cannot determine track %i offset (%lx)", i, mciError);
+            mci_restoreTmsf();
+            return 0;
+        }
+		n += cddb_sum(mci_msf_totalSeconds(static_cast<int>(mciStatusParms.dwReturn)));
+		i++;
+	}
+
+	t = mci_msf_totalSeconds(totalLength);
+
+    mci_restoreTmsf();
+	return ((n % 0xff) << 24 | t << 8 | trackCount);
+}
+
+void RBAList(void)
+{
+    if (!wCDDeviceID) return;
+
+    MCIERROR mciError;
+    MCI_STATUS_PARMS mciStatusParms;
+    int trackCount = RBAGetNumberOfTracks();
+
+    mci_enableMsf();
+
+    for (int i = 1; i <= trackCount; ++i) {
+        int isAudioTrack, length, offset;
+        mciStatusParms.dwTrack = i;
+
+        mciStatusParms.dwItem = MCI_CDA_STATUS_TYPE_TRACK;
+        if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+        {
+            Warning("RBAudio win32: cannot determine track %d type (%lx)", i, mciError);
+            continue;
+        }
+        isAudioTrack = mciStatusParms.dwReturn == MCI_CDA_TRACK_AUDIO;
+
+        mciStatusParms.dwItem = MCI_STATUS_POSITION;
+        if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+        {
+            Warning("RBAudio win32: cannot determine track %d offset (%lx)", i, mciError);
+            continue;
+        }
+        offset = mci_msf_totalFrames(static_cast<int>(mciStatusParms.dwReturn));
+
+        mciStatusParms.dwItem = MCI_STATUS_LENGTH;
+        if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+        {
+            Warning("RBAudio win32: cannot determine track %d length (%lx)", i, mciError);
+            continue;
+        }
+        length = mci_msf_totalFrames(static_cast<int>(mciStatusParms.dwReturn));
+
+		con_printf(CON_VERBOSE, "RBAudio win32: CD track %d, type %s, length %d, offset %d", i, isAudioTrack ? "audio" : "data", length, offset);
+    }
+    
+    mci_restoreTmsf();
+}
+
+}
+
+#endif

--- a/common/arch/win32/rbaudio.cpp
+++ b/common/arch/win32/rbaudio.cpp
@@ -36,307 +36,307 @@ namespace dcx {
 #define CD_FPS 75
 
 static UINT wCDDeviceID = 0U;
-static int initialised = 0;
-static int playEnd = 0;
-static int lastFrames = 0;
-static int isPaused = 0;
+static bool initialised;
+static DWORD playEnd;
+static DWORD lastFrames;
+static bool isPaused;
 
 void RBAExit()
 {
-    if (wCDDeviceID)
-    {
-        initialised = 0;
-        mciSendCommand(wCDDeviceID, MCI_CLOSE, MCI_WAIT, 0);
-        wCDDeviceID = 0U;
-    }
+	if (wCDDeviceID)
+	{
+		initialised = false;
+		mciSendCommand(wCDDeviceID, MCI_CLOSE, MCI_WAIT, 0);
+		wCDDeviceID = 0U;
+	}
 }
 
 static bool mci_HasMedia()
 {
-    if (!wCDDeviceID) return false;
+	if (!wCDDeviceID) return false;
 
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
 
-    mciStatusParms.dwItem = MCI_STATUS_MEDIA_PRESENT;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot determine MCI media status (%lx)", mciError);
-        RBAExit();
-        return false;
-    }
-    return mciStatusParms.dwReturn != 0;
+	mciStatusParms.dwItem = MCI_STATUS_MEDIA_PRESENT;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot determine MCI media status (%lx)", mciError);
+		RBAExit();
+		return false;
+	}
+	return mciStatusParms.dwReturn != 0;
 }
 
-static unsigned int mci_TotalFramesMsf(int msf)
+static unsigned mci_TotalFramesMsf(const DWORD msf)
 {
-    return (MCI_MSF_MINUTE(msf) * 60 + MCI_MSF_SECOND(msf)) * CD_FPS + MCI_MSF_FRAME(msf);
+	return (MCI_MSF_MINUTE(msf) * 60 + MCI_MSF_SECOND(msf)) * CD_FPS + MCI_MSF_FRAME(msf);
 }
 
-static int mci_FramesToMsf(int frames)
+static unsigned mci_FramesToMsf(const int frames)
 {
-    int m = frames / (CD_FPS * 60);
-    int s = (frames / CD_FPS) % 60;
-    int f = frames % CD_FPS;
-    return MCI_MAKE_MSF(m, s, f);
+	int m = frames / (CD_FPS * 60);
+	int s = (frames / CD_FPS) % 60;
+	int f = frames % CD_FPS;
+	return MCI_MAKE_MSF(m, s, f);
 }
 
-static int mci_GetTrackOffset(int track)
+static unsigned mci_GetTrackOffset(const int track)
 {
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
 
-    mciStatusParms.dwItem = MCI_STATUS_POSITION;
-    mciStatusParms.dwTrack = track;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot determine track %i offset (%lx)", track, mciError);
-        return -1;
-    }
-    return mci_TotalFramesMsf(mciStatusParms.dwReturn);
+	mciStatusParms.dwItem = MCI_STATUS_POSITION;
+	mciStatusParms.dwTrack = track;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot determine track %i offset (%lx)", track, mciError);
+		return -1;
+	}
+	return mci_TotalFramesMsf(mciStatusParms.dwReturn);
 }
 
-static int mci_GetTrackLength(int track)
+static unsigned mci_GetTrackLength(const int track)
 {
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
 
-    mciStatusParms.dwItem = MCI_STATUS_LENGTH;
-    mciStatusParms.dwTrack = track;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot determine track %i length (%lx)", track, mciError);
-        return -1;
-    }
-    return mci_TotalFramesMsf(mciStatusParms.dwReturn);
+	mciStatusParms.dwItem = MCI_STATUS_LENGTH;
+	mciStatusParms.dwTrack = track;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot determine track %i length (%lx)", track, mciError);
+		return -1;
+	}
+	return mci_TotalFramesMsf(mciStatusParms.dwReturn);
 }
 
-static int mci_GetTotalLength()
+static unsigned mci_GetTotalLength()
 {
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
 
-    mciStatusParms.dwItem = MCI_STATUS_LENGTH;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot determine media length (%lx)", mciError);
-        return -1;
-    }
-    return mci_TotalFramesMsf(mciStatusParms.dwReturn);
+	mciStatusParms.dwItem = MCI_STATUS_LENGTH;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot determine media length (%lx)", mciError);
+		return -1;
+	}
+	return mci_TotalFramesMsf(mciStatusParms.dwReturn);
 }
 
 void RBAInit()
 {
-    MCIERROR mciError;
-    MCI_OPEN_PARMS mciOpenParms;
-    MCI_SET_PARMS mciSetParms;
+	MCIERROR mciError;
+	MCI_OPEN_PARMS mciOpenParms;
+	MCI_SET_PARMS mciSetParms;
 
-    if (initialised) return;
-    
-    mciOpenParms.lpstrDeviceType = "cdaudio";
-    if ((mciError = mciSendCommand(0, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_SHAREABLE, reinterpret_cast<DWORD_PTR>(&mciOpenParms))))
-    {
-        con_puts(CON_NORMAL, "RBAudio win32/MCI: cannot find MCI cdaudio (no CD drive?)");
-        return;
-    }
+	if (initialised) return;
+	
+	mciOpenParms.lpstrDeviceType = "cdaudio";
+	if ((mciError = mciSendCommand(0, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_SHAREABLE, reinterpret_cast<DWORD_PTR>(&mciOpenParms))))
+	{
+		con_puts(CON_NORMAL, "RBAudio win32/MCI: cannot find MCI cdaudio (no CD drive?)");
+		return;
+	}
 
-    wCDDeviceID = mciOpenParms.wDeviceID;
+	wCDDeviceID = mciOpenParms.wDeviceID;
 
-    if (!mci_HasMedia())
-    {
-        con_puts(CON_NORMAL, "RBAudio win32/MCI: no media in CD drive.");
-        RBAExit();
-        return;
-    }
+	if (!mci_HasMedia())
+	{
+		con_puts(CON_NORMAL, "RBAudio win32/MCI: no media in CD drive.");
+		RBAExit();
+		return;
+	}
 
-    mciSetParms.dwTimeFormat = MCI_FORMAT_MSF;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_SET, MCI_SET_TIME_FORMAT, reinterpret_cast<DWORD_PTR>(&mciSetParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot set time format for CD to MSF (strange)");
-        RBAExit();
-        return;
-    }
+	mciSetParms.dwTimeFormat = MCI_FORMAT_MSF;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_SET, MCI_SET_TIME_FORMAT, reinterpret_cast<DWORD_PTR>(&mciSetParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot set time format for CD to MSF (strange)");
+		RBAExit();
+		return;
+	}
 
-    initialised = 1;
-    RBAList();
+	initialised = true;
+	RBAList();
 }
 
 int RBAEnabled()
 {
-    return initialised;
+	return initialised;
 }
 
-static void (*redbook_finished_hook)() = NULL;
+static void (*redbook_finished_hook)() = nullptr;
 
 int RBAPlayTrack(int a)
 {
-    if (!wCDDeviceID)
-        return 0;
+	if (!wCDDeviceID)
+		return 0;
 
-    if (mci_HasMedia())
-    {
-        MCIERROR mciError;
-        MCI_PLAY_PARMS mciPlayParms;
-        int playStart;
+	if (mci_HasMedia())
+	{
+		MCIERROR mciError;
+		MCI_PLAY_PARMS mciPlayParms;
+		DWORD playStart;
 
-        con_printf(CON_VERBOSE, "RBAudio win32/MCI: Playing track %i", a);
+		con_printf(CON_VERBOSE, "RBAudio win32/MCI: Playing track %i", a);
 
-        playStart = mci_GetTrackOffset(a);
-        playEnd = playStart + mci_GetTrackLength(a);
+		playStart = mci_GetTrackOffset(a);
+		playEnd = playStart + mci_GetTrackLength(a);
 
-        mciPlayParms.dwFrom = mci_FramesToMsf(playStart);
-        mciPlayParms.dwTo = mci_FramesToMsf(playEnd);
+		mciPlayParms.dwFrom = mci_FramesToMsf(playStart);
+		mciPlayParms.dwTo = mci_FramesToMsf(playEnd);
 
-        if ((mciError = mciSendCommand(wCDDeviceID, MCI_PLAY, MCI_FROM | MCI_TO, reinterpret_cast<DWORD_PTR>(&mciPlayParms))))
-        {
-            Warning("RBAudio win32/MCI: could not play track (%lx)", mciError);
-            return 0;
-        }
+		if ((mciError = mciSendCommand(wCDDeviceID, MCI_PLAY, MCI_FROM | MCI_TO, reinterpret_cast<DWORD_PTR>(&mciPlayParms))))
+		{
+			Warning("RBAudio win32/MCI: could not play track (%lx)", mciError);
+			return 0;
+		}
 
-        return 1;
-    }
-    return 0;
+		return 1;
+	}
+	return 0;
 }
 
 // plays tracks first through last, inclusive
 int RBAPlayTracks(int first, int last, void (*hook_finished)(void))
 {
-    if (!wCDDeviceID)
-        return 0;
+	if (!wCDDeviceID)
+		return 0;
 
-    if (mci_HasMedia())
-    {
-        MCIERROR mciError;
-        MCI_PLAY_PARMS mciPlayParms;
+	if (mci_HasMedia())
+	{
+		MCIERROR mciError;
+		MCI_PLAY_PARMS mciPlayParms;
 
-        redbook_finished_hook = hook_finished;
+		redbook_finished_hook = hook_finished;
 
-        con_printf(CON_VERBOSE, "RBAudio win32/MCI: Playing tracks %i to %i", first, last);
+		con_printf(CON_VERBOSE, "RBAudio win32/MCI: Playing tracks %i to %i", first, last);
 
-        playEnd = mci_GetTrackOffset(last) + mci_GetTrackLength(last);
+		playEnd = mci_GetTrackOffset(last) + mci_GetTrackLength(last);
 
-        mciPlayParms.dwFrom = mci_FramesToMsf(mci_GetTrackOffset(first));
-        mciPlayParms.dwTo = mci_FramesToMsf(playEnd);
+		mciPlayParms.dwFrom = mci_FramesToMsf(mci_GetTrackOffset(first));
+		mciPlayParms.dwTo = mci_FramesToMsf(playEnd);
 
-        if ((mciError = mciSendCommand(wCDDeviceID, MCI_PLAY, MCI_FROM | MCI_TO, reinterpret_cast<DWORD_PTR>(&mciPlayParms))))
-        {
-            Warning("RBAudio win32/MCI: could not play tracks (%lx)", mciError);
-            return 0;
-        }
+		if ((mciError = mciSendCommand(wCDDeviceID, MCI_PLAY, MCI_FROM | MCI_TO, reinterpret_cast<DWORD_PTR>(&mciPlayParms))))
+		{
+			Warning("RBAudio win32/MCI: could not play tracks (%lx)", mciError);
+			return 0;
+		}
 
-        return 1;
-    }
-    return 0;
+		return 1;
+	}
+	return 0;
 }
 
 void RBAStop()
 {
-    if (!wCDDeviceID) return;
-    
-    MCIERROR mciError;
+	if (!wCDDeviceID) return;
+	
+	MCIERROR mciError;
 
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STOP, 0, 0)))
-    {
-        Warning("RBAudio win32/MCI: could not stop music (%lx)", mciError);
-    }
-    redbook_finished_hook = NULL;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STOP, 0, 0)))
+	{
+		Warning("RBAudio win32/MCI: could not stop music (%lx)", mciError);
+	}
+	redbook_finished_hook = nullptr;
 }
 
 void RBAEjectDisk()
 {
-    if (!wCDDeviceID) return;
-    
-    MCIERROR mciError;
+	if (!wCDDeviceID) return;
+	
+	MCIERROR mciError;
 
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_SET, MCI_SET_DOOR_OPEN | MCI_WAIT, 0)))
-    {
-        Warning("RBAudio win32/MCI: could not open CD tray (%lx)", mciError);
-    }
-    initialised = 0;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_SET, MCI_SET_DOOR_OPEN | MCI_WAIT, 0)))
+	{
+		Warning("RBAudio win32/MCI: could not open CD tray (%lx)", mciError);
+	}
+	initialised = false;
 }
 
 void RBASetVolume(int)
 {
-    // MCI does not support this
+	// MCI does not support this
 }
 
 void RBAPause()
 {
-    if (!wCDDeviceID) return;
-    
-    MCIERROR mciError;
+	if (!wCDDeviceID) return;
+	
+	MCIERROR mciError;
 
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_PAUSE, 0, 0)))
-    {
-        Warning("RBAudio win32/MCI: could not pause music (%lx)", mciError);
-        return;
-    }
-    con_puts(CON_VERBOSE, "RBAudio win32/MCI: Playback paused");
-    isPaused = 1;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_PAUSE, 0, 0)))
+	{
+		Warning("RBAudio win32/MCI: could not pause music (%lx)", mciError);
+		return;
+	}
+	con_puts(CON_VERBOSE, "RBAudio win32/MCI: Playback paused");
+	isPaused = true;
 }
 
 int RBAResume()
 {
-    if (!wCDDeviceID) return -1;
-    
-    MCIERROR mciError;
+	if (!wCDDeviceID) return -1;
+	
+	MCIERROR mciError;
 
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_RESUME, 0, 0)))
-    {
-        Warning("RBAudio win32/MCI: could not resume music (%lx)", mciError);
-        return -1;
-    }
-    con_puts(CON_VERBOSE, "RBAudio win32/MCI: Playback resumed");
-    isPaused = 0;
-    return 1;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_RESUME, 0, 0)))
+	{
+		Warning("RBAudio win32/MCI: could not resume music (%lx)", mciError);
+		return -1;
+	}
+	con_puts(CON_VERBOSE, "RBAudio win32/MCI: Playback resumed");
+	isPaused = false;
+	return 1;
 }
 
 int RBAPauseResume()
 {
-    if (!wCDDeviceID) return 0;
-    
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
+	if (!wCDDeviceID) return 0;
+	
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
 
-    mciStatusParms.dwItem = MCI_STATUS_MODE;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot determine MCI media status (%lx)", mciError);
-        return 0;
-    }
+	mciStatusParms.dwItem = MCI_STATUS_MODE;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot determine MCI media status (%lx)", mciError);
+		return 0;
+	}
 
-    if (mciStatusParms.dwReturn == MCI_MODE_PLAY)
-    {
-        con_puts(CON_VERBOSE, "RBAudio win32/MCI: Toggle Playback pause");
-        RBAPause();
-    }
-        // MCI_MODE_STOP is actually paused, because logic
-    else if (mciStatusParms.dwReturn == MCI_MODE_PAUSE || (isPaused && mciStatusParms.dwReturn == MCI_MODE_STOP))
-    {
-        con_puts(CON_VERBOSE, "RBAudio win32/MCI: Toggle Playback resume");
-        return RBAResume() > 0;
-    }
-    else
-        return 0;
+	if (mciStatusParms.dwReturn == MCI_MODE_PLAY)
+	{
+		con_puts(CON_VERBOSE, "RBAudio win32/MCI: Toggle Playback pause");
+		RBAPause();
+	}
+	// MCI may also use MCI_MODE_STOP for pause instead of MCI_MODE_PAUSE
+	else if (mciStatusParms.dwReturn == MCI_MODE_PAUSE || (isPaused && mciStatusParms.dwReturn == MCI_MODE_STOP))
+	{
+		con_puts(CON_VERBOSE, "RBAudio win32/MCI: Toggle Playback resume");
+		return RBAResume() > 0;
+	}
+	else
+		return 0;
 
-    return 1;
+	return 1;
 }
 
 int RBAGetNumberOfTracks()
 {
-    if (!wCDDeviceID) return -1;
-    
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
+	if (!wCDDeviceID) return -1;
+	
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
 
-    mciStatusParms.dwItem = MCI_STATUS_NUMBER_OF_TRACKS;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: could not get track count (%lx)", mciError);
-        return -1;
-    }
+	mciStatusParms.dwItem = MCI_STATUS_NUMBER_OF_TRACKS;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: could not get track count (%lx)", mciError);
+		return -1;
+	}
 
-    return static_cast<int>(mciStatusParms.dwReturn);
+	return static_cast<int>(mciStatusParms.dwReturn);
 }
 
 // check if we need to call the 'finished' hook
@@ -345,182 +345,182 @@ int RBAGetNumberOfTracks()
 //   for whatever reason
 void RBACheckFinishedHook()
 {
-    static fix64 last_check_time = 0;
-    
-    if (!wCDDeviceID) return;
+	static fix64 last_check_time = 0;
+	
+	if (!wCDDeviceID) return;
 
-    if ((timer_query() - last_check_time) >= F2_0)
-    {
-        MCIERROR mciError;
-        MCI_STATUS_PARMS mciStatusParms;
+	if ((timer_query() - last_check_time) >= F2_0)
+	{
+		MCIERROR mciError;
+		MCI_STATUS_PARMS mciStatusParms;
 
-        mciStatusParms.dwItem = MCI_STATUS_POSITION;
-        if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-        {
-            Warning("RBAudio win32/MCI: cannot determine MCI position (%lx)", mciError);
-            return;
-        }
+		mciStatusParms.dwItem = MCI_STATUS_POSITION;
+		if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+		{
+			Warning("RBAudio win32/MCI: cannot determine MCI position (%lx)", mciError);
+			return;
+		}
 
-        // time for a hack. for some reason, MCI sometimes stops
-        // from around a few to few dozen frames before it should,
-        // so we will check if we haven't moved from the last check
-        // and allow a bit of a leeway when checking if so.
+		// time for a hack. for some reason, MCI sometimes stops
+		// from around a few to few dozen frames before it should,
+		// so we will check if we haven't moved from the last check
+		// and allow a bit of a leeway when checking if so.
 
-        int checkValue = playEnd;
-        int thisFrames = mci_TotalFramesMsf(mciStatusParms.dwReturn);
+		DWORD checkValue = playEnd;
+		DWORD thisFrames = mci_TotalFramesMsf(mciStatusParms.dwReturn);
 
-        if (thisFrames == lastFrames)
-            checkValue -= 64;
+		if (thisFrames == lastFrames)
+			checkValue = checkValue < 64 ? 0 : checkValue - 64; // prevent underflow
 
-        if (redbook_finished_hook && playEnd >= 0 && lastFrames >= checkValue)
-        {
-            con_puts(CON_VERBOSE, "RBAudio win32/MCI: Playback done, calling finished-hook");
-            redbook_finished_hook();
-        }
-        lastFrames = thisFrames;
-        last_check_time = timer_query();
-    }
+		if (redbook_finished_hook && playEnd > 0 && lastFrames >= checkValue)
+		{
+			con_puts(CON_VERBOSE, "RBAudio win32/MCI: Playback done, calling finished-hook");
+			redbook_finished_hook();
+		}
+		lastFrames = thisFrames;
+		last_check_time = timer_query();
+	}
 }
 
 // return the track number currently playing.  Useful if RBAPlayTracks()
 // is called.  Returns 0 if no track playing, else track number
 int RBAGetTrackNum()
 {
-    if (!wCDDeviceID) return 0;
-    
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
+	if (!wCDDeviceID) return 0;
+	
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
 
-    mciStatusParms.dwItem = MCI_STATUS_MODE;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot determine MCI media status (%lx)", mciError);
-        return 0;
-    }
+	mciStatusParms.dwItem = MCI_STATUS_MODE;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot determine MCI media status (%lx)", mciError);
+		return 0;
+	}
 
-    if (mciStatusParms.dwReturn != MCI_MODE_PLAY)
-        return 0;
+	if (mciStatusParms.dwReturn != MCI_MODE_PLAY)
+		return 0;
 
-    mciStatusParms.dwItem = MCI_STATUS_CURRENT_TRACK;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot determine MCI track number (%lx)", mciError);
-        return 0;
-    }
+	mciStatusParms.dwItem = MCI_STATUS_CURRENT_TRACK;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot determine MCI track number (%lx)", mciError);
+		return 0;
+	}
 
-    return static_cast<int>(mciStatusParms.dwReturn);
+	return static_cast<int>(mciStatusParms.dwReturn);
 }
 
 int RBAPeekPlayStatus()
 {
-    if (!wCDDeviceID) return 0;
-    
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
+	if (!wCDDeviceID) return 0;
+	
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
 
-    mciStatusParms.dwItem = MCI_STATUS_MODE;
-    if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-    {
-        Warning("RBAudio win32/MCI: cannot determine MCI media status (%lx)", mciError);
-        return 0;
-    }
+	mciStatusParms.dwItem = MCI_STATUS_MODE;
+	if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+	{
+		Warning("RBAudio win32/MCI: cannot determine MCI media status (%lx)", mciError);
+		return 0;
+	}
 
-    if (mciStatusParms.dwReturn == MCI_MODE_PLAY)
-        return 1;
-    else if (mciStatusParms.dwReturn == MCI_MODE_PAUSE || (isPaused && mciStatusParms.dwReturn == MCI_MODE_STOP))
-        return -1; // hack so it doesn't keep restarting paused music
-        // MCI_MODE_STOP is actually paused, because logic
-    else
-        return 0;
+	if (mciStatusParms.dwReturn == MCI_MODE_PLAY)
+		return 1;
+	// MCI may also use MCI_MODE_STOP for pause instead of MCI_MODE_PAUSE
+	else if (mciStatusParms.dwReturn == MCI_MODE_PAUSE || (isPaused && mciStatusParms.dwReturn == MCI_MODE_STOP))
+		return -1; // hack so it doesn't keep restarting paused music; -1 is still truthy, unlike 0
+	else
+		return 0;
 }
 
 static int cddb_sum(int n)
 {
-    int ret;
+	int ret;
 
-    /* For backward compatibility this algorithm must not change */
+	/* For backward compatibility this algorithm must not change */
 
-    ret = 0;
+	ret = 0;
 
-    while (n > 0) {
-        ret = ret + (n % 10);
-        n = n / 10;
-    }
+	while (n > 0) {
+		ret = ret + (n % 10);
+		n = n / 10;
+	}
 
-    return (ret);
+	return (ret);
 }
 
 unsigned long RBAGetDiscID()
 {
-    int i, t = 0, n = 0, trackCount, totalLength;
+	int i, t = 0, n = 0, trackCount, totalLength;
 
-    if (!wCDDeviceID)
-        return 0;
+	if (!wCDDeviceID)
+		return 0;
 
-    MCIERROR mciError;
-    trackCount = RBAGetNumberOfTracks();
-    totalLength = mci_GetTotalLength();
-    if (totalLength < 0)
-    {
-        Warning("RBAudio win32/MCI: cannot determine total length (%lx)", mciError);
-        return 0;
-    }
+	MCIERROR mciError;
+	trackCount = RBAGetNumberOfTracks();
+	totalLength = mci_GetTotalLength();
+	if (totalLength < 0)
+	{
+		Warning("RBAudio win32/MCI: cannot determine total length (%lx)", mciError);
+		return 0;
+	}
 
-    /* For backward compatibility this algorithm must not change */
+	/* For backward compatibility this algorithm must not change */
 
-    i = 1;
+	i = 1;
 
-    while (i <= trackCount)
-    {
-        int offset = mci_GetTrackOffset(i);
-        if (offset < 0)
-        {
-            Warning("RBAudio win32/MCI: cannot determine track %i offset (%lx)", i, mciError);
-            return 0;
-        }
-        n += cddb_sum(offset / CD_FPS);
-        i++;
-    }
+	while (i <= trackCount)
+	{
+		int offset = mci_GetTrackOffset(i);
+		if (offset < 0)
+		{
+			Warning("RBAudio win32/MCI: cannot determine track %i offset (%lx)", i, mciError);
+			return 0;
+		}
+		n += cddb_sum(offset / CD_FPS);
+		i++;
+	}
 
-    t = totalLength / CD_FPS;
+	t = totalLength / CD_FPS;
 
-    return ((n % 0xff) << 24 | t << 8 | trackCount);
+	return ((n % 0xff) << 24 | t << 8 | trackCount);
 }
 
 void RBAList(void)
 {
-    if (!wCDDeviceID) return;
+	if (!wCDDeviceID) return;
 
-    MCIERROR mciError;
-    MCI_STATUS_PARMS mciStatusParms;
-    int trackCount = RBAGetNumberOfTracks();
+	MCIERROR mciError;
+	MCI_STATUS_PARMS mciStatusParms;
+	int trackCount = RBAGetNumberOfTracks();
 
-    for (int i = 1; i <= trackCount; ++i) {
-        int isAudioTrack, length, offset;
-        mciStatusParms.dwTrack = i;
+	for (int i = 1; i <= trackCount; ++i) {
+		int isAudioTrack, length, offset;
+		mciStatusParms.dwTrack = i;
 
-        mciStatusParms.dwItem = MCI_CDA_STATUS_TYPE_TRACK;
-        if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
-        {
-            Warning("RBAudio win32/MCI: cannot determine track %d type (%lx)", i, mciError);
-            continue;
-        }
-        isAudioTrack = mciStatusParms.dwReturn == MCI_CDA_TRACK_AUDIO;
+		mciStatusParms.dwItem = MCI_CDA_STATUS_TYPE_TRACK;
+		if ((mciError = mciSendCommand(wCDDeviceID, MCI_STATUS, MCI_STATUS_ITEM | MCI_TRACK, reinterpret_cast<DWORD_PTR>(&mciStatusParms))))
+		{
+			Warning("RBAudio win32/MCI: cannot determine track %d type (%lx)", i, mciError);
+			continue;
+		}
+		isAudioTrack = mciStatusParms.dwReturn == MCI_CDA_TRACK_AUDIO;
 
-        offset = mci_GetTrackOffset(i);
-        if (offset < 0)
-        {
-            continue;
-        }
+		offset = mci_GetTrackOffset(i);
+		if (offset < 0)
+		{
+			continue;
+		}
 
-        length = mci_GetTrackLength(i);
-        if (length < 0)
-        {
-            continue;
-        }
+		length = mci_GetTrackLength(i);
+		if (length < 0)
+		{
+			continue;
+		}
 
-        con_printf(CON_VERBOSE, "RBAudio win32/MCI: CD track %d, type %s, length %d, offset %d", i, isAudioTrack ? "audio" : "data", length, offset);
-    }
+		con_printf(CON_VERBOSE, "RBAudio win32/MCI: CD track %d, type %s, length %d, offset %d", i, isAudioTrack ? "audio" : "data", length, offset);
+	}
 }
 
 }

--- a/common/include/rbaudio.h
+++ b/common/include/rbaudio.h
@@ -34,10 +34,13 @@ struct RBACHANNELCTL
 	unsigned int out2in, out2vol;
 	unsigned int out3in, out3vol;
 };
+#endif
 
 extern void RBAInit(void);
 extern void RBAExit();
+#if SDL_MAJOR_VERSION == 1
 extern long RBAGetDeviceStatus(void);
+#endif
 extern int RBAPlayTrack(int track);
 extern int RBAPlayTracks(int first, int last, void (*hook_finished)(void));	//plays tracks first through last, inclusive
 extern int RBACheckMediaChange();
@@ -45,65 +48,40 @@ extern long	RBAGetHeadLoc(int *min, int *sec, int *frame);
 extern int	RBAPeekPlayStatus(void);
 extern void RBAStop(void);
 extern void RBAEjectDisk(void);
+#if SDL_MAJOR_VERSION == 1
 extern void RBASetStereoAudio(RBACHANNELCTL *channels);
 extern void RBASetQuadAudio(RBACHANNELCTL *channels);
 extern void RBAGetAudioInfo(RBACHANNELCTL *channels);
 extern void RBASetChannelVolume(int channel, int volume);
-#ifdef __linux__
+#endif
+#if defined(__linux__) || SDL_MAJOR_VERSION != 1
 extern void RBASetVolume(int volume);
 #else
 static inline void RBASetVolume(int)
 {
 }
 #endif
+
 extern int	RBAEnabled(void);
+#if SDL_MAJOR_VERSION == 1
 extern void RBADisable(void);
 extern void RBAEnable(void);
-extern int	RBAGetNumberOfTracks(void);
-extern void RBACheckFinishedHook();
-extern void	RBAPause();
-extern int	RBAResume();
-extern int	RBAPauseResume();
-
-//return the track number currently playing.  Useful if RBAPlayTracks() 
-//is called.  Returns 0 if no track playing, else track number
-int RBAGetTrackNum();
-
-// get the cddb discid for the current cd.
-unsigned long RBAGetDiscID();
-
-// List the tracks on the CD
-void RBAList(void);
-
-#elif SDL_MAJOR_VERSION == 2
-
-extern void RBAInit(void);
-extern void RBAExit();
-extern int RBAPlayTrack(int track);
-extern int RBAPlayTracks(int first, int last, void (*hook_finished)(void));	//plays tracks first through last, inclusive
-extern int	RBAPeekPlayStatus(void);
-extern void RBAStop(void);
-extern void RBAEjectDisk(void);
-extern void RBASetVolume(int volume);
-
-extern int	RBAEnabled(void);
-extern int	RBAGetNumberOfTracks(void);
-extern void RBACheckFinishedHook();
-extern void	RBAPause();
-extern int	RBAResume();
-extern int	RBAPauseResume();
-
-//return the track number currently playing.  Useful if RBAPlayTracks() 
-//is called.  Returns 0 if no track playing, else track number
-int RBAGetTrackNum();
-
-// get the cddb discid for the current cd.
-unsigned long RBAGetDiscID();
-
-// List the tracks on the CD
-void RBAList(void);
-
 #endif
+extern int	RBAGetNumberOfTracks(void);
+extern void RBACheckFinishedHook();
+extern void	RBAPause();
+extern int	RBAResume();
+extern int	RBAPauseResume();
+
+//return the track number currently playing.  Useful if RBAPlayTracks() 
+//is called.  Returns 0 if no track playing, else track number
+int RBAGetTrackNum();
+
+// get the cddb discid for the current cd.
+unsigned long RBAGetDiscID();
+
+// List the tracks on the CD
+void RBAList(void);
 
 #endif
 

--- a/common/include/rbaudio.h
+++ b/common/include/rbaudio.h
@@ -74,7 +74,37 @@ unsigned long RBAGetDiscID();
 
 // List the tracks on the CD
 void RBAList(void);
+
+#elif SDL_MAJOR_VERSION == 2
+
+extern void RBAInit(void);
+extern void RBAExit();
+extern int RBAPlayTrack(int track);
+extern int RBAPlayTracks(int first, int last, void (*hook_finished)(void));	//plays tracks first through last, inclusive
+extern int	RBAPeekPlayStatus(void);
+extern void RBAStop(void);
+extern void RBAEjectDisk(void);
+extern void RBASetVolume(int volume);
+
+extern int	RBAEnabled(void);
+extern int	RBAGetNumberOfTracks(void);
+extern void RBACheckFinishedHook();
+extern void	RBAPause();
+extern int	RBAResume();
+extern int	RBAPauseResume();
+
+//return the track number currently playing.  Useful if RBAPlayTracks() 
+//is called.  Returns 0 if no track playing, else track number
+int RBAGetTrackNum();
+
+// get the cddb discid for the current cd.
+unsigned long RBAGetDiscID();
+
+// List the tracks on the CD
+void RBAList(void);
+
+#endif
+
 #endif
 
 }
-#endif

--- a/common/main/digi.h
+++ b/common/main/digi.h
@@ -123,7 +123,7 @@ extern void digi_start_sound_queued( short soundnum, fix volume );
 
 #define MUSIC_TYPE_NONE		0
 #define MUSIC_TYPE_BUILTIN	1
-#if SDL_MAJOR_VERSION == 1
+#if DXX_USE_SDL_REDBOOK_AUDIO
 #define MUSIC_TYPE_REDBOOK	2
 #endif
 #define MUSIC_TYPE_CUSTOM	3

--- a/similar/arch/sdl/init.cpp
+++ b/similar/arch/sdl/init.cpp
@@ -17,7 +17,6 @@
 #include "text.h"
 #include "args.h"
 #include "window.h"
-#include "fwd-event.h"
 
 namespace dsx {
 
@@ -79,8 +78,6 @@ void arch_init(void)
 
 	if ((t = gr_init()) != 0)
 		Error(TXT_CANT_INIT_GFX,t);
-
-	event_init();
 
 	atexit(arch_close);
 }

--- a/similar/arch/sdl/init.cpp
+++ b/similar/arch/sdl/init.cpp
@@ -17,6 +17,7 @@
 #include "text.h"
 #include "args.h"
 #include "window.h"
+#include "fwd-event.h"
 
 namespace dsx {
 
@@ -78,6 +79,8 @@ void arch_init(void)
 
 	if ((t = gr_init()) != 0)
 		Error(TXT_CANT_INIT_GFX,t);
+
+	event_init();
 
 	atexit(arch_close);
 }

--- a/similar/main/config.cpp
+++ b/similar/main/config.cpp
@@ -98,7 +98,7 @@ int ReadConfigFile()
 	GameCfg.MusicVolume = 8;
 	GameCfg.ReverseStereo = 0;
 	GameCfg.OrigTrackOrder = 0;
-#if SDL_MAJOR_VERSION == 1 && defined(__APPLE__) && defined(__MACH__)
+#if DXX_USE_SDL_REDBOOK_AUDIO && defined(__APPLE__) && defined(__MACH__)
 	GameCfg.MusicType = MUSIC_TYPE_REDBOOK;
 #else
 	GameCfg.MusicType = MUSIC_TYPE_BUILTIN;

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -1991,7 +1991,7 @@ namespace {
 #define DXX_SOUND_ADDON_MUSIC_MENU_ITEM(VERB)
 #endif
 
-#if SDL_MAJOR_VERSION == 1
+#if DXX_USE_SDL_REDBOOK_AUDIO
 #define DXX_SOUND_CD_MUSIC_MENU_ITEM(VERB)	\
 	DXX_MENUITEM(VERB, RADIO, "CD music", opt_sm_mtype2, GameCfg.MusicType == MUSIC_TYPE_REDBOOK, optgrp_music_type)	\
 
@@ -2128,7 +2128,7 @@ int sound_menu_items::menuset(newmenu *, const d_event &event, sound_menu_items 
 				replay = 1;
 			}
 #endif
-#if SDL_MAJOR_VERSION == 1
+#if DXX_USE_SDL_REDBOOK_AUDIO
 			else if (citem == opt_sm_mtype2)
 			{
 				GameCfg.MusicType = MUSIC_TYPE_REDBOOK;

--- a/similar/main/songs.cpp
+++ b/similar/main/songs.cpp
@@ -45,6 +45,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "physfsx.h"
 #include "game.h"
 #include "compiler-make_unique.h"
+#include "console.h"
 
 namespace dcx {
 
@@ -389,6 +390,7 @@ static int songs_have_cd()
 		return 0;
 
 	discid = RBAGetDiscID();
+	con_printf(CON_DEBUG, "CD-ROM disc ID is 0x%08lx", discid);
 
 	switch (discid) {
 #if defined(DXX_BUILD_DESCENT_I)


### PR DESCRIPTION
This readds Red Book (CD Audio) support for Win32 when using SDL2. With SDL2, there are no SDL functions for handling CD playback, unlike in SDL1. Therefore we need to implement our own code, and  this case, I implemented something that works on top of MCI. This allows using CD music on SDL2, although only on Windows for now.

common/arch/win32/rbaudio.cpp is a bit messy right now, since it only contains anything if we are on SDL2, but is still compiled even on SDL1 as long as the platform is Win32. It's probably a better idea to remove those #if's and modify the SConstruct script to include it only if both SDL2 and Win32, but I don't have the expertise to work with SConstruct scripts to a sufficient degree.

There are some hacks in the code - the most major one allows track end detection to be more lenient, as MCI on some setups stops playback just before your specified time, making it difficult to detect when the track actually ends. MCI would also support a notification system passing a Win32 message (MM_MCINOTIFY), but this doesn't work either for likely the same reason mentioned before (that it's unable to play properly until the actual end point).

Disc ID detection *should* produce the same results as on SDL1. I only tested it with some unrelated discs, as I don't possess actual Descent discs to test it with.