### PR TITLE
Fix Apple Clang errors and warnings

### DIFF
--- a/common/main/cli.cpp
+++ b/common/main/cli.cpp
@@ -320,7 +320,7 @@ void CLIState::execute_active_line()
 	const char *p = m_line.c_str();
 	con_printf(CON_NORMAL, "con%c%s", g_prompt_strings[0], p);
 	cmd_append(p);
-	m_lines[0] = move(m_line);
+	m_lines[0] = std::move(m_line);
 	m_lines.emplace_front();
 	m_history_position = 0;
 	if (m_lines.size() > m_maximum_history_lines)
@@ -394,7 +394,7 @@ void CLIState::history_move(unsigned position)
 {
 	if (position >= m_lines.size())
 		return;
-	m_lines[m_history_position] = move(m_line);
+	m_lines[m_history_position] = std::move(m_line);
 	auto &l = m_lines[m_history_position = position];
 	m_line_position = l.size();
 	m_line = l;

--- a/similar/2d/font.cpp
+++ b/similar/2d/font.cpp
@@ -1030,7 +1030,7 @@ static std::unique_ptr<grs_font> gr_internal_init_font(const char *fontname)
 	//set curcanv vars
 
 	auto &ft_filename = font->ft_filename;
-	font->ft_allocdata = move(ft_allocdata);
+	font->ft_allocdata = std::move(ft_allocdata);
 	strncpy(&ft_filename[0], fontname, ft_filename.size());
 	return font;
 }

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -287,7 +287,6 @@ static void ogl_texture_stats(grs_canvas &canvas)
 {
 	int used = 0, usedother = 0, usedidx = 0, usedrgb = 0, usedrgba = 0;
 	int databytes = 0, truebytes = 0;
-	int prio0=0,prio1=0,prio2=0,prio3=0,prioh=0;
 	GLint idx, r, g, b, a, dbl, depth;
 	int res, colorsize, depthsize;
 	range_for (auto &i, ogl_texture_list)
@@ -296,11 +295,6 @@ static void ogl_texture_stats(grs_canvas &canvas)
 			used++;
 			databytes+=i.bytesu;
 			truebytes+=i.bytes;
-			if (i.prio<0.299)prio0++;
-			else if (i.prio<0.399)prio1++;
-			else if (i.prio<0.499)prio2++;
-			else if (i.prio<0.599)prio3++;
-			else prioh++;
 			if (i.format == GL_RGBA)
 				usedrgba++;
 			else if (i.format == GL_RGB)

--- a/similar/main/multi.cpp
+++ b/similar/main/multi.cpp
@@ -4179,13 +4179,10 @@ static void multi_do_drop_blob(fvmobjptr &vmobjptr, const playernum_t pnum)
 
 void multi_send_sound_function (char whichfunc, char sound)
 {
-	int count=0;
-
-	count++;
 	multi_command<multiplayer_command_t::MULTI_SOUND_FUNCTION> multibuf;
-	multibuf[1]=Player_num;             count++;
-	multibuf[2]=whichfunc;              count++;
-	multibuf[3] = sound; count++;       // this would probably work on the PC as well.  Jason?
+	multibuf[1]=Player_num;
+	multibuf[2]=whichfunc;
+	multibuf[3] = sound;       // this would probably work on the PC as well.  Jason?
 	multi_send_data(multibuf, multiplayer_data_priority::_2);
 }
 

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -1302,7 +1302,6 @@ namespace {
 
 static void newmenu_create_structure(newmenu_layout &menu, const grs_font &cv_font)
 {
-	int nmenus;
 	auto &canvas = menu.parent_canvas;
 
 	auto iterative_layout_max_width = 0u;
@@ -1329,7 +1328,6 @@ static void newmenu_create_structure(newmenu_layout &menu, const grs_font &cv_fo
 	int aw = 0;
 	auto iterative_layout_body_width = 0u;
 	const auto initial_layout_height = iterative_layout_max_height;
-	nmenus = 0;
 
 	const auto &&fspacx = FSPACX();
 	const auto &&fspacy = FSPACY();
@@ -1343,9 +1341,6 @@ static void newmenu_create_structure(newmenu_layout &menu, const grs_font &cv_fo
 		const auto average_width = cv_font.ft_w;
 		auto [string_width, string_height] = gr_get_string_size(cv_font, i.text);
 		i.right_offset = 0;
-
-		if (i.type == nm_type::menu)
-			nmenus++;
 
 		if (i.type == nm_type::slider)
 		{
@@ -1394,7 +1389,6 @@ static void newmenu_create_structure(newmenu_layout &menu, const grs_font &cv_fo
 				auto &im = i.imenu();
 				im.group = 0;
 				im.saved_text.copy_if(i.text);
-				nmenus++;
 			}
 		}
 

--- a/similar/main/state.cpp
+++ b/similar/main/state.cpp
@@ -2440,7 +2440,6 @@ int state_restore_all_sub(const d_level_shared_destructible_light_state &LevelSh
 	{
 		player restore_players[MAX_PLAYERS];
 		object restore_objects[MAX_PLAYERS];
-		int coop_got_nplayers = 0;
 
 		for (playernum_t i = 0; i < MAX_PLAYERS; i++) 
 		{
@@ -2476,7 +2475,6 @@ int state_restore_all_sub(const d_level_shared_destructible_light_state &LevelSh
 					auto &p = *vmplayerptr(i);
 					p = restore_players[j];
 					coop_player_got[i] = 1;
-					coop_got_nplayers++;
 
 					const auto &&obj = vmobjptridx(vcplayerptr(i)->objnum);
 					// since a player always uses the same object, we just have to copy the saved object properties to the existing one. i hate you...


### PR DESCRIPTION
Xcode 14.3 was released a few days ago, which bumped Clang to 14.0.3 and libcxx to 15.x.  Some part of these changes caused compilation to generate some new warnings, with a few of those (the ones for set-but-unused variables) being promoted to errors.  This fixes those warnings, so the tree compiles cleanly on Apple Clang again.

Separately, the update also means that the ranges backports are no longer necessary for up-to-date versions of Apple Clang.  I was able to successfully compile the tree with the changes in this pull request and an additional change to set the preprocessor checks in `backports-ranges.h` to a nonexistant macro.  I haven't changed anything regarding that in this pull request, though.