### PR TITLE
Use macos-12 in github macOS workflow

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -12,7 +12,7 @@ on:
 jobs:          
   macos:
     name: macOS Apps
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Clone repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Needed since the macos-11 compiler doesn't support std::ranges.