### PR TITLE
Small enhancement: set console output priority to highest given option rather than most recently specified

### DIFF
--- a/similar/misc/args.cpp
+++ b/similar/misc/args.cpp
@@ -351,9 +351,15 @@ static void ReadCmdArgs(Inilist &ini, Arglist &Args)
 	// Debug Options
 
 		else if (!d_stricmp(p, "-debug"))
-			CGameArg.DbgVerbose 	= CON_DEBUG;
+		{
+			if (CGameArg.DbgVerbose < CON_DEBUG)
+				CGameArg.DbgVerbose = CON_DEBUG;
+		}
 		else if (!d_stricmp(p, "-verbose"))
-			CGameArg.DbgVerbose 	= CON_VERBOSE;
+		{
+			if (CGameArg.DbgVerbose < CON_VERBOSE)
+				CGameArg.DbgVerbose = CON_VERBOSE;
+		}
 
 		else if (!d_stricmp(p, "-no-grab"))
 			CGameArg.DbgForbidConsoleGrab = true;


### PR DESCRIPTION
Currently, if both the "-debug" and "-verbose" options are provided (as was the case for me recently when attempting to read output that had "debug" priority and being confused about it not appearing, as the existing behaviour was not clear), if the "-verbose" option is provided later than the "-debug" option, it will result in debug output not being shown. This fix ensures that debug output will always be shown if the option is provided.

(as the condition for the -debug option will always be true as it currently stands, it's possible that comparison is superfluous, however I included it for consistency)