### PR TITLE
Fix rendering of "classic reboot" crosshair

### DIFF
--- a/similar/main/gauges.cpp
+++ b/similar/main/gauges.cpp
@@ -3146,7 +3146,7 @@ void show_reticle(grs_canvas &canvas, const player_info &player_info, int reticl
 		}
 		case RET_TYPE_CLASSIC_REBOOT:
 #if DXX_USE_OGL
-			ogl_draw_vertex_reticle(*grd_curcanv, cross_bm_num,primary_bm_num,secondary_bm_num,BM_XRGB(PlayerCfg.ReticleRGBA[0],PlayerCfg.ReticleRGBA[1],PlayerCfg.ReticleRGBA[2]),PlayerCfg.ReticleRGBA[3],PlayerCfg.ReticleSize);
+			ogl_draw_vertex_reticle(canvas, cross_bm_num,primary_bm_num,secondary_bm_num,BM_XRGB(PlayerCfg.ReticleRGBA[0],PlayerCfg.ReticleRGBA[1],PlayerCfg.ReticleRGBA[2]),PlayerCfg.ReticleRGBA[3],PlayerCfg.ReticleSize);
 #endif
 			return;
 		case RET_TYPE_X:


### PR DESCRIPTION
When the a number of functions were updated in commit bb29e6fca85dcdfb73cc0cf9f8e1f9d02ad992f3 to have a canvas passed to them, the "classic reboot" crosshair became severely misaligned when either the status bar or full HUD were active (as it was drawn as though the game was in full screen); this change appears to fix the problem (although my inexperience with the system in question may result in it not being the optimal fix).