### PR TITLE
Fix macOS builds with current clang version

### DIFF
--- a/similar/main/wall.cpp
+++ b/similar/main/wall.cpp
@@ -1426,7 +1426,7 @@ void wall_frame_process(const d_robot_info_array &Robot_info)
 		const auto &&r = partial_range(CloakingWalls, CloakingWalls.get_count());
 		auto &Walls = LevelUniqueWallSubsystemState.Walls;
 		cw_removal_predicate rp{Segments.vmptr, Walls};
-		std::remove_if(r.begin(), r.end(), std::ref(rp));
+		static_cast<void>(std::remove_if(r.begin(), r.end(), std::ref(rp)));
 		CloakingWalls.set_count(rp.num_cloaking_walls);
 	}
 #endif


### PR DESCRIPTION
The current version of clang on macOS yields this error when compiling D2X:

```
CXX d2x build/ similar/main/wall.cpp
similar/main/wall.cpp:1429:3: error: ignoring return value of function declared with 'nodiscard' attribute [-Werror,-Wunused-result]
        std::remove_if(r.begin(), r.end(), std::ref(rp));
        ^~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
scons: *** [build/similar/main/.d2x-rebirth.wall.o] Error 1
```

So, this explicitly discards the return value from that `std::remove_if` call there.  Applying it results in a clean build.