### PR TITLE
always init extra_bitmap_num in load_exit_models

### DIFF
--- a/similar/main/bm.cpp
+++ b/similar/main/bm.cpp
@@ -694,6 +694,10 @@ int load_exit_models()
 		bm_free_extra_models(LevelSharedPolygonModelState);
 		bm_free_extra_objbitmaps();
 	}
+	else if (!Exit_bitmaps_loaded)
+	{
+		extra_bitmap_num = Num_bitmap_files;
+	}
 
 	// make sure there is enough space to load textures and models
 	if (!Exit_bitmaps_loaded && N_ObjBitmaps > ObjBitmaps.size() - 6)


### PR DESCRIPTION
Commit cb2b844 and subsequent commits changed load_exit_models to only
call bm_free_extra_objbitmaps if EMULATING_D1. The variable
extra_bitmap_num is initialized as a side effect of
bm_free_extra_objbitmaps, so it wasn't initialized anymore if
not EMULATING_D1. This broke the exit sequence with the
D2 Mac Demo data and add-on missions with custom exit sequences.
This commit adds initialization of extra_bitmap_num if not EMULATING_D1
to fix the exit handling.