### PR TITLE
Fix #486 - update to load_mission_by_name to allow it to find missions in subdirectories

### DIFF
--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -419,7 +419,10 @@ static void gameseq_init_network_players(object_array &Objects)
 			auto &ri = Robot_info[get_robot_id(o)];
 			if ((!retain_guidebot && robot_is_companion(ri)) ||
 				(remove_thief && robot_is_thief(ri)))
+			{
+				object_create_robot_egg(o);
 				obj_delete(LevelUniqueObjectState, Segments, o);		//kill the buddy in netgames
+			}
 		}
 #endif
 	}
@@ -475,7 +478,10 @@ void gameseq_remove_unused_players()
 				{
 					auto &ri = Robot_info[get_robot_id(o)];
 					if (robot_is_thief(ri))
+					{
+						object_create_robot_egg(o);
 						obj_delete(LevelUniqueObjectState, Segments, o);
+					}
 				}
 			}
 		}

--- a/similar/main/mission.cpp
+++ b/similar/main/mission.cpp
@@ -1122,6 +1122,36 @@ static const char *load_mission(const mle *const mission)
 
 }
 
+//Extends load_mission_by_name with a recursive search if necessary
+//Returns nullptr if mission loaded ok, else error string.
+const char *load_mission_by_name_from_subdir(const char *const mission_name, mission_list_type &subdir);
+
+const char *load_mission_by_name_from_subdir(const char *const mission_name, mission_list_type &subdir)
+{
+	const char *found = nullptr;
+
+	range_for (auto &i, subdir)
+    {
+		if (!d_stricmp(mission_name, &*i.filename))
+		{
+			found = load_mission(&i);
+			break;
+		}
+    }
+    
+    if (!found)
+	range_for (auto &i, subdir)
+    {
+		if (!i.directory.empty())
+		{
+			found = load_mission_by_name_from_subdir(mission_name, i.directory);
+			break;
+		}
+    }
+    
+    return found;
+}
+
 //loads the named mission if exists.
 //Returns nullptr if mission loaded ok, else error string.
 const char *load_mission_by_name(const char *const mission_name)
@@ -1130,11 +1160,24 @@ const char *load_mission_by_name(const char *const mission_name)
 	const char *found = nullptr;
 
 	range_for (auto &i, mission_list)
+    {
 		if (!d_stricmp(mission_name, &*i.filename))
 		{
 			found = load_mission(&i);
 			break;
 		}
+    }
+    
+    if (!found)
+	range_for (auto &i, mission_list)
+    {
+		if (!i.directory.empty())
+		{
+			found = load_mission_by_name_from_subdir(mission_name, i.directory);
+			break;
+		}
+    }
+
 	return found;
 }
 

--- a/similar/main/mission.cpp
+++ b/similar/main/mission.cpp
@@ -1124,9 +1124,9 @@ static const char *load_mission(const mle *const mission)
 
 //Extends load_mission_by_name with a recursive search if necessary
 //Returns nullptr if mission loaded ok, else error string.
-const char *load_mission_by_name_from_subdir(const char *const mission_name, mission_list_type &subdir);
+const char *load_mission_by_name_from_subdir(const char *const mission_name, mission_list_type &subdir, bool &inSubdir);
 
-const char *load_mission_by_name_from_subdir(const char *const mission_name, mission_list_type &subdir)
+const char *load_mission_by_name_from_subdir(const char *const mission_name, mission_list_type &subdir, bool &inSubdir)
 {
 	const char *found = nullptr;
 
@@ -1135,20 +1135,20 @@ const char *load_mission_by_name_from_subdir(const char *const mission_name, mis
 		if (!d_stricmp(mission_name, &*i.filename))
 		{
 			found = load_mission(&i);
+            inSubdir = true;
 			break;
 		}
     }
     
     if (!found)
-	range_for (auto &i, subdir)
-    {
-		if (!i.directory.empty())
-		{
-			found = load_mission_by_name_from_subdir(mission_name, i.directory);
-			break;
-		}
-    }
-    
+        range_for (auto &i, subdir)
+            if (!i.directory.empty())
+            {
+                found = load_mission_by_name_from_subdir(mission_name, i.directory, inSubdir);
+                if (inSubdir)
+                    break;
+            }
+        
     return found;
 }
 
@@ -1168,15 +1168,15 @@ const char *load_mission_by_name(const char *const mission_name)
 		}
     }
     
+    bool inSubdir = false;
     if (!found)
-	range_for (auto &i, mission_list)
-    {
-		if (!i.directory.empty())
-		{
-			found = load_mission_by_name_from_subdir(mission_name, i.directory);
-			break;
-		}
-    }
+        range_for (auto &i, mission_list)
+            if (!i.directory.empty())
+            {
+                found = load_mission_by_name_from_subdir(mission_name, i.directory, inSubdir);
+                if (inSubdir)
+                    break;
+            }
 
 	return found;
 }


### PR DESCRIPTION
Not being familiar with the Rebirth codebase, I'm not 100% sure this is the best way to implement this change, but it fixes the issue without changing how load_mission_by_name is used. If there are multiple mission files available with the same name (but in different subdirs), it will load the first one it finds, which will result in it loading whichever is closer to the root directory, in the first path alphabetically.