### PR TITLE
Exclude D1 player lasers from the quad laser damage reduction

### DIFF
--- a/similar/main/laser.cpp
+++ b/similar/main/laser.cpp
@@ -722,9 +722,9 @@ imobjptridx_t Laser_create_new(const vms_vector &direction, const vms_vector &po
 				obj->ctype.laser_info.multiplier /= 2;
 #endif
 		}
+#if defined(DXX_BUILD_DESCENT_II)
 		else if (is_laser_weapon_type(weapon_type) && (parent->ctype.player_info.powerup_flags & PLAYER_FLAGS_QUAD_LASERS))
 			obj->ctype.laser_info.multiplier = F1_0*3/4;
-#if defined(DXX_BUILD_DESCENT_II)
 		else if (weapon_type == weapon_id_type::GUIDEDMISS_ID) {
 			if (parent==get_local_player().objnum) {
 				LevelUniqueObjectState.Guided_missile.set_player_active_guided_missile(obj, Player_num);


### PR DESCRIPTION
The code that provides the 0.75x multiplier to laser bolts when they're fired using the quad laser is present in D1 as in D2, however it is incorrect and results in it not being applied. As such, it is more accurate to exclude the multiplier when compiling D1.

The relevant line in D1 is `else if ((weapon_type == LASER_ID) && (Players[Objects[parent].id].flags & PLAYER_FLAGS_QUAD_LASERS))`, which looks correct, but LASER_ID refers to the blue robot laser rather than any player laser types.

Thanks to SaladBadger for the tip (and the relevant segment of D1 code).