### PR TITLE
Make sure SDL2 uses specified audio format

### DIFF
--- a/similar/arch/sdl/digi_mixer.cpp
+++ b/similar/arch/sdl/digi_mixer.cpp
@@ -124,7 +124,11 @@ int digi_mixer_init()
 #endif
 	if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0) Error("SDL audio initialisation failed: %s.", SDL_GetError());
 
+#if SDL_MAJOR_VERSION == 1
 	if (Mix_OpenAudio(digi_sample_rate, MIX_OUTPUT_FORMAT, MIX_OUTPUT_CHANNELS, SOUND_BUFFER_SIZE))
+#else
+	if (Mix_OpenAudioDevice(digi_sample_rate, MIX_OUTPUT_FORMAT, MIX_OUTPUT_CHANNELS, SOUND_BUFFER_SIZE, NULL, 0))
+#endif
 	{
 		//edited on 10/05/98 by Matt Mueller - should keep running, just with no sound.
 		con_printf(CON_URGENT,"\nError: Couldn't open audio: %s", SDL_GetError());


### PR DESCRIPTION
Use extended open function Mix_OpenAudioDevice to set allowed_changes to 0.
Prevents higher pitched sound on Windows.