### PR TITLE
Added test for dylibbundler on macOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2901,7 +2901,7 @@ BOOST_AUTO_TEST_CASE(f)
 		dylibbundler_output = os.popen('dylibbundler -h').read()
 		if 'dylibbundler is a utility' not in dylibbundler_output:
 			context.Result('no')
-			raise SCons.Errors.StopError('dylibbundler is required for compilation on macOS when not using frameworks')
+			raise SCons.Errors.StopError('dylibbundler is required for compilation for a macOS target when not using frameworks')
 		context.Result('yes')
 		return
 

--- a/SConstruct
+++ b/SConstruct
@@ -2889,9 +2889,9 @@ BOOST_AUTO_TEST_CASE(f)
 			self.check_boost_test(context)
 
 	# dylibbundler is used to embed libraries into macOS app bundles,
-	# however it's only available on macOS.  While required for macOS
-	# builds, builds should not fail on other operating systems if
-	# it's absent.
+	# however it's only meaningful for macOS builds, and, for those,
+	# only required when frameworks are not used for the build.  Builds
+	# should not fail on other operating system targets if it's absent.
 	@_custom_test
 	def _check_dylibbundler(self,context):
 		context.Display('%s: checking whether dylibbundler is installed...' % self.msgprefix)

--- a/SConstruct
+++ b/SConstruct
@@ -2901,7 +2901,7 @@ BOOST_AUTO_TEST_CASE(f)
 		dylibbundler_output = os.popen('dylibbundler -h').read()
 		if 'dylibbundler is a utility' not in dylibbundler_output and not self.user_settings.macos_add_frameworks:
 			context.Result('no')
-			raise SCons.Errors.StopError('dylibbundler is required for compilation on macOS')
+			raise SCons.Errors.StopError('dylibbundler is required for compilation on macOS when not using frameworks')
 		context.Result('yes')
 		return
 

--- a/SConstruct
+++ b/SConstruct
@@ -2888,6 +2888,23 @@ BOOST_AUTO_TEST_CASE(f)
 		if register_runtime_test_link_targets:
 			self.check_boost_test(context)
 
+	# dylibbundler is used to embed libraries into macOS app bundles,
+	# however it's only available on macOS.  While required for macOS
+	# builds, builds should not fail on other operating systems if
+	# it's absent.
+	@_custom_test
+	def _check_dylibbundler(self,context):
+		context.Display('%s: checking whether dylibbundler is installed...' % self.msgprefix)
+		if sys.platform != 'darwin':
+			context.Result('n/a')
+			return True
+		dylibbundler_output = os.popen('dylibbundler -h').read()
+		if 'dylibbundler is a utility' not in dylibbundler_output:
+			context.Result('no')
+			raise SCons.Errors.StopError('dylibbundler is required for compilation on macOS\n')
+		context.Result('yes')
+		return True
+
 	# This must be the last custom test.  It does not test the environment,
 	# but is responsible for reversing test-environment-specific changes made
 	# by check_cxx_works.

--- a/SConstruct
+++ b/SConstruct
@@ -2895,15 +2895,15 @@ BOOST_AUTO_TEST_CASE(f)
 	@_custom_test
 	def _check_dylibbundler(self,context):
 		context.Display('%s: checking whether dylibbundler is installed...' % self.msgprefix)
-		if sys.platform != 'darwin':
+		if self.user_settings.host_platform != 'darwin':
 			context.Result('n/a')
-			return True
+			return
 		dylibbundler_output = os.popen('dylibbundler -h').read()
-		if 'dylibbundler is a utility' not in dylibbundler_output:
+		if 'dylibbundler is a utility' not in dylibbundler_output and not self.user_settings.macos_add_frameworks:
 			context.Result('no')
-			raise SCons.Errors.StopError('dylibbundler is required for compilation on macOS\n')
+			raise SCons.Errors.StopError('dylibbundler is required for compilation on macOS')
 		context.Result('yes')
-		return True
+		return
 
 	# This must be the last custom test.  It does not test the environment,
 	# but is responsible for reversing test-environment-specific changes made

--- a/SConstruct
+++ b/SConstruct
@@ -414,6 +414,7 @@ class ConfigureTests(_ConfigureTests):
 	_implicit_test = Collector()
 	_custom_test = Collector()
 	_guarded_test_windows = GuardedCollector(_custom_test, lambda user_settings: user_settings.host_platform == 'win32')
+	_guarded_test_darwin = GuardedCollector(_custom_test, lambda user_settings: user_settings.host_platform == 'darwin')
 	implicit_tests = _implicit_test.tests
 	custom_tests = _custom_test.tests
 	comment_not_supported = '/* not supported */'
@@ -2892,10 +2893,10 @@ BOOST_AUTO_TEST_CASE(f)
 	# however it's only meaningful for macOS builds, and, for those,
 	# only required when frameworks are not used for the build.  Builds
 	# should not fail on other operating system targets if it's absent.
-	@_custom_test
+	@_guarded_test_darwin
 	def _check_dylibbundler(self,context):
 		context.Display('%s: checking whether dylibbundler is installed...' % self.msgprefix)
-		if self.user_settings.host_platform != 'darwin' or self.user_settings.macos_add_frameworks:
+		if self.user_settings.macos_add_frameworks:
 			context.Result('n/a')
 			return
 		dylibbundler_output = os.popen('dylibbundler -h').read()

--- a/SConstruct
+++ b/SConstruct
@@ -2899,7 +2899,7 @@ BOOST_AUTO_TEST_CASE(f)
 			context.Result('n/a')
 			return
 		dylibbundler_output = os.popen('dylibbundler -h').read()
-		if 'dylibbundler is a utility' not in dylibbundler_output and not self.user_settings.macos_add_frameworks:
+		if 'dylibbundler is a utility' not in dylibbundler_output:
 			context.Result('no')
 			raise SCons.Errors.StopError('dylibbundler is required for compilation on macOS when not using frameworks')
 		context.Result('yes')

--- a/SConstruct
+++ b/SConstruct
@@ -2895,7 +2895,7 @@ BOOST_AUTO_TEST_CASE(f)
 	@_custom_test
 	def _check_dylibbundler(self,context):
 		context.Display('%s: checking whether dylibbundler is installed...' % self.msgprefix)
-		if self.user_settings.host_platform != 'darwin':
+		if self.user_settings.host_platform != 'darwin' or self.user_settings.macos_add_frameworks:
 			context.Result('n/a')
 			return
 		dylibbundler_output = os.popen('dylibbundler -h').read()


### PR DESCRIPTION
Since macOS builds now fail if dylibbundler isn't installed, this adds a simple test to verify that it exists and is executable.