### PR TITLE
Fixed 'format string is not a string literal' warning, which gets tre…

### DIFF
--- a/similar/main/powerup.cpp
+++ b/similar/main/powerup.cpp
@@ -140,6 +140,7 @@ static void _powerup_basic_nonhud(int redadd, int greenadd, int blueadd, int sco
 	add_points_to_score(ConsoleObject->ctype.player_info, score);
 }
 
+__attribute__((__format__ (__printf__, 5, 0)))
 void (powerup_basic)(int redadd, int greenadd, int blueadd, int score, const char *format, ...)
 {
 	va_list	args;


### PR DESCRIPTION
…ated as an error

I'm not sure whether this started in a recent commit, or as the result of the recent new version of clang, but the existing codebase fails on similar/main/powerup.cpp because one of the methods eventually passes an argument through to printf as a format string.  This gets reported as a warning, which then gets elevated to an error, causing compilation to fail.  This just adds an attribute to the method to indicate that that's expected.