### PR TITLE
Require SDL 2 for macOS builds

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,9 +3,6 @@ tap "homebrew/core"
 
 # Install dependencies
 brew "scons"
-brew "sdl"
-brew "sdl_image"
-brew "sdl_mixer"
 brew "sdl2"
 brew "sdl2_image"
 brew "sdl2_mixer"

--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -126,10 +126,14 @@ from the Terminal.  This may need to be done after each major OS upgrade as well
 
 DXX-Rebirth can be built from the Terminal (via SCons) without Xcode; to build using Xcode requires Xcode to be installed.
 
+When building for Mac OS X, only SDL 2 is currently supported, as SDL 1.2 has long-standing issues with modern versions of the operating system.  Terminal builds for Mac OS X default to SDL 2, which is equivalent to passing **sdl2=True** as a parameter to the SCons command.
+
 ##### [Homebrew](https://github.com/Homebrew/homebrew/)
 The project includes a Brewfile for installing all required dependencies, if you use Homebrew.  You can install them with:
 
 * **brew bundle**
+
+**Note:** Because Homebrew only installs libraries and not frameworks, when building for Mac OS X with Homebrew-provided dependencies, you must provide **macos_add_frameworks=False** as a SCons command parameter in order for the build system to look for libraries rather than frameworks.
 
 ### Building
 Once prerequisites are installed, run **scons** *options* to build.  By default, both D1X-Rebirth and D2X-Rebirth are built.  To build only D1X-Rebirth, run **scons d1x=1**.  To build only D2X-Rebirth, run **scons d2x=1**.

--- a/SConstruct
+++ b/SConstruct
@@ -3572,7 +3572,7 @@ class DXXCommon(LazyObjectConstructor):
 				return True
 			return False
 		def default_sdl2(self):
-			if self.raspberrypi in ('mesa',):
+			if self.raspberrypi in ('mesa',) or self.host_platform == 'darwin':
 				return True
 			return False
 		@classmethod
@@ -4050,6 +4050,8 @@ class DXXCommon(LazyObjectConstructor):
 		# arguments are included.
 		tools = ('gcc', 'g++', 'applelink')
 		def adjust_environment(self,program,env):
+			if self.user_settings.sdl2 == False:
+				raise SCons.Errors.StopError('macOS builds do not support SDL 1.2.')
 			macos_add_frameworks = self.user_settings.macos_add_frameworks
 			if macos_add_frameworks:
 				# The user may or may not have a private installation of


### PR DESCRIPTION
This implements the Brewfile and documentation changes (information about SDL 2 and information about the `macos_add_frameworks` parameter when using Homebrew for dependency satisfaction), defaults macOS builds to SDL 2 and returns an error when attempting to build for macOS using SDL 1.2, per the conversation in https://github.com/dxx-rebirth/dxx-rebirth/issues/679.