### PR TITLE
Fixed macOS compilation by bypassing GL library check

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1397,6 +1397,9 @@ static void terminate_handler()
 		if self.user_settings.opengles:
 			# GLES builds do not use the GL utility functions
 			return
+		if sys.platform == 'darwin':
+			# macOS provides these in a system framework, so this test always fails
+			return
 		self._check_system_library(context, header=['GL/glu.h'], main='''
 	gluPerspective(90.0,1.0,0.1,5000.0);
 	gluBuild2DMipmaps (GL_TEXTURE_2D, 0, 1, 1, 1, GL_UNSIGNED_BYTE, nullptr);


### PR DESCRIPTION
Commit https://github.com/dxx-rebirth/dxx-rebirth/commit/969caa8c0cb5de8a8af29e7368ca2d21c02e34d7 (which didn't get captured in that experimental branch) broke compilation on macOS.  In macOS, the OpenGL headers and libraries are included in a framework that's bundled as part of the system SDK, so the test always fails.  However, since they're included as part of the system SDK, they should be guaranteed to always be there unless somebody's build environment is broken.