### PR TITLE
Fix gl.h include location for macOS

### DIFF
--- a/common/include/3d.h
+++ b/common/include/3d.h
@@ -35,7 +35,11 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include <array>
 
 #if DXX_USE_OGL
+#if defined(__APPLE__) && defined(__MACH__)
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #endif
 
 #if DXX_USE_EDITOR


### PR DESCRIPTION
Commit https://github.com/dxx-rebirth/dxx-rebirth/commit/4fd412b2eabd1c412ede95ad1406b3226e2719b7 added an include line which refers to a header that's in a different location on macOS.  This adds a preprocessor condition to test for that and use the macOS location when compiling on macOS.