### PR TITLE
clipper.cpp: Fix build with gcc10

### DIFF
--- a/common/3d/clipper.cpp
+++ b/common/3d/clipper.cpp
@@ -11,6 +11,7 @@
 #include "dxxerror.h"
 
 #include "compiler-range_for.h"
+#include <stdexcept>
 
 namespace dcx {
 


### PR DESCRIPTION
| common/3d/clipper.cpp:29:14: error: 'out_of_range' is not a member of 'std'

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>