### PR TITLE
Fix building and runtime crash on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1392,6 +1392,10 @@ static void terminate_handler()
 
 	@_custom_test
 	def check_glu(self,context):
+		glulib = (
+			'GLU32' if self.user_settings.host_platform == 'win32' else
+				'GLU'
+			)
 		if not self.user_settings.opengl:
 			return
 		if self.user_settings.opengles:
@@ -1403,7 +1407,7 @@ static void terminate_handler()
 		self._check_system_library(context, header=['GL/glu.h'], main='''
 	gluPerspective(90.0,1.0,0.1,5000.0);
 	gluBuild2DMipmaps (GL_TEXTURE_2D, 0, 1, 1, 1, GL_UNSIGNED_BYTE, nullptr);
-''', lib='GLU', testflags={'LIBS': ['GLU']})
+''', lib=glulib, testflags={'LIBS': [glulib]})
 
 	@_custom_test
 	def _check_SDL(self,context):

--- a/common/misc/hmp.cpp
+++ b/common/misc/hmp.cpp
@@ -428,7 +428,7 @@ int hmp_play(hmp_file *hmp, int bLoop)
 
 	if ((rc = setup_buffers(hmp)))
 		return rc;
-	if ((midiStreamOpen(&hmp->hmidi, &hmp->devid,1, static_cast<DWORD>(reinterpret_cast<uintptr_t>(&midi_callback)), 0, CALLBACK_FUNCTION)) != MMSYSERR_NOERROR)
+	if ((midiStreamOpen(&hmp->hmidi, &hmp->devid, 1, reinterpret_cast<DWORD_PTR>(&midi_callback), 0, CALLBACK_FUNCTION)) != MMSYSERR_NOERROR)
 	{
 		hmp->hmidi = NULL;
 		return HMP_MM_ERR;


### PR DESCRIPTION
Hi, I've been occasionally building (and playing) d1x-rebirth for over a year on Windows 10. (Though I don't pretend to be any good at either.) This is my first attempted contribution, here goes...

This PR addresses two problems:

1. Since GLU detection was added in https://github.com/dxx-rebirth/dxx-rebirth/commit/969caa8c0cb5de8a8af29e7368ca2d21c02e34d7, configuration wouldn't complete on MSYS2/mingw64. Microsoft provides [opengl32/glu32](https://www.opengl.org/archives/resources/faq/technical/mswindows.htm#mswi0130), and from what I can tell each portable project needs to accommodate importing the different library names; see also https://github.com/msys2/MINGW-packages/issues/6693#issuecomment-660605885.

2. When MSYS2's mingw64/gcc recently started building image bases above 32 bits (I think they "reverted" that with msys2/MINGW-packages#6907), d1x-rebirth would crash calling `midi_callback()`. Debugging showed Windows calling the "correct" address, but truncated to 32 bits, which of course worked fine with a lower image base.

Now with these patches, d{1,2}x-rebirth will build and run on x86_64. Sorry, I don't have the i686 toolchain installed anymore to test that platform.

A quick-and-dirty grepping of the codebase didn't find any other suspicious casts. I am by no means fluent in python or C++, and I don't know if any of this will break builds on MSVC or whatever else, so advice and criticism are welcome.