### PR TITLE
Fix or disable compiler warnings warnings

### DIFF
--- a/common/include/window.h
+++ b/common/include/window.h
@@ -21,6 +21,7 @@
 #include "console.h"
 
 #include <assert.h>
+#include <memory>
 
 #include "fwd-window.h"
 #include "event.h"
@@ -36,7 +37,7 @@ private:
 	class window *next = nullptr;				// the next window in the doubly linked list
 	uint8_t w_visible = 1;						// whether it's visible
 	uint8_t w_modal = 1;						// modal = accept all user input exclusively
-	bool *w_exists = nullptr;					// optional pointer to a tracking variable
+	std::shared_ptr<bool> w_exists;					// optional pointer to a tracking variable
 public:
 	explicit window(grs_canvas &src, int x, int y, int w, int h);
 	window(const window &) = delete;
@@ -85,9 +86,9 @@ public:
 		return wind.prev;
 	}
 
-	void track(bool *exists)
+	void track(std::shared_ptr<bool> exists)
 	{
-		assert(w_exists == nullptr);
+		assert(!w_exists);
 		w_exists = exists;
 	}
 };

--- a/common/main/newmenu.h
+++ b/common/main/newmenu.h
@@ -354,7 +354,7 @@ struct newmenu : newmenu_layout, window
 		newmenu_layout(title, subtitle, filename, src, tiny_mode, tabs_flag, citem_init, draw_box), window(src, x, y, w, h)
 	{
 	}
-	int *rval = nullptr;			// Pointer to return value (for polling newmenus)
+	std::shared_ptr<int> rval;		// Pointer to return value (for polling newmenus)
 	virtual window_event_result event_handler(const d_event &) override;
 	static int process_until_closed(newmenu *);
 };

--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -23,6 +23,8 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
  *
  */
 
+#include <memory>
+
 #include <string.h>
 #ifndef macintosh
 # include <sys/types.h>
@@ -379,8 +381,8 @@ movie_play_status RunMovie(const char *const filename, const std::span<const cha
 	}
 	const auto reshow = hide_menus();
 	auto wind = window_create<movie>(grd_curscreen->sc_canvas, std::move(mvestream));
-	bool exists = true;
-	wind->track(&exists);
+	auto window_exists = std::make_shared<bool>(true);
+	wind->track(window_exists);
 	init_subtitles(wind->SubtitleState, subtitles);
 
 #if DXX_USE_OGL
@@ -392,7 +394,7 @@ movie_play_status RunMovie(const char *const filename, const std::span<const cha
 	gr_set_mode(hires_flag ? screen_mode{640, 480} : screen_mode{320, 200});
 #endif
 
-	while (exists)
+	while (*window_exists)
 		event_process();
 	wind = nullptr;
 

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -2337,10 +2337,13 @@ window_event_result browser::callback_handler(const d_event &event, window_event
 			{
 				const size_t len_newpath = strlen(newpath.data());
 				const size_t len_item = strlen(list[citem]);
-				if (len_newpath + len_item < newpath.size())
+				// Add a separator if the path doesn't already end with one.
+				const size_t len_sep = strlen(sep);
+				const char* sep_to_add = strncmp(&newpath[len_newpath - len_sep], sep, len_sep) ? sep : "";
+				const size_t len_sep_to_add = (sep_to_add == sep) ? len_sep : 0;
+				if (len_newpath + len_item + len_sep_to_add < newpath.size())
 				{
-					const size_t len_sep = strlen(sep);
-					snprintf(&newpath[len_newpath], newpath.size() - len_newpath, "%s%s", strncmp(&newpath[len_newpath - len_sep], sep, len_sep) ? sep : "", list[citem]);
+					snprintf(&newpath[len_newpath], newpath.size() - len_newpath, "%s%s", sep_to_add, list[citem]);
 				}
 			}
 			if ((citem == 0) || PHYSFS_isDirectory(list[citem]))

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -534,22 +534,22 @@ int newmenu_do2(const menu_title title, const menu_subtitle subtitle, const rang
 
 int newmenu::process_until_closed(newmenu *const menu)
 {
-	bool exists = true;
-	int rval = -1;
-	menu->rval = &rval;
+	auto rval_ptr = std::make_shared<int>(-1);
+	menu->rval = rval_ptr;
 	// Track to see when the window is freed
 	// Doing this way in case another window is opened on top without its own polling loop
-	menu->track(&exists);
+	auto window_exists = std::make_shared<bool>(true);
+	menu->track(window_exists);
 
 	// newmenu_do2 and simpler get their own event loop
 	// This is so the caller doesn't have to provide a callback that responds to EVENT_NEWMENU_SELECTED
-	while (exists)
+	while (*window_exists)
 		event_process();
 
 	/* menu is now a pointer to freed memory, and cannot be accessed
 	 * further
 	 */
-	return rval;
+	return *rval_ptr;
 }
 
 namespace {

--- a/similar/main/render.cpp
+++ b/similar/main/render.cpp
@@ -1048,7 +1048,12 @@ static void sort_seg_children(fvcvertptr &vcvertptr, const vms_vector &Viewer_ey
 	{
 		return compare_children(vcvertptr, Viewer_eye, seg, a, b);
 	};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+		// gcc produces invalid bounds checks when sorting arrays of size 6 due to a compiler optimization bug.
+		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107986
 		std::sort(r.begin(), r.end(), predicate);
+#pragma GCC diagnostic pop
 }
 
 static void add_obj_to_seglist(render_state_t &rstate, objnum_t objnum, segnum_t segnum)


### PR DESCRIPTION
The flatpak default build setup enables some extra warnings with -Werror. They had 4 failures: 2 of them detected valid bounds checking mistakes, 1 complained about some technically correct but dangerous code that I thought was worth changing, and 1 I had to disable because it was triggering a compiler bug in GCC 12.x.