### PR TITLE
Fix OpenGL ES build on SDL2.

### DIFF
--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -72,7 +72,7 @@ namespace dcx {
 
 static int ogl_brightness_r, ogl_brightness_g, ogl_brightness_b;
 
-#if DXX_USE_OGLES
+#if DXX_USE_OGLES && SDL_MAJOR_VERSION == 1
 static int sdl_video_flags;
 
 #ifdef RPI
@@ -125,7 +125,7 @@ void gr_set_mode_from_window_size()
 
 }
 
-#if DXX_USE_OGLES
+#if DXX_USE_OGLES && SDL_MAJOR_VERSION == 1 
 static EGLDisplay eglDisplay=EGL_NO_DISPLAY;
 static EGLConfig eglConfig;
 static EGLSurface eglSurface=EGL_NO_SURFACE;
@@ -154,7 +154,7 @@ namespace dcx {
 void ogl_swap_buffers_internal(void)
 {
 	sync_helper.before_swap();
-#if DXX_USE_OGLES
+#if DXX_USE_OGLES && SDL_MAJOR_VERSION == 1
 	eglSwapBuffers(eglDisplay, eglSurface);
 #else
 #if SDL_MAJOR_VERSION == 1
@@ -309,7 +309,7 @@ static int rpi_setup_element(int x, int y, Uint32 video_flags, int update)
 
 #endif // RPI
 
-#if DXX_USE_OGLES
+#if DXX_USE_OGLES && SDL_MAJOR_VERSION == 1
 static void ogles_destroy()
 {
 	if( eglDisplay != EGL_NO_DISPLAY ) {
@@ -338,7 +338,7 @@ static void ogles_destroy()
 
 static int ogl_init_window(int w, int h)
 {
-#if DXX_USE_OGLES
+#if DXX_USE_OGLES && SDL_MAJOR_VERSION == 1
 	SDL_SysWMinfo info;
 	Window    x11Window = 0;
 	Display*  x11Display = 0;
@@ -401,7 +401,7 @@ static int ogl_init_window(int w, int h)
 		SDL_SetWindowSize(SDLWindow, w, h);
 #endif
 
-#if DXX_USE_OGLES
+#if DXX_USE_OGLES && SDL_MAJOR_VERSION == 1
 #ifndef RPI
 	// NOTE: on the RPi, the EGL stuff is not connected to the X11 window,
 	//       so there is no need to destroy and recreate this
@@ -409,7 +409,7 @@ static int ogl_init_window(int w, int h)
 #endif
 
 	SDL_VERSION(&info.version);
-	
+
 	if (SDL_GetWMInfo(&info) > 0) {
 		if (info.subsystem == SDL_SYSWM_X11) {
 			x11Display = info.info.x11.display;
@@ -593,6 +593,7 @@ namespace dsx {
 
 static void ogl_tune_for_current(void)
 {
+#if !DXX_USE_OGLES
 	const auto gl_vendor = reinterpret_cast<const char *>(glGetString(GL_VENDOR));
 	const auto gl_renderer = reinterpret_cast<const char *>(glGetString(GL_RENDERER));
 	const auto gl_version = reinterpret_cast<const char *>(glGetString(GL_VERSION));
@@ -632,6 +633,7 @@ static void ogl_tune_for_current(void)
 		con_puts(CON_VERBOSE, "DXX-Rebirth: OpenGL: anisotropic texture filter not supported");
 		CGameCfg.TexAnisotropy = false;
 	}
+#endif
 }
 
 }
@@ -791,6 +793,10 @@ void gr_set_attributes(void)
 	}
 	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, buffers);
 	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, samples);
+#else
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 #endif
 	ogl_smash_texture_list_internal();
 	gr_remap_color_fonts();
@@ -822,6 +828,8 @@ int gr_init()
 	ogl_init_load_library();
 #endif
 
+	gr_set_attributes();
+
 #if SDL_MAJOR_VERSION == 1
 	if (!CGameCfg.WindowMode && !CGameArg.SysWindow)
 		sdl_video_flags|=SDL_FULLSCREEN;
@@ -848,8 +856,6 @@ int gr_init()
 	if (const auto window_icon = SDL_LoadBMP(DXX_SDL_WINDOW_ICON_BITMAP))
 		SDL_SetWindowIcon(SDLWindow, window_icon);
 #endif
-
-	gr_set_attributes();
 
 	ogl_init_texture_list_internal();
 
@@ -898,7 +904,7 @@ void gr_close()
 		OpenGL_LoadLibrary(false, OglLibPath);
 #endif
 
-#if DXX_USE_OGLES
+#if DXX_USE_OGLES && SDL_MAJOR_VERSION == 1
 	ogles_destroy();
 #ifdef RPI
 	con_printf(CON_DEBUG, "RPi: cleanuing up");

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1271,6 +1271,7 @@ void ogl_start_frame(grs_canvas &canvas)
 	glLoadIdentity();//clear matrix
 }
 
+#if !DXX_USE_OGLES
 void ogl_stereo_frame(const bool left_eye, const int xoff)
 {
 	const float dxoff = xoff * 2.0f / grd_curscreen->sc_canvas.cv_bitmap.bm_w;
@@ -1356,6 +1357,7 @@ void ogl_stereo_frame(const bool left_eye, const int xoff)
 	glLoadMatrixf(ogl_stereo_transform.data());
 	glMatrixMode(GL_MODELVIEW);
 }
+#endif
 
 void ogl_end_frame(void){
 	OGL_VIEWPORT(0, 0, grd_curscreen->get_screen_width(), grd_curscreen->get_screen_height());

--- a/similar/main/render.cpp
+++ b/similar/main/render.cpp
@@ -1260,7 +1260,7 @@ void render_frame(grs_canvas &canvas, fix eye_offset, window_rendered_data &wind
   
 	g3_start_frame(canvas);
 
-#if DXX_USE_OGL
+#if DXX_USE_OGL && !DXX_USE_OGLES
 	// select stereo viewport/transform/buffer per left/right eye
 	if (VR_stereo != StereoFormat::None && eye_offset)
 		ogl_stereo_frame(eye_offset < 0, VR_eye_offset);


### PR DESCRIPTION
This makes it possible to run DXX-Rebirth with OpenGL ES and SDL2 on devices such as Odroid Go Advance and similar. For a better experience more changes are needed (such as proper support for gamepad api and better menu functionality), but such discussion would happen somewhere else other than this patchset.