### PR TITLE
Use Brewfile for macOS Github builds

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -22,7 +22,7 @@ jobs:
         
       - name: Install dependencies
         run: |
-          brew install scons sdl2 sdl2_image sdl2_mixer jpeg physfs pkg-config dylibbundler
+          brew bundle --verbose
           
       - name: Configure and build
         run: scons -j2 opengl=1 sdl2=1 sdlmixer=1 macos_add_frameworks=0 macos_bundle_libs=1


### PR DESCRIPTION
This one could probably benefit from input from @raptor, with the work they've done recently on the Github actions.

I did some thinking, and figured it'd make sense to move the dependency acquisition into a Brewfile (which has already been merged with the main tree here in https://github.com/dxx-rebirth/dxx-rebirth/pull/655) in order to minimize potential issues when somebody builds from source.  I was also thinking that it would make sense to use the same Brewfile for the Github action, so I updated the workflow on my branch, and it does seem to work just fine.  I generated and artifact in run https://github.com/Kreeblah/dxx-rebirth/runs/7850790479?check_suite_focus=true and can download and run the app bundles in it on my Mac just fine (both the D1X and D2X app bundles).

So, I think this has the opportunity to further reduce the separate configuration required for Github workflows vs. manual builds, since if another dependency is introduced down the road that has a Homebrew package available, it would just need to be added to the Brewfile for use in both the CI builds and manual builds.

I can't think of any undesirable side effects with this method, though I have to admit I'm not overly familiar with Github actions, so I don't know whether I just haven't found any.