### PR TITLE
Fix macOS compilation

### DIFF
--- a/common/include/partial_range.h
+++ b/common/include/partial_range.h
@@ -146,7 +146,7 @@ public:
 		 * and neither can be handled here.  These checks attempt to
 		 * catch obvious mistakes.
 		 */
-		requires(std::ranges::borrowed_range<T>)
+		requires(ranges::borrowed_range<T>)
 		partial_range_t(T &&t) :
 			m_begin(std::ranges::begin(t)), m_end(std::ranges::end(t))
 	{

--- a/common/main/d_enumerate.h
+++ b/common/main/d_enumerate.h
@@ -131,7 +131,7 @@ public:
 		 * fully consumed.  If `range_type &&` is an ephemeral range, then its
 		 * storage may cease to exist after this constructor returns.
 		 */
-		requires(std::ranges::borrowed_range<range_type>)
+		requires(ranges::borrowed_range<range_type>)
 		enumerate(range_type &&t, const index_type i = index_type{}) :
 			base_type(std::forward<range_type>(t)), m_idx(i)
 	{
@@ -151,5 +151,5 @@ template <typename range_iterator_type, typename range_sentinel_type, typename i
 inline constexpr bool std::ranges::enable_borrowed_range<enumerate<range_iterator_type, range_sentinel_type, index_type>> = true;
 
 template <typename range_type, typename index_type = decltype(d_enumerate::detail::array_index_type(static_cast<typename std::remove_reference<range_type>::type *>(nullptr)))>
-requires(std::ranges::borrowed_range<range_type>)
+requires(ranges::borrowed_range<range_type>)
 enumerate(range_type &&r, index_type start = {/* value ignored for deduction guide */}) -> enumerate</* range_iterator_type = */ decltype(std::ranges::begin(std::declval<range_type &>())), /* range_sentinel_type = */ decltype(std::ranges::end(std::declval<range_type &>())), index_type>;

--- a/common/main/d_zip.h
+++ b/common/main/d_zip.h
@@ -345,7 +345,7 @@ public:
 	template <typename... rangeN_type>
 		requires(
 			sizeof...(rangeN_type) > 0 &&
-			(std::ranges::borrowed_range<rangeN_type> && ...)
+			(ranges::borrowed_range<rangeN_type> && ...)
 		)
 		constexpr zip(rangeN_type &&... rN) :
 			iterator(std::ranges::begin(rN)...), m_end(d_zip::detail::capture_end_iterators<range_sentinel_type>(typename iterator::index_sequence_type(), rN...))


### PR DESCRIPTION
Looks like there are a couple instances of `std::ranges` that need to be switched over to the ranges backport for macOS compilation to succeed.