### PR TITLE
Prevent extremely uncommon crash upon D1 level load… (fixes issue #515)

### DIFF
--- a/similar/main/switch.cpp
+++ b/similar/main/switch.cpp
@@ -570,17 +570,20 @@ window_event_result check_trigger(const vcsegptridx_t seg, const unsigned side, 
 		{
 			t.flags &= ~TRIGGER_ON;
 	
-			const shared_segment &csegp = *vcsegptr(seg->children[side]);
-			auto cside = find_connect_side(seg, csegp);
-			Assert(cside != side_none);
-		
-			const auto cwall_num = csegp.sides[cside].wall_num;
-			if (cwall_num == wall_none)
-				return window_event_result::ignored;
+			if (IS_CHILD(seg->children[side]))
+			{
+				const shared_segment &csegp = *vcsegptr(seg->children[side]);
+				auto cside = find_connect_side(seg, csegp);
+				Assert(cside != side_none);
 			
-			const auto ctrigger_num = vcwallptr(cwall_num)->trigger;
-			auto &ct = *vmtrgptr(ctrigger_num);
-			ct.flags &= ~TRIGGER_ON;
+				const auto cwall_num = csegp.sides[cside].wall_num;
+				if (cwall_num == wall_none)
+				return window_event_result::ignored;
+
+				const auto ctrigger_num = vcwallptr(cwall_num)->trigger;
+				auto &ct = *vmtrgptr(ctrigger_num);
+				ct.flags &= ~TRIGGER_ON;
+			}
 		}
 #endif
 		if (Game_mode & GM_MULTI)


### PR DESCRIPTION
…when one-shot trigger has same trigger number as previous level's exit trigger.

An alternative solution would be to remove the one-shot block entirely, as it currently has no effect on gameplay.