### PR TITLE
Send periodic endlevel packets after last level

### DIFF
--- a/similar/main/kmatrix.cpp
+++ b/similar/main/kmatrix.cpp
@@ -202,6 +202,7 @@ struct kmatrix_window : window
 	}
 	grs_main_bitmap background;
 	fix64 end_time = -1;
+	fix64 last_endlevel_time = 0;
 	kmatrix_network network;
 	kmatrix_result &result;
 };
@@ -414,6 +415,13 @@ window_event_result kmatrix_window::event_handler(const d_event &event)
 #endif
 				if (playing != kmatrix_status_mode::mission_finished)
 					return window_event_result::close;
+			}
+
+			// If Control_center_destroyed is still true this is handled by do_protocol_frame
+			if (timer_query() >= last_endlevel_time + F1_0 && !LevelUniqueObjectState.ControlCenterState.Control_center_destroyed)
+			{
+				last_endlevel_time = timer_query();
+				multi::dispatch->send_endlevel_packet();
 			}
 
 			kmatrix_status_msg(*grd_curcanv, playing == kmatrix_status_mode::reactor_countdown_running ? LevelUniqueControlCenterState.Countdown_seconds_left : f2i(end_time - timer_query()), playing);


### PR DESCRIPTION
Add periodic calls to send_endlevel_packet in kmatrix if
Control_center_destroyed is false.

Needed because after finishing the last level, kmatrix is called from a
different place where Control_center_destroyed is already false.

It looks like this issue was introduced in Rebirth 0.56 with the
split off of the ipx code (febe5d1). That commit removes the call to
multi_endlevel_poll2 from kmatrix_view, which did the same periodic
sends. (Maybe because in D1 Control_center_destroyed was always true
in kmatrix so it was not needed there.)

Reported-by: snytek <#520>
Fixes: febe5d1 ("Abstracting networking protocols")