### PR TITLE
Added high DPI flag to SDL 2.0 builds for macOS

### DIFF
--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -835,6 +835,9 @@ int gr_init()
 		sdl_window_flags |= SDL_WINDOW_BORDERLESS;
 	if (!CGameCfg.WindowMode && !CGameArg.SysWindow)
 		sdl_window_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+#if defined(__APPLE__) && defined(__MACH__)
+	sdl_window_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+#endif
 	const auto mode = Game_screen_mode;
 	const auto SDLWindow = SDL_CreateWindow(DESCENT_VERSION, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, SM_W(mode), SM_H(mode), sdl_window_flags);
 	if (!SDLWindow)


### PR DESCRIPTION
Most Macs made in the last several years (nearly a decade now) support some form of high DPI mode.  This enables using these machines' full resolutions in SDL 2.0 builds with an SDL 2.0.1-and-above flag.  Without this, the max resolution is half of the horizontal and half of the vertical resolution of the display (which then gets integer scaled by the system in both directions).