### PR TITLE
Small fix: Thief bot immediately drops all map-specified powerups if suppressed

### DIFF
--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -419,7 +419,10 @@ static void gameseq_init_network_players(object_array &Objects)
 			auto &ri = Robot_info[get_robot_id(o)];
 			if ((!retain_guidebot && robot_is_companion(ri)) ||
 				(remove_thief && robot_is_thief(ri)))
+			{
+				object_create_robot_egg(o);
 				obj_delete(LevelUniqueObjectState, Segments, o);		//kill the buddy in netgames
+			}
 		}
 #endif
 	}
@@ -475,7 +478,10 @@ void gameseq_remove_unused_players()
 				{
 					auto &ri = Robot_info[get_robot_id(o)];
 					if (robot_is_thief(ri))
+					{
+						object_create_robot_egg(o);
 						obj_delete(LevelUniqueObjectState, Segments, o);
+					}
 				}
 			}
 		}

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -420,7 +420,10 @@ static void gameseq_init_network_players(object_array &Objects)
 			if ((!retain_guidebot && robot_is_companion(ri)) ||
 				(remove_thief && robot_is_thief(ri)))
 			{
-				object_create_robot_egg(o);
+				if (o->contains_count > 0)
+				{
+					object_create_robot_egg(o);
+				}
 				obj_delete(LevelUniqueObjectState, Segments, o);		//kill the buddy in netgames
 			}
 		}
@@ -479,7 +482,10 @@ void gameseq_remove_unused_players()
 					auto &ri = Robot_info[get_robot_id(o)];
 					if (robot_is_thief(ri))
 					{
-						object_create_robot_egg(o);
+						if (o->contains_count > 0)
+						{
+							object_create_robot_egg(o);
+						}
 						obj_delete(LevelUniqueObjectState, Segments, o);
 					}
 				}


### PR DESCRIPTION
Currently, if the option to suppress the thief bot is enabled, any objects it was to drop will be lost along with it. This is mostly only relevant when the thief bot is carrying keys, but this fix will drop any item it was carrying before deleting the bot (as the level could feasibly rely on other objects, for example requiring a Phoenix Cannon or Guided Missiles for hitting an out-of-sight switch). I've tested this in single player, and I believe (albeit with my minimal knowledge of the network code) that it should work in multiplayer as well, but I haven't tested that.

Also, I apologise for the extra commits; my fork also includes the load_mission_by_name fix, and I couldn't figure out how to get rid of them beyond just resetting it with an extra commit. Nothing that I've encountered in software development thus far has made me feel more like I need an adult than version control. :P