### PR TITLE
Added Brewfile and updated macOS compilation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ xcuserdata
 # PyCharm generated files #
 ###########################
 .idea
+
+# Brewfile installation artifacts
+#################################
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,16 @@
+# This should already be tapped, but just in case
+tap "homebrew/core"
+
+# Install dependencies
+brew "scons"
+brew "sdl"
+brew "sdl_image"
+brew "sdl_mixer"
+brew "sdl2"
+brew "sdl2_image"
+brew "sdl2_mixer"
+brew "libpng"
+brew "jpeg"
+brew "physfs"
+brew "pkg-config"
+brew "dylibbundler"

--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -127,15 +127,9 @@ from the Terminal.  This may need to be done after each major OS upgrade as well
 DXX-Rebirth can be built from the Terminal (via SCons) without Xcode; to build using Xcode requires Xcode to be installed.
 
 ##### [Homebrew](https://github.com/Homebrew/homebrew/)
-* **brew install
- scons
- sdl
- sdl\_image
- sdl\_mixer
- physfs
- libpng
- pkg-config
- dylibbundler**
+The project includes a Brewfile for installing all required dependencies, if you use Homebrew.  You can install them with:
+
+* **brew bundle**
 
 ### Building
 Once prerequisites are installed, run **scons** *options* to build.  By default, both D1X-Rebirth and D2X-Rebirth are built.  To build only D1X-Rebirth, run **scons d1x=1**.  To build only D2X-Rebirth, run **scons d2x=1**.


### PR DESCRIPTION
Homebrew has the notion of a "Brewfile", which is essentially a list of package repositories and packages to install with a single command.  It's typically used to install a full set of dependencies without requiring a user to type out an entire list.

So, I've created one here, and updated the documentation and ignore file to account for it.  I do have it installing both SDL 1.2 and SDL 2, as the project can be built with either, having them both installed doesn't cause issues, and they don't take up a whole lot of space.