### PR TITLE
Updated enums and added define to silence deprecation warnings

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4178,6 +4178,7 @@ class DXXCommon(LazyObjectConstructor):
 				env.Append(FRAMEWORKS = ['SDL'])
 			if self.user_settings.opengl or self.user_settings.opengles:
 				env.Append(FRAMEWORKS = ['OpenGL'])
+				env.Append(CXXFLAGS = ['-DGL_SILENCE_DEPRECATION'])
 	# Settings to apply to Linux builds
 	class LinuxPlatformSettings(_PlatformSettings):
 		sharepath = '{prefix}/share/games/{program_target}'.format

--- a/common/arch/cocoa/messagebox.mm
+++ b/common/arch/cocoa/messagebox.mm
@@ -24,7 +24,7 @@ void display_cocoa_alert(const char *message, int error)
 {
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	NSAlert *alert = [[NSAlert alloc] init];
-	alert.alertStyle = error == 1 ? NSCriticalAlertStyle : NSWarningAlertStyle;
+	alert.alertStyle = error == 1 ? NSAlertStyleCritical : NSAlertStyleWarning;
 	alert.messageText = error ? @"Sorry, a critical error has occurred." : @"Attention!";
 	alert.informativeText = [NSString stringWithUTF8String:message];
 	


### PR DESCRIPTION
The way the code is today, it builds successfully on macOS, but it throws a bunch of deprecation warnings.  One of these is easy to fix (the enum changes in `messagebox.mm`), which just requires changing a couple of enums to the currently suggested names.  The actual underlying values are the same, but at some point the old enum names may be removed.  So, I updated those.  This does, however, raise the minimum supported macOS version to 10.12 (at least for compilation; since the underlying integer is the same, I expect it would still run on older versions, though I don't have any handy to test on).  Given that that's five years old at this point, I don't see it as too much of an issue, but I do want to mention it.

The other issue is trickier to properly fix.  Apple deprecated OpenGL on Macs a while back, and while they still include the libraries and frameworks for it, compiling code against OpenGL throws a warning.  At some point, that might be removed (in which case something like an OpenGL to Metal shim might be worth looking into), but for now, it works.  The warnings can be silenced by defining `GL_SILENCE_DEPRECATION`, so I added that to the SConstruct file.  Given how many of these warnings popped up, it would have been easy to miss other warnings in there.

With these changes, the code now builds cleanly on macOS without warnings.