### PR TITLE
Workaround for missing forever flag in sound object demo recording

### DIFF
--- a/similar/main/digiobj.cpp
+++ b/similar/main/digiobj.cpp
@@ -418,7 +418,15 @@ void digi_link_sound_to_object3(const unsigned org_soundnum, const vcobjptridx_t
 	}
 
 	if ( Newdemo_state == ND_STATE_RECORDING )		{
-		newdemo_record_link_sound_to_object3( org_soundnum, objnum, max_volume, max_distance, loop_start, loop_end );
+		if ( !forever ) { // forever flag is not recorded, use original limited sound objects hack for demo recording
+			int volume, pan;
+			auto segnum = vcsegptridx(objnum->segnum);
+			digi_get_sound_loc(viewer->orient, viewer->pos, segnum.absolute_sibling(viewer->segnum),
+			       objnum->pos, segnum, max_volume,
+			       &volume, &pan, max_distance);
+			newdemo_record_sound_3d_once( org_soundnum, pan, volume );
+		} else
+			newdemo_record_link_sound_to_object3( org_soundnum, objnum, max_volume, max_distance, loop_start, loop_end );
 	}
 
 	const auto &&f = find_sound_object(SoundObjects, soundnum, objnum, once);


### PR DESCRIPTION
In the original code there was a 'Hack to keep sounds from building up...'
which changed a non-forever linked sound to a non-linked sound. Therefore
the forever flag wasn't needed in the demo files. The commit
4a98e796abb099eb4c592d9520e4edbef7a15d7e removed the hack, which caused
non-forever sounds to start looping on demo playback.
This commit restores the hack as far as demo files are concerned.

Reported-by: zicodxx <https://github.com/dxx-rebirth/dxx-rebirth/issues/477>
Fixes: 4a98e796abb099eb4c592d9520e4edbef7a15d7e ("Prevent stacking weapon rotation sounds")