### PR TITLE
Stereo patch

### DIFF
--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -136,7 +136,8 @@ DXX-Rebirth can be built from the Terminal (via SCons) without Xcode; to build u
  sdl\_mixer
  physfs
  libpng
- pkg-config**
+ pkg-config
+ dylibbundler**
 
 ### Building
 Once prerequisites are installed, run **scons** *options* to build.  By default, both D1X-Rebirth and D2X-Rebirth are built.  To build only D1X-Rebirth, run **scons d1x=1**.  To build only D2X-Rebirth, run **scons d2x=1**.

--- a/SConstruct
+++ b/SConstruct
@@ -5254,6 +5254,10 @@ class DXXProgram(DXXCommon):
 					typecode='APPL', creator='DCNT',
 					icon_file=os.path.join(cocoa, '%s-rebirth.icns' % dxxstr),
 					resources=[[os.path.join(self.srcdir, s), s] for s in ['English.lproj/InfoPlist.strings']])
+			if not self.user_settings.macos_add_frameworks:
+				Command('%s.app/Contents/libs' % self.PROGRAM_NAME,
+						'%s.app/Contents/MacOS/%s-rebirth' % (self.PROGRAM_NAME, dxxstr),
+						"dylibbundler -od -b -x $SOURCE -d $TARGET")
 
 class D1XProgram(DXXProgram):
 	LazyObjectState = DXXProgram.LazyObjectState

--- a/common/include/args.h
+++ b/common/include/args.h
@@ -100,6 +100,8 @@ struct CArg : prohibit_void_ptr<CArg>
 	bool DbgGlGetTexLevelParamOk;
 	bool DbgGlLuminance4Alpha4Ok;
 	bool DbgGlRGBA2Ok;
+	bool OglStereo;
+	uint8_t OglStereoView;
 	unsigned OglSyncWait;
 #else
 	bool DbgSdlHWSurface;

--- a/common/include/ogl_init.h
+++ b/common/include/ogl_init.h
@@ -68,6 +68,7 @@ void ogl_loadbmtexture_f(grs_bitmap &bm, opengl_texture_filter texfilt, bool tex
 void ogl_freebmtexture(grs_bitmap &bm);
 
 void ogl_start_frame(grs_canvas &);
+void ogl_stereo_frame(int xeye, int xoff);
 void ogl_end_frame(void);
 void ogl_set_screen_mode(void);
 

--- a/common/main/game.h
+++ b/common/main/game.h
@@ -200,8 +200,6 @@ enum StereoFormat : uint8_t {
 };
 
 extern int  VR_stereo;
-extern bool VR_half_width;
-extern bool VR_half_height;
 extern fix  VR_eye_width;
 extern int  VR_eye_offset;
 extern grs_canvas VR_hud_left;

--- a/common/main/game.h
+++ b/common/main/game.h
@@ -189,6 +189,23 @@ struct d_game_unique_state
 extern int Global_missile_firing_count;
 
 extern int PaletteRedAdd, PaletteGreenAdd, PaletteBlueAdd;
+
+// Stereo viewport formats
+enum StereoFormat : uint8_t {
+	STEREO_NONE=0,
+	STEREO_ABOVE_BELOW,
+	STEREO_SIDE_BY_SIDE,
+	STEREO_SIDE_BY_SIDE2,
+	STEREO_MAX_FORMAT
+};
+
+extern int  VR_stereo;
+extern bool VR_half_width;
+extern bool VR_half_height;
+extern fix  VR_eye_width;
+extern int  VR_eye_offset;
+extern grs_canvas VR_hud_left;
+extern grs_canvas VR_hud_right;
 }
 
 #define MAX_PALETTE_ADD 30
@@ -205,6 +222,7 @@ extern game_window *Game_wind;
 
 void game();
 void init_game();
+void init_stereo();
 void init_cockpit();
 extern void PALETTE_FLASH_ADD(int dr, int dg, int db);
 

--- a/common/main/game.h
+++ b/common/main/game.h
@@ -196,12 +196,14 @@ enum StereoFormat : uint8_t {
 	STEREO_ABOVE_BELOW,
 	STEREO_SIDE_BY_SIDE,
 	STEREO_SIDE_BY_SIDE2,
+	STEREO_ABOVE_BELOW_SYNC,
 	STEREO_MAX_FORMAT
 };
 
 extern int  VR_stereo;
 extern fix  VR_eye_width;
 extern int  VR_eye_offset;
+extern int  VR_sync_width;
 extern grs_canvas VR_hud_left;
 extern grs_canvas VR_hud_right;
 }

--- a/common/main/kconfig.h
+++ b/common/main/kconfig.h
@@ -29,7 +29,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "joy.h"
 #include "dxxsconf.h"
 
-#ifdef __cplusplus
+#include "maths.h"
 #include <vector>
 #include "fwd-event.h"
 #include "strutil.h"
@@ -208,5 +208,4 @@ using joybutton_text_t = joystick_text_t<number_to_text_length<DXX_MAX_JOYSTICKS
 extern joybutton_text_t joybutton_text;
 
 }
-#endif
 #endif

--- a/common/main/powerup.h
+++ b/common/main/powerup.h
@@ -28,8 +28,6 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "dxxsconf.h"
 #include "fwd-vclip.h"
 #include "fmtcheck.h"
-
-#ifdef __cplusplus
 #include "fwd-object.h"
 
 #if defined(DXX_BUILD_DESCENT_I) || defined(DXX_BUILD_DESCENT_II)
@@ -148,19 +146,10 @@ int do_powerup(vmobjptridx_t obj);
 
 //process (animate) a powerup for one frame
 void do_powerup_frame(const d_vclip_array &Vclip, vmobjptridx_t obj);
-}
-#endif
-#endif
 
-// Diminish shields and energy towards max in case they exceeded it.
-extern void diminish_towards_max(void);
-
-#ifdef dsx
-namespace dsx {
-extern void do_megawow_powerup(int quantity);
+void do_megawow_powerup(object &plrobj, int quantity);
 
 void powerup_basic_str(int redadd, int greenadd, int blueadd, int score, const char *str) __attribute_nonnull();
 }
 #endif
-
 #endif

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1324,6 +1324,7 @@ void ogl_stereo_frame(int xeye, int xoff)
 			// center unsqueezed side-by-side format
 			case STEREO_SIDE_BY_SIDE2:
 				ogl_stereo_viewport[1] -= ogl_stereo_viewport[3]/2;		// y = h/4
+				DXX_BOOST_FALLTHROUGH;
 			// half-width viewports for side-by-side format
 			case STEREO_SIDE_BY_SIDE:
 				ogl_stereo_viewport[0] += ogl_stereo_viewport[2];		// x = w/2

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1338,14 +1338,11 @@ void ogl_stereo_frame(const int xeye, const int xoff)
 				ogl_stereo_viewport[0] += ogl_stereo_viewport[2];		// x = w/2
 				break;
 			// half-height viewports for above/below format
-			case STEREO_ABOVE_BELOW_SYNC: {
-				int dy = VR_sync_width/2;
-				ogl_stereo_viewport[1] -= ogl_stereo_viewport[3];		// y = h/2
-				ogl_stereo_viewport[3] -= dy;
-				}
-				break;
+			case STEREO_ABOVE_BELOW_SYNC:
 			case STEREO_ABOVE_BELOW:
 				ogl_stereo_viewport[1] -= ogl_stereo_viewport[3];		// y = h/2
+				if (VR_stereo == STEREO_ABOVE_BELOW_SYNC)
+					ogl_stereo_viewport[3] -= VR_sync_width/2;
 				break;
 			}
 			glViewport(ogl_stereo_viewport[0], ogl_stereo_viewport[1], ogl_stereo_viewport[2], ogl_stereo_viewport[3]);

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -140,7 +140,6 @@ static std::array<ogl_texture, 20000> ogl_texture_list;
 static int ogl_texture_list_cur;
 
 static GLboolean 	ogl_stereo_enabled = false;
-static std::array<GLint, 4> 		ogl_stereo_viewport;
 static std::array<GLfloat, 16>  	ogl_stereo_transform;
 
 /* some function prototypes */
@@ -1289,7 +1288,7 @@ void ogl_start_frame(grs_canvas &canvas)
 	glLoadIdentity();//clear matrix
 }
 
-void ogl_stereo_frame(int xeye, int xoff)
+void ogl_stereo_frame(const int xeye, const int xoff)
 {
 	float dxoff = xoff * 2.0f / grd_curscreen->sc_canvas.cv_bitmap.bm_w;
 
@@ -1300,11 +1299,12 @@ void ogl_stereo_frame(int xeye, int xoff)
 		// left eye view
 		if (ogl_stereo_enabled)
 			glDrawBuffer(GL_BACK_LEFT);
-		else {
+		else if (VR_stereo == STEREO_SIDE_BY_SIDE2)
+		{
+			std::array<GLint, 4> ogl_stereo_viewport;
 			glGetIntegerv(GL_VIEWPORT, ogl_stereo_viewport.data());
 			// center unsqueezed side-by-side format
-			if (VR_stereo == STEREO_SIDE_BY_SIDE2)
-				ogl_stereo_viewport[1] -= ogl_stereo_viewport[3]/2;		// y = h/4
+			ogl_stereo_viewport[1] -= ogl_stereo_viewport[3]/2;		// y = h/4
 			glViewport(ogl_stereo_viewport[0], ogl_stereo_viewport[1], ogl_stereo_viewport[2], ogl_stereo_viewport[3]);
 		}
 		// rightward image shift adjustment for left eye offset
@@ -1319,6 +1319,7 @@ void ogl_stereo_frame(int xeye, int xoff)
 		if (ogl_stereo_enabled)
 			glDrawBuffer(GL_BACK_RIGHT);
 		else {
+			std::array<GLint, 4> ogl_stereo_viewport;
 			glGetIntegerv(GL_VIEWPORT, ogl_stereo_viewport.data());
 			switch (VR_stereo) {
 			// center unsqueezed side-by-side format

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1340,10 +1340,10 @@ void ogl_stereo_frame(const int xeye, const int xoff)
 			// half-height viewports for above/below format
 			case STEREO_ABOVE_BELOW_SYNC: {
 				int dy = VR_sync_width/2;
+				ogl_stereo_viewport[1] -= ogl_stereo_viewport[3];		// y = h/2
 				ogl_stereo_viewport[3] -= dy;
-				ogl_stereo_viewport[1] -= dy;
 				}
-				DXX_BOOST_FALLTHROUGH;
+				break;
 			case STEREO_ABOVE_BELOW:
 				ogl_stereo_viewport[1] -= ogl_stereo_viewport[3];		// y = h/2
 				break;

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1301,12 +1301,21 @@ void ogl_stereo_frame(const int xeye, const int xoff)
 	const auto left_eye = xeye < 0;
 	if (left_eye) {
 		// left eye view
-		if (!ogl_stereo_enabled && VR_stereo == STEREO_SIDE_BY_SIDE2)
+		if (!ogl_stereo_enabled)
 		{
 			std::array<GLint, 4> ogl_stereo_viewport;
 			glGetIntegerv(GL_VIEWPORT, ogl_stereo_viewport.data());
 			// center unsqueezed side-by-side format
-			ogl_stereo_viewport[1] -= ogl_stereo_viewport[3]/2;		// y = h/4
+			switch (VR_stereo) {
+			case STEREO_SIDE_BY_SIDE2:
+				ogl_stereo_viewport[1] -= ogl_stereo_viewport[3]/2;		// y = h/4
+				break;
+			case STEREO_ABOVE_BELOW_SYNC:
+				int dy = VR_sync_width/2;
+				ogl_stereo_viewport[3] -= dy;
+				ogl_stereo_viewport[1] += dy;
+				break;
+			}
 			glViewport(ogl_stereo_viewport[0], ogl_stereo_viewport[1], ogl_stereo_viewport[2], ogl_stereo_viewport[3]);
 		}
 		// rightward image shift adjustment for left eye offset
@@ -1329,6 +1338,12 @@ void ogl_stereo_frame(const int xeye, const int xoff)
 				ogl_stereo_viewport[0] += ogl_stereo_viewport[2];		// x = w/2
 				break;
 			// half-height viewports for above/below format
+			case STEREO_ABOVE_BELOW_SYNC: {
+				int dy = VR_sync_width/2;
+				ogl_stereo_viewport[3] -= dy;
+				ogl_stereo_viewport[1] -= dy;
+				}
+				DXX_BOOST_FALLTHROUGH;
 			case STEREO_ABOVE_BELOW:
 				ogl_stereo_viewport[1] -= ogl_stereo_viewport[3];		// y = h/2
 				break;

--- a/similar/main/collide.cpp
+++ b/similar/main/collide.cpp
@@ -780,24 +780,21 @@ static window_event_result collide_weapon_and_wall(
 		multi_digi_link_sound_to_pos(SOUND_FORCEFIELD_BOUNCE_WEAPON, hitseg, 0, hitpt, 0, f1_0);
 		return window_event_result::ignored;	//bail here. physics code will bounce this object
 	}
+#endif
 
 	#ifndef NDEBUG
 	if (keyd_pressed[KEY_LAPOSTRO])
 		if (weapon->ctype.laser_info.parent_num == get_local_player().objnum) {
 			//	MK: Real pain when you need to know a seg:side and you've got quad lasers.
 			HUD_init_message(HM_DEFAULT, "Hit at segment = %hu, side = %i", static_cast<vmsegptridx_t::integral_type>(hitseg), hitwall);
+#if defined(DXX_BUILD_DESCENT_II)
 			if (get_weapon_id(weapon) < 4)
 				subtract_light(LevelSharedDestructibleLightState, hitseg, hitwall);
 			else if (get_weapon_id(weapon) == weapon_id_type::FLARE_ID)
 				add_light(LevelSharedDestructibleLightState, hitseg, hitwall);
-		}
-
-		//@@#ifdef EDITOR
-		//@@Cursegp = &Segments[hitseg];
-		//@@Curside = hitwall;
-		//@@#endif
-	#endif
 #endif
+		}
+	#endif
 
 	if ((weapon->mtype.phys_info.velocity.x == 0) && (weapon->mtype.phys_info.velocity.y == 0) && (weapon->mtype.phys_info.velocity.z == 0)) {
 		Int3();	//	Contact Matt: This is impossible.  A weapon with 0 velocity hit a wall, which doesn't move.

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -252,6 +252,10 @@ void init_cockpit()
 	}
 #endif
 
+	// Hack to keep stereo formats remaining fullscreen
+	if (VR_stereo && PlayerCfg.CockpitMode[1] != CM_FULL_SCREEN)
+		PlayerCfg.CockpitMode[1] = CM_FULL_SCREEN;
+
 	gr_set_default_canvas();
 
 	switch( PlayerCfg.CockpitMode[1] ) {

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -189,6 +189,7 @@ screen_mode Game_screen_mode = initial_large_game_screen_mode;
 int  VR_stereo = false;
 fix  VR_eye_width = F1_0;
 int  VR_eye_offset = 0;
+int  VR_sync_width = 20;
 grs_canvas VR_hud_left;
 grs_canvas VR_hud_right;
 }
@@ -208,6 +209,7 @@ void init_stereo()
 		{
 			case STEREO_NONE:
 			case STEREO_ABOVE_BELOW:
+			case STEREO_ABOVE_BELOW_SYNC:
 				VR_eye_offset = full_width_eye_offset;
 				break;
 			case STEREO_SIDE_BY_SIDE:
@@ -216,6 +218,7 @@ void init_stereo()
 				break;
 		}
 		VR_eye_width = (F1_0 * 7) / 10;	// Descent 1.5 defaults
+		VR_sync_width = (20 * SHEIGHT) / 480;
 		PlayerCfg.CockpitMode[1] = CM_FULL_SCREEN;
 	}
 	else {
@@ -282,6 +285,7 @@ void init_cockpit()
 						/* Preserve height */
 						break;
 					case STEREO_ABOVE_BELOW:
+					case STEREO_ABOVE_BELOW_SYNC:
 						/* Preserve width */
 						/* Change height */
 						h /= 2;
@@ -353,6 +357,7 @@ void game_init_render_sub_buffers( int x, int y, int w, int h )
 	if (VR_stereo) {
 		// offset HUD screen rects to force out-of-screen parallax on HUD overlays
 		int dx = (VR_eye_offset < 0) ? -VR_eye_offset : 0;
+		int dy = VR_sync_width / 2;
 		switch (VR_stereo) {
 		case STEREO_NONE:
 			gr_init_sub_canvas(VR_hud_left,  grd_curscreen->sc_canvas, x+dx, y, w-dx, h);
@@ -361,6 +366,10 @@ void game_init_render_sub_buffers( int x, int y, int w, int h )
 		case STEREO_ABOVE_BELOW:
 			gr_init_sub_canvas(VR_hud_left,  grd_curscreen->sc_canvas, x+dx, y, w-dx, h);
 			gr_init_sub_canvas(VR_hud_right, grd_curscreen->sc_canvas, x, y+h, w-dx, h);
+			break;
+		case STEREO_ABOVE_BELOW_SYNC:
+			gr_init_sub_canvas(VR_hud_left,  grd_curscreen->sc_canvas, x+dx, y, w-dx, h-dy);
+			gr_init_sub_canvas(VR_hud_right, grd_curscreen->sc_canvas, x, y+h+dy, w-dx, h-dy);
 			break;
 		case STEREO_SIDE_BY_SIDE:
 			gr_init_sub_canvas(VR_hud_left,  grd_curscreen->sc_canvas, x+dx, y, w-dx, h);

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -252,10 +252,6 @@ void init_cockpit()
 	}
 #endif
 
-	// Hack to keep stereo formats remaining fullscreen
-	if (VR_stereo && PlayerCfg.CockpitMode[1] != CM_FULL_SCREEN)
-		PlayerCfg.CockpitMode[1] = CM_FULL_SCREEN;
-
 	gr_set_default_canvas();
 
 	switch( PlayerCfg.CockpitMode[1] ) {
@@ -338,6 +334,10 @@ void init_cockpit()
 //selects a given cockpit (or lack of one).  See types in game.h
 void select_cockpit(cockpit_mode_t mode)
 {
+	// skip switching cockpit views while stereo viewport active
+	if (VR_stereo && mode != CM_FULL_SCREEN)
+		return;
+
 	if (mode != PlayerCfg.CockpitMode[1]) {		//new mode
 		PlayerCfg.CockpitMode[1]=mode;
 		init_cockpit();

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -399,6 +399,8 @@ static void format_time(char (&str)[9], unsigned secs_int, unsigned hours_extra)
 	snprintf(str, sizeof(str), "%1u:%02u:%02u", h, m, s);
 }
 
+#ifndef RELEASE
+#if DXX_USE_EDITOR
 struct choose_curseg_menu_items
 {
 	std::array<char, 40> caption;
@@ -443,6 +445,8 @@ window_event_result choose_curseg_menu::event_handler(const d_event &event)
 	}
 	return newmenu::event_handler(event);
 }
+#endif
+#endif
 
 }
 

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -912,6 +912,37 @@ static window_event_result HandleSystemKey(int key)
 			break;
 #endif
 
+#if DXX_USE_OGL
+		case KEY_SHIFTED + KEY_F5:
+			VR_eye_offset -= 1;
+			reset_cockpit();
+			break;
+		case KEY_SHIFTED + KEY_F6:
+			VR_eye_offset += 1;
+			reset_cockpit();
+			break;
+		case KEY_SHIFTED + KEY_ALTED + KEY_F5:
+			VR_eye_width -= (F1_0/10); //*= 10/11;
+			reset_cockpit();
+			break;
+		case KEY_SHIFTED + KEY_ALTED + KEY_F6:
+			VR_eye_width += (F1_0/10); //*= 11/10;
+			reset_cockpit();
+			break;
+		case KEY_SHIFTED + KEY_F7:
+		case KEY_SHIFTED + KEY_ALTED + KEY_F7:
+			VR_eye_width = F1_0;
+			VR_eye_offset = 0;
+			reset_cockpit();
+			break;
+		case KEY_SHIFTED + KEY_F8:
+		case KEY_SHIFTED + KEY_ALTED + KEY_F8:
+			++VR_stereo %= STEREO_MAX_FORMAT;
+			init_stereo();
+			reset_cockpit();
+			break;
+#endif
+
 			/*
 			 * Jukebox hotkeys -- MD2211, 2007
 			 * Now for all music

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -143,7 +143,7 @@ struct pause_window : ::dcx::pause_window
 };
 
 #ifndef RELEASE
-static void do_cheat_menu();
+static void do_cheat_menu(object &plrobj, grs_canvas &cv_canvas);
 static void play_test_sound();
 #endif
 
@@ -1423,13 +1423,20 @@ static window_event_result HandleTestKey(fvmsegptridx &vmsegptridx, int key, con
 #endif
 
 		case KEY_DEBUGGED + KEY_C:
-			do_cheat_menu();
+		{
+			auto &plrobj = get_local_plrobj();
+			do_cheat_menu(plrobj, grd_curscreen->sc_canvas);
 			break;
+		}
 		case KEY_DEBUGGED + KEY_SHIFTED + KEY_A:
-			do_megawow_powerup(10);
+		{
+			auto &plrobj = get_local_plrobj();
+			do_megawow_powerup(plrobj, 10);
 			break;
+		}
 		case KEY_DEBUGGED + KEY_A:	{
-			do_megawow_powerup(200);
+			auto &plrobj = get_local_plrobj();
+			do_megawow_powerup(plrobj, 200);
 				break;
 		}
 
@@ -1806,7 +1813,7 @@ static window_event_result FinalCheats()
 		HUD_init_message(HM_DEFAULT, "Rapid fire %s!", cheats.rapidfire?TXT_ON:TXT_OFF);
 #if defined(DXX_BUILD_DESCENT_I)
                 if (cheats.rapidfire)
-                        do_megawow_powerup(200);
+					do_megawow_powerup(plrobj, 200);
 #endif
 	}
 
@@ -2024,12 +2031,9 @@ int wimp_menu::subfunction_handler(const d_event &event)
 	return 0;
 }
 
-static void do_cheat_menu()
+static void do_cheat_menu(object &plrobj, grs_canvas &cv_canvas)
 {
-	auto &Objects = LevelUniqueObjectState.Objects;
-	auto &vmobjptr = Objects.vmptr;
-	auto &plrobj = get_local_plrobj();
-	auto menu = window_create<wimp_menu>(plrobj, grd_curscreen->sc_canvas);
+	auto menu = window_create<wimp_menu>(plrobj, cv_canvas);
 	(void)menu;
 }
 #endif

--- a/similar/main/gamemine.cpp
+++ b/similar/main/gamemine.cpp
@@ -292,6 +292,7 @@ uint16_t convert_d1_tmap_num(const uint16_t d1_tmap_num)
 	case 368: return 395;
 	case 369: return 396;
 	case 370:  return  d1_pig_present ? 195 : 392; // mntr04d (devil: -1)
+	case 570: return 635;
 	// range 371..584 handled by default case (wall01 and door frames)
 	default:
 		// ranges:

--- a/similar/main/gamerend.cpp
+++ b/similar/main/gamerend.cpp
@@ -778,7 +778,7 @@ int BigWindowSwitch=0;
 //render a frame for the game
 void game_render_frame_mono(const control_info &Controls)
 {
-	int no_draw_hud=0;
+	int no_draw_hud = 0;
 
 	gr_set_current_canvas(Screen_3d_window);
 #if defined(DXX_BUILD_DESCENT_II)
@@ -803,7 +803,12 @@ void game_render_frame_mono(const control_info &Controls)
 
 		window_rendered_data window;
 		update_rendered_data(window, *Viewer, 0);
-		render_frame(*grd_curcanv, 0, window);
+		if (VR_stereo) {
+			render_frame(*grd_curcanv, -VR_eye_width, window);
+			render_frame(*grd_curcanv, +VR_eye_width, window);
+		}
+		else
+			render_frame(*grd_curcanv, 0, window);
 
 		wake_up_rendered_objects(*Viewer, window);
 		show_HUD_names(*grd_curcanv);
@@ -838,7 +843,12 @@ void game_render_frame_mono(const control_info &Controls)
 #if defined(DXX_BUILD_DESCENT_II)
 		update_rendered_data(window, *Viewer, Rear_view);
 #endif
-		render_frame(*grd_curcanv, 0, window);
+		if (VR_stereo) {
+			render_frame(*grd_curcanv, -VR_eye_width, window);
+			render_frame(*grd_curcanv, +VR_eye_width, window);
+		}
+		else
+			render_frame(*grd_curcanv, 0, window);
 	}
 
 #if defined(DXX_BUILD_DESCENT_II)
@@ -857,8 +867,14 @@ void game_render_frame_mono(const control_info &Controls)
 		Game_mode = GM_NORMAL;
 
 	gr_set_current_canvas(Screen_3d_window);
-	if (!no_draw_hud)
-		game_draw_hud_stuff(*grd_curcanv, Controls);
+	if (!no_draw_hud) {
+		if (VR_stereo) {
+			game_draw_hud_stuff(VR_hud_left, Controls);
+			game_draw_hud_stuff(VR_hud_right, Controls);
+		}
+		else
+			game_draw_hud_stuff(*grd_curcanv, Controls);
+	}
 
 #if defined(DXX_BUILD_DESCENT_II)
 	gr_set_default_canvas();
@@ -876,7 +892,7 @@ void toggle_cockpit()
 {
 	enum cockpit_mode_t new_mode=CM_FULL_SCREEN;
 
-	if (Rear_view || Player_dead_state != player_dead_state::no)
+	if (Rear_view || Player_dead_state != player_dead_state::no || VR_stereo)
 		return;
 
 	switch (PlayerCfg.CockpitMode[1])

--- a/similar/main/inferno.cpp
+++ b/similar/main/inferno.cpp
@@ -205,6 +205,11 @@ static void print_commandline_help()
 		VERB("                                    5: Auto: if VSync is enabled and ARB_sync is supported, use mode 2, otherwise mode 0\n")	\
 		VERB("  -gl_syncwait <n>              Wait interval (ms) for sync mode 2 (default: " DXX_STRINGIZE(OGL_SYNC_WAIT_DEFAULT) ")\n")	\
 		VERB("  -gl_darkedges                 Re-enable dark edges around filtered textures (as present in earlier versions of the engine)\n")	\
+		VERB("  -gl_stereo                    Enable OpenGL stereo quad buffering, if available\n")	\
+		VERB("  -gl_stereoview <n>            Select OpenGL stereo viewport mode\n")	\
+		VERB("                                    1: above/below half-height format\n")	\
+		VERB("                                    2: side/by/side half-width format\n")	\
+		VERB("                                    3: side/by/side half-size format, normal aspect ratio\n") \
 	)	\
 	DXX_if_defined_01(DXX_USE_UDP, (	\
 		VERB("\n Multiplayer:\n\n")	\

--- a/similar/main/inferno.cpp
+++ b/similar/main/inferno.cpp
@@ -221,7 +221,8 @@ static void print_commandline_help()
 		VERB("                                    1: above/below half-height format\n")	\
 		VERB("                                    2: side/by/side half-width format\n")	\
 		VERB("                                    3: side/by/side half-size format, normal aspect ratio\n") \
-	))	\
+		VERB("                                    4: above/below format with external sync blank interval\n")	\
+		))	\
 	)	\
 	DXX_if_defined_01(DXX_USE_UDP, (	\
 		VERB("\n Multiplayer:\n\n")	\

--- a/similar/main/inferno.cpp
+++ b/similar/main/inferno.cpp
@@ -129,9 +129,19 @@ static void print_commandline_help()
 
 #define DXX_if_defined_placeholder1	,
 #define DXX_if_defined_unwrap(A,...)	A, ## __VA_ARGS__
+	/* If the parameter V, after macro expansion, evaluates to `1`, then
+	 * expand to the parameter F.  Otherwise, expand to nothing.
+	 */
 #define DXX_if_defined(V,F)	DXX_if_defined2(V,F)
+	/* If the parameter V, after macro expansion, evaluates to anything
+	 * other than `1`, then expand to the parameter F.  Otherwise,
+	 * expand to nothing.
+	 */
+#define DXX_if_not_defined_to_1(V,F)	DXX_if_not_defined_to_1_2(V,F)
 #define DXX_if_defined2(V,F)	DXX_if_defined3(DXX_if_defined_placeholder##V, F)
+#define DXX_if_not_defined_to_1_2(V,F)	DXX_if_not_defined_to_1_3(DXX_if_defined_placeholder##V, F)
 #define DXX_if_defined3(V,F)	DXX_if_defined4(F, V 1, 0)
+#define DXX_if_not_defined_to_1_3(V,F)	DXX_if_defined4(F, V 0, 1)
 #define DXX_if_defined4(F,_,V,...)	DXX_if_defined5_##V(F)
 #define DXX_if_defined5_0(F)
 #define DXX_if_defined5_1(F)	DXX_if_defined_unwrap F
@@ -205,11 +215,13 @@ static void print_commandline_help()
 		VERB("                                    5: Auto: if VSync is enabled and ARB_sync is supported, use mode 2, otherwise mode 0\n")	\
 		VERB("  -gl_syncwait <n>              Wait interval (ms) for sync mode 2 (default: " DXX_STRINGIZE(OGL_SYNC_WAIT_DEFAULT) ")\n")	\
 		VERB("  -gl_darkedges                 Re-enable dark edges around filtered textures (as present in earlier versions of the engine)\n")	\
+		DXX_if_not_defined_to_1(RELEASE, (	\
 		VERB("  -gl_stereo                    Enable OpenGL stereo quad buffering, if available\n")	\
-		VERB("  -gl_stereoview <n>            Select OpenGL stereo viewport mode\n")	\
+		VERB("  -gl_stereoview <n>            Select OpenGL stereo viewport mode (experimental; incomplete)\n")	\
 		VERB("                                    1: above/below half-height format\n")	\
 		VERB("                                    2: side/by/side half-width format\n")	\
 		VERB("                                    3: side/by/side half-size format, normal aspect ratio\n") \
+	))	\
 	)	\
 	DXX_if_defined_01(DXX_USE_UDP, (	\
 		VERB("\n Multiplayer:\n\n")	\

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -2248,17 +2248,17 @@ window_event_result browser::callback_handler(const d_event &event, window_event
 		{
 			if (event_key_get(event) == KEY_CTRLED + KEY_D)
 			{
-				char text[4] = "c";
+				std::array<char, 4> text{{"c"}};
 				int rval = 0;
 
 				std::array<newmenu_item, 1> m{{
 					nm_item_input(text),
 				}};
 				rval = newmenu_do2(menu_title{nullptr}, menu_subtitle{"Enter drive letter"}, m, unused_newmenu_subfunction, unused_newmenu_userdata);
-				text[1] = '\0';
+				const auto t0 = text[0];
 				std::array<char, PATH_MAX> newpath;
-				snprintf(newpath.data(), newpath.size(), "%s:%s", text, sep);
-				if (!rval && text[0])
+				snprintf(newpath.data(), newpath.size(), "%c:%s", t0, sep);
+				if (!rval && t0)
 				{
 					select_file_recursive(title, newpath, ext_range, select_dir, userdata);
 					// close old box.

--- a/similar/main/powerup.cpp
+++ b/similar/main/powerup.cpp
@@ -153,12 +153,10 @@ void powerup_basic_str(int redadd, int greenadd, int blueadd, int score, const c
 
 //#ifndef RELEASE
 //	Give the megawow powerup!
-void do_megawow_powerup(int quantity)
+void do_megawow_powerup(object &plrobj, const int quantity)
 {
-	auto &Objects = LevelUniqueObjectState.Objects;
-	auto &vmobjptr = Objects.vmptr;
 	powerup_basic(30, 0, 30, 1, "MEGA-WOWIE-ZOWIE!");
-	auto &player_info = get_local_plrobj().ctype.player_info;
+	auto &player_info = plrobj.ctype.player_info;
 #if defined(DXX_BUILD_DESCENT_I)
 	player_info.primary_weapon_flags = (HAS_LASER_FLAG | HAS_VULCAN_FLAG | HAS_SPREADFIRE_FLAG | HAS_PLASMA_FLAG | HAS_FUSION_FLAG);
 #elif defined(DXX_BUILD_DESCENT_II)
@@ -174,7 +172,7 @@ void do_megawow_powerup(int quantity)
 		i = quantity/5;
 
 	player_info.energy = F1_0*200;
-	get_local_plrobj().shields = F1_0*200;
+	plrobj.shields = F1_0*200;
 	player_info.powerup_flags |= PLAYER_FLAGS_QUAD_LASERS;
 #if defined(DXX_BUILD_DESCENT_I)
 	const auto laser_level = MAX_LASER_LEVEL;
@@ -662,7 +660,7 @@ int do_powerup(const vmobjptridx_t obj)
 			}
 	#ifndef RELEASE
 		case	POW_MEGAWOW:
-			do_megawow_powerup(50);
+			do_megawow_powerup(plrobj, 50);
 			used = 1;
 			break;
 	#endif

--- a/similar/main/render.cpp
+++ b/similar/main/render.cpp
@@ -1215,6 +1215,12 @@ void render_frame(grs_canvas &canvas, fix eye_offset, window_rendered_data &wind
   
 	g3_start_frame(canvas);
 
+#if DXX_USE_OGL
+	// select stereo viewport/transform/buffer per left/right eye
+	if (VR_stereo)
+		ogl_stereo_frame(eye_offset, VR_eye_offset);
+#endif
+
 	auto Viewer_eye = Viewer->pos;
 
 //	if (Viewer->type == OBJ_PLAYER && (PlayerCfg.CockpitMode[1]!=CM_REAR_VIEW))

--- a/similar/misc/args.cpp
+++ b/similar/misc/args.cpp
@@ -153,6 +153,8 @@ static void InitGameArg()
 #if DXX_USE_OGL
 	CGameArg.OglSyncMethod = OGL_SYNC_METHOD_DEFAULT;
 	CGameArg.OglSyncWait = OGL_SYNC_WAIT_DEFAULT;
+	CGameArg.OglStereo = false;
+	CGameArg.OglStereoView = STEREO_NONE;
 	CGameArg.DbgGlIntensity4Ok 	= true;
 	CGameArg.DbgGlLuminance4Alpha4Ok = true;
 	CGameArg.DbgGlRGBA2Ok = true;
@@ -293,6 +295,10 @@ static void ReadCmdArgs(Inilist &ini, Arglist &Args)
 			CGameArg.OglSyncWait = arg_integer(pp, end);
 		else if (!d_stricmp(p, "-gl_darkedges"))
 			CGameArg.OglDarkEdges = true;
+		else if (!d_stricmp(p, "-gl_stereo"))
+			CGameArg.OglStereo = true;
+		else if (!d_stricmp(p, "-gl_stereoview"))
+			CGameArg.OglStereoView = arg_integer(pp, end);
 #endif
 
 	// Multiplayer Options


### PR DESCRIPTION
Prepared stereo-patch for re-introducing basic stereo rendering based on Descent 1.5 StereoGraphics/SimulEyes port. 
Let me know if this patch might better be suited for separate branch for time being. 

Initially attempted to support OGL stereo quad buffering for GL_STEREO capable graphics boards + LCS glasses, which might not be getting properly supported in SDL layer. Active via '-gl_stereo' option.

Then added fallback stereo rendering mode for half-height and half-width formats. Side-by-side formats were typical for HMDs, and above/below format was amenable to LCS glasses + sync doublers. Active via '-gl_stereoview [1..3]' options.

Disabled all planar graphics elements like cockpit, status bar, and HUD elements to avoid interference with stereo rendered views. (HUD effects in Descent 1.5 were handled with forced parallax to match stereo depth effects.) No attempt at special handling for popup dialogs/menus or auto-map either, as these required graphics mode switches in Descent 1.5.

Used available function keys SHIFT/ALT F5..F8 for adjusting stereo parallax parameters and resetting stereo modes. Simplified adjustments for viewpoint separation + image shift without automatic recalculations per Bob Akka port. 

Noticed from changelogs that all the 'VR_' stuff had been removed, so had to put a couple 'VR_' globals back. VR_eye_width + VR_eye_offset retain their original meaning for viewpoint separation + image shift adjustment.