### PR TITLE
Embed dylibs in app bundles

### DIFF
--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -136,7 +136,8 @@ DXX-Rebirth can be built from the Terminal (via SCons) without Xcode; to build u
  sdl\_mixer
  physfs
  libpng
- pkg-config**
+ pkg-config
+ dylibbundler**
 
 ### Building
 Once prerequisites are installed, run **scons** *options* to build.  By default, both D1X-Rebirth and D2X-Rebirth are built.  To build only D1X-Rebirth, run **scons d1x=1**.  To build only D2X-Rebirth, run **scons d2x=1**.

--- a/SConstruct
+++ b/SConstruct
@@ -5255,7 +5255,7 @@ class DXXProgram(DXXCommon):
 					icon_file=os.path.join(cocoa, '%s-rebirth.icns' % dxxstr),
 					resources=[[os.path.join(self.srcdir, s), s] for s in ['English.lproj/InfoPlist.strings']])
 			if not self.user_settings.macos_add_frameworks:
-				Command('%s.app/Contents/Frameworks' % self.PROGRAM_NAME,
+				Command('%s.app/Contents/libs' % self.PROGRAM_NAME,
 						'%s.app/Contents/MacOS/%s-rebirth' % (self.PROGRAM_NAME, dxxstr),
 						"dylibbundler -od -b -x $SOURCE -d $TARGET")
 

--- a/SConstruct
+++ b/SConstruct
@@ -5254,6 +5254,10 @@ class DXXProgram(DXXCommon):
 					typecode='APPL', creator='DCNT',
 					icon_file=os.path.join(cocoa, '%s-rebirth.icns' % dxxstr),
 					resources=[[os.path.join(self.srcdir, s), s] for s in ['English.lproj/InfoPlist.strings']])
+			if not self.user_settings.macos_add_frameworks:
+				Command('%s.app/Contents/Frameworks' % self.PROGRAM_NAME,
+						'%s.app/Contents/MacOS/%s-rebirth' % (self.PROGRAM_NAME, dxxstr),
+						"dylibbundler -od -b -x $SOURCE -d $TARGET")
 
 class D1XProgram(DXXProgram):
 	LazyObjectState = DXXProgram.LazyObjectState


### PR DESCRIPTION
I'm having trouble figuring out how to test for the existence of a binary named `dylibbundler` on the system path, but these changes implement steps 6 and 7 from https://github.com/dxx-rebirth/dxx-rebirth/issues/561 and add a note about the additional dependency in INSTALL.markdown.