### PR TITLE
Fix building without OpenGL

### DIFF
--- a/common/3d/draw.cpp
+++ b/common/3d/draw.cpp
@@ -22,6 +22,7 @@
 #endif
 #include "d_enumerate.h"
 #include "d_zip.h"
+#include "partial_range.h"
 
 namespace dcx {
 

--- a/similar/main/gamefont.cpp
+++ b/similar/main/gamefont.cpp
@@ -33,7 +33,9 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "physfsx.h"
 #include "gamefont.h"
 #include "mission.h"
+#if DXX_USE_OGL
 #include "ogl_init.h"
+#endif
 #include "config.h"
 
 #include "d_array.h"


### PR DESCRIPTION
One issue was just a missing header. The other issue was unconditional inclusion of an OpenGL header.