### PR TITLE
Skip SDL OpenGL build check when the SDL2 wrapper is detected

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1586,8 +1586,10 @@ static void terminate_handler()
 		init_cdrom = '0' if sdl2 else 'SDL_INIT_CDROM'
 		error_text_opengl_mismatch = f'Rebirth configured with OpenGL enabled, but SDL{sdl2} configured with OpenGL disabled.  Disable Rebirth OpenGL or install an SDL{sdl2} with OpenGL enabled.'
 		test_opengl = (f'''
+#if !((SDL_MAJOR_VERSION == 1) && (SDL_MINOR_VERSION == 2) && (SDL_PATCHLEVEL >= 50))
 #ifndef SDL_VIDEO_OPENGL
 #error "{error_text_opengl_mismatch}"
+#endif
 #endif
 ''') if user_settings.opengl else ''
 		main = '''


### PR DESCRIPTION
The wrapper does not define SDL_VIDEO_OPENGL in SDL_config.h. This appears to be deliberate, although it's not entirely clear why.

    /* Don't define most of the SDL backends, under the assumption checking for these against the headers won't work anyhow.
       The exception is the X11 backend; you need its define to know if you can use its syswm interface. */

We could check SDL2's SDL_config.h instead, but that seems awkward to pull off.

Closes: https://github.com/dxx-rebirth/dxx-rebirth/issues/689