### PR TITLE
Raspberry Pi bugfixes

### DIFF
--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -554,6 +554,7 @@ void g3_draw_line(grs_canvas &canvas, const g3s_point &p0, const g3s_point &p1, 
   
 	ogl_client_states<int, GL_VERTEX_ARRAY, GL_COLOR_ARRAY> cs;
 	OGL_DISABLE(TEXTURE_2D);
+	glDisable(GL_CULL_FACE);
 	color_r = PAL2Tr(c);
 	color_g = PAL2Tg(c);
 	color_b = PAL2Tb(c);

--- a/similar/main/polyobj.cpp
+++ b/similar/main/polyobj.cpp
@@ -766,9 +766,9 @@ void polygon_model_data_read(polymodel *pm, PHYSFS_File *fp)
 	if (words_bigendian)
 	swap_polygon_model_data(pm->model_data.get());
 #if defined(DXX_BUILD_DESCENT_I)
-	g3_validate_polygon_model(pm->model_data.get(), model_data_size);
+	g3_validate_polygon_model(pm->model_data.get(), pm->model_data_size);
 #elif defined(DXX_BUILD_DESCENT_II)
-	g3_init_polygon_model(pm->model_data.get(), model_data_size);
+	g3_init_polygon_model(pm->model_data.get(), pm->model_data_size);
 #endif
 }
 }


### PR DESCRIPTION
Fixes for two bugs that plagued DXX-Rebirth on Raspberry Pi systems:
- empty automap (no lines drawn)
- Medium Hulk and Heavy Hulk models were missing their heads
