### PR TITLE
Add PIGGY_PAGE_IN to ogl_cache_polymodel_textures

### DIFF
--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -372,6 +372,7 @@ void ogl_cache_polymodel_textures(const unsigned model_num)
 	const unsigned last_texture = i + po.n_textures;
 	for (; i != last_texture; ++i)
 	{
+		PIGGY_PAGE_IN(ObjBitmaps[ObjBitmapPtrs[i]]);
 		ogl_loadbmtexture(GameBitmaps[ObjBitmaps[ObjBitmapPtrs[i]].index], 1);
 	}
 }


### PR DESCRIPTION
Fix data = NULL crash in ogl_loadtexture after piggy_bitmap_page_out_all() ran at an unfortunate time. Happens with an unreleased level by TRUEpiiiicness.
https://descentbb.net/viewtopic.php?f=22&t=24641
