### PR TITLE
Fix legacy screenshot errors

### DIFF
--- a/similar/2d/pcx.cpp
+++ b/similar/2d/pcx.cpp
@@ -48,8 +48,6 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 namespace dcx {
 
-namespace {
-
 #if DXX_USE_SDLIMAGE
 struct RAII_SDL_Surface
 {
@@ -167,12 +165,9 @@ static pcx_result pcx_support_not_compiled(const char *const filename, grs_main_
 
 }
 
-}
 
 #if defined(DXX_BUILD_DESCENT_I)
 namespace dsx {
-
-namespace {
 
 #if DXX_USE_SDLIMAGE
 static std::pair<std::unique_ptr<uint8_t[]>, std::size_t> load_physfs_blob(const char *const filename)
@@ -214,8 +209,6 @@ static std::pair<std::unique_ptr<uint8_t[]>, std::size_t> load_decoded_physfs_bl
 	return {std::move(decoded_buffer), data_size};
 }
 #endif
-
-}
 
 pcx_result bald_guy_load(const char *const filename, grs_main_bitmap &bmp, palette_array_t &palette)
 {

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -900,7 +900,7 @@ void save_screen_shot(int automap_flag)
 #if DXX_USE_SCREENSHOT_FORMAT_PNG
 	write_error = write_screenshot_png(file, tm, grd_curscreen->sc_canvas.cv_bitmap, pal);
 #elif DXX_USE_SCREENSHOT_FORMAT_LEGACY
-	write_error = pcx_write_bitmap(file, &temp_canv->cv_bitmap, pal);
+	write_error = static_cast<unsigned>(pcx_write_bitmap(file, &temp_canv->cv_bitmap, pal));
 #endif
 #endif
 	}


### PR DESCRIPTION
Currently (commit 5bc927b) the build fails with `scons screenshot=legacy`. There are two compilation errors:

- missing cast from `pcx_result` to `unsigned` in `similar/main/game.cpp`
- visibility problems for `pcx_encode_line` and `pcx_encode_byte` in `similar/2d/pcx.cpp`

The first problem is certainly a missing cast. As for the second one, I just removed the anonymous namespace wrapped around the problematic functions. Supposedly, a better fix is possible which preserves the namespace. Feel free to tell me how you prefer this to be fixed, or drop this PR and implement both fixes yourself.
