### PR TITLE
Instructions for building with MSYS2

### DIFF
--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -69,6 +69,9 @@ previous Rebirth release and installing current PhysFS headers.
 However, building from source is recommended to ensure a consistent
 environment.
 
+#### MSYS2/mingw-w64 (Windows alternate method)
+* `pacman -S git ${MINGW_PACKAGE_PREFIX}-{gcc,pkgconf,scons,SDL,SDL_image,SDL_mixer,libpng,physfs}`
+
 #### Linux
 Install the listed prerequisites through your system package manager.
 * Arch PKGBUILD files are in `contrib/arch/`
@@ -207,6 +210,24 @@ Linux output with **program\_name** unset:
 
 * *build-directory*/d1x-rebirth/d1x-rebirth*[-editor]*
 * *build-directory*/d2x-rebirth/d2x-rebirth*[-editor]*
+
+##### Compiling with MSYS2
+MSYS2 offers its users three terminal environments: msys2, for building with POSIX compatibility (linking to runtime `/usr/bin/msys-2.0.dll`); and mingw32 and mingw64, for building portable native Windows apps (linking to `C:\WINDOWS\System32\msvcrt.dll`), on i686 and x86_64 respectively.
+* Install [MSYS2](https://www.msys2.org), following the directions on the main page.
+* In either a mingw32 or mingw64 (not msys2) terminal:
+
+      pacman -Syuu  # update MSYS2, as needed
+      pacman -S --needed git ${MINGW_PACKAGE_PREFIX}-{gcc,pkgconf,scons,SDL,SDL_image,SDL_mixer,libpng,physfs}
+        #  ^ substitute SDL2 for SDL if desired
+      git clone https://github.com/dxx-rebirth/dxx-rebirth.git
+      cd dxx-rebirth
+      scons
+        # Or (for example) to build d1x only, with SDL 2, with lower process priority, on all cores:
+      time nice scons -j$(nproc) sdl2=1 d1x=1
+
+* A locally built executable will run anywhere if it's invoked from inside the appropriate mingw32 or mingw64 terminal. To run it instead directly in Windows, either:
+    1. The linked mingw-w64 libraries will need to be added to PATH (See [contrib/msys2](contrib/msys2) for working example batch files); or
+    2. Dependency DLLs from MSYS2 will need to be copied to the same directory as the executable.
 
 #### Installing
 For Windows and Linux, DXX-Rebirth installs only the main game binary.  The binary can be run from anywhere and can be installed by copying the game binary.  The game does not inspect the name of its binary.  You may rename the output after compilation without affecting the game.

--- a/contrib/msys2/README.md
+++ b/contrib/msys2/README.md
@@ -1,0 +1,7 @@
+### MSYS2 example batch files
+
+These scripts add the mingw-w64 DLL directory to `PATH`, then run a locally built copy of Descent. They assume MSYS2 is installed at its default location `C:\msys64`, along with dxx-rebirth's dependencies; see the [MSYS2 build instructions](../../INSTALL.markdown#compiling-with-msys2).
+
+How to use:
+* Copy the appropriate batch file to the same directory as the executable you just built. For example, put `d2x-64bit.bat` along with your 64-bit build of `d2x-rebirth.exe` in the Descent 2 data directory.
+* Run the batch file.

--- a/contrib/msys2/d1x-32bit.bat
+++ b/contrib/msys2/d1x-32bit.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+PATH=C:\msys64\mingw32\bin;%PATH%
+d1x-rebirth.exe

--- a/contrib/msys2/d1x-64bit.bat
+++ b/contrib/msys2/d1x-64bit.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+PATH=C:\msys64\mingw64\bin;%PATH%
+d1x-rebirth.exe

--- a/contrib/msys2/d2x-32bit.bat
+++ b/contrib/msys2/d2x-32bit.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+PATH=C:\msys64\mingw32\bin;%PATH%
+d2x-rebirth.exe

--- a/contrib/msys2/d2x-64bit.bat
+++ b/contrib/msys2/d2x-64bit.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+PATH=C:\msys64\mingw64\bin;%PATH%
+d2x-rebirth.exe


### PR DESCRIPTION
First commit: it was always `BIN_DIR`, not `BINDIR`, as far as I can tell. Just something I noticed a while back while learning to build this project natively.

Second commit: This is the simplest way I've found to build dxx-rebirth on Windows. I welcome nitpicks if you think the layout doesn't match the rest of the document or whatever.
