### PR TITLE
Fix door lock/unlock triggers causing a crash when given an invalid wall location

### DIFF
--- a/similar/main/switch.cpp
+++ b/similar/main/switch.cpp
@@ -132,6 +132,8 @@ static void do_unlock_doors(fvcsegptr &vcsegptr, fvmwallptr &vmwallptr, const tr
 {
 	const auto op = [&vmwallptr](const shared_segment &segp, const unsigned sidenum) {
 		const auto wall_num = segp.sides[sidenum].wall_num;
+		if (wall_num == wall_none)
+			return;
 		auto &w = *vmwallptr(wall_num);
 		w.flags &= ~WALL_DOOR_LOCKED;
 		w.keys = wall_key::none;
@@ -144,6 +146,8 @@ static void do_lock_doors(fvcsegptr &vcsegptr, fvmwallptr &vmwallptr, const trig
 {
 	const auto op = [&vmwallptr](const shared_segment &segp, const unsigned sidenum) {
 		const auto wall_num = segp.sides[sidenum].wall_num;
+		if (wall_num == wall_none)
+			return;
 		auto &w = *vmwallptr(wall_num);
 		w.flags |= WALL_DOOR_LOCKED;
 	};


### PR DESCRIPTION
Currently, a door locking or unlocking trigger will cause a crash if given a location where there isn't a wall. This is not inline with original behaviour, as it seemingly ignores these (or at least doesn't crash consistently). This should (hopefully; it certainly seems to in my testing) make Rebirth simply ignore such invalid triggers instead.