### PR TITLE
Fix inaccurate handling of D2 super laser damage with quad-lasers

### DIFF
--- a/similar/main/laser.cpp
+++ b/similar/main/laser.cpp
@@ -656,14 +656,13 @@ static void do_omega_stuff(fvmsegptridx &vmsegptridx, const vmobjptridx_t parent
 	}
 }
 
+// Note that this is only used for determining if the quad laser per-bolt damage penalty should be applied, and consequently excludes super lasers
 static int is_laser_weapon_type(const weapon_id_type weapon_type)
 {
 	return weapon_type == weapon_id_type::LASER_ID_L1 ||
 		weapon_type == weapon_id_type::LASER_ID_L2 ||
 		weapon_type == weapon_id_type::LASER_ID_L3 ||
-		weapon_type == weapon_id_type::LASER_ID_L4 ||
-		weapon_type == weapon_id_type::LASER_ID_L5 ||
-		weapon_type == weapon_id_type::LASER_ID_L6;
+		weapon_type == weapon_id_type::LASER_ID_L4;
 }
 
 }


### PR DESCRIPTION
Upon a review of D2 weapon damage, it would appear that D2 did not apply the quad laser per-bolt damage penalty to super lasers; the code was written with it clearly being intended, but as SUPER_MAX_LASER_LEVEL was inexplicably set to 5, it only checked for a laser id between 1 and 5 (LASER_ID to LASER_ID + 4), however the super lasers used ID 30 and 31, and as such did not lose damage. (see LASER.C line 644 for reference)