### PR TITLE
Fix compilation on ARM Macs and make dylibbundler an optional step

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -5288,7 +5288,7 @@ class DXXProgram(DXXCommon):
 					icon_file=os.path.join(cocoa, '%s-rebirth.icns' % dxxstr),
 					resources=[[os.path.join(self.srcdir, s), s] for s in ['English.lproj/InfoPlist.strings']])
 			if self.user_settings.macos_bundle_libs and not self.user_settings.macos_add_frameworks:
-				print('Bundling libraries for  %s' % self.PROGRAM_NAME)
+				print('Bundling libraries for %s' % self.PROGRAM_NAME)
 				dylibbundler_process = StaticSubprocess.pcall(('dylibbundler', '-od', '-b', '-x', '%s.app/Contents/MacOS/%s-rebirth' % (self.PROGRAM_NAME, dxxstr), '-d', '%s.app/Contents/libs' % self.PROGRAM_NAME))
 
 class D1XProgram(DXXProgram):

--- a/SConstruct
+++ b/SConstruct
@@ -5288,6 +5288,7 @@ class DXXProgram(DXXCommon):
 					icon_file=os.path.join(cocoa, '%s-rebirth.icns' % dxxstr),
 					resources=[[os.path.join(self.srcdir, s), s] for s in ['English.lproj/InfoPlist.strings']])
 			if self.user_settings.macos_bundle_libs and not self.user_settings.macos_add_frameworks:
+				print('Bundling libraries for  %s' % self.PROGRAM_NAME)
 				dylibbundler_process = StaticSubprocess.pcall(('dylibbundler', '-od', '-b', '-x', '%s.app/Contents/MacOS/%s-rebirth' % (self.PROGRAM_NAME, dxxstr), '-d', '%s.app/Contents/libs' % self.PROGRAM_NAME))
 
 class D1XProgram(DXXProgram):

--- a/SConstruct
+++ b/SConstruct
@@ -5294,7 +5294,7 @@ class DXXProgram(DXXCommon):
 					icon_file=os.path.join(cocoa, '%s-rebirth.icns' % dxxstr),
 					resources=[[os.path.join(self.srcdir, s), s] for s in ['English.lproj/InfoPlist.strings']])
 			bundledir = bundledir_list[0]
-			appfile = SCons.Node.FS.default_fs.File(str(bundledir.Dir('Contents/MacOS')) + '/%s-rebirth' % dxxstr)
+			appfile = bundledir.File('Contents/MacOS/%s-rebirth' % dxxstr)
 			if self.user_settings.macos_bundle_libs and not self.user_settings.macos_add_frameworks:
 				message(self, 'Bundling libraries for %s' % (str(bundledir),))
 				# If the user has set $PATH, use it in preference to the


### PR DESCRIPTION
I just got an ARM Mac, and found a couple of issues that don't exist on the Intel Mac builds.

First, it failed to compile due to the dylibbundler step.  Because the dylibbundler test used a different method for calling dylibbundler, it found it in the test but not in the actual call to use it to bundle libraries into the app bundle.  On ARM Macs, Homebrew is installed into a different location which requires adding a directory to the path in .zshrc (or equivalent file), which doesn't seem to be called in the previous method of using dylibbundler.  So, I updated it to use the same subprocess call that the test does, and inherit the same path settings.  This fixes the issue where the build process can't find dylibbundler during the build step, even though it found it during the test.

The other issue I found is that dylibbundler seems to give me binaries which just don't run on my ARM Mac.  The project is not maintained very well these days (per https://github.com/auriamg/macdylibbundler/issues/41#issuecomment-523246398), so while I will mention it upstream, it seemed that making this an optional step makes the most sense in the meantime.  To do that, I added `macos_bundle_libs` which defaults to `False`.  It will only use dylibbundler if `macos_use_frameworks` is `False` and `macos_bundle_libs` is `True`.