### PR TITLE
Merge 5c900ca7a stereo updates

### DIFF
--- a/common/2d/bitblt.cpp
+++ b/common/2d/bitblt.cpp
@@ -32,6 +32,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "dxxerror.h"
 #include "byteutil.h"
 #if DXX_USE_OGL
+#include "fwd-gr.h"
 #include "ogl_init.h"
 #endif
 
@@ -488,14 +489,14 @@ inside:
 
 }
 
-void show_fullscr(grs_canvas &canvas, grs_bitmap &bm)
+void show_fullscr(grs_canvas &canvas, grs_bitmap &bm, bool fill)
 {
 	auto &scr = canvas.cv_bitmap;
 #if DXX_USE_OGL
 	if (bm.get_type() == bm_mode::linear && scr.get_type() == bm_mode::ogl &&
 		bm.bm_w <= grd_curscreen->get_screen_width() && bm.bm_h <= grd_curscreen->get_screen_height()) // only scale with OGL if bitmap is not bigger than screen size
 	{
-		ogl_ubitmapm_cs(canvas, 0, 0, opengl_bitmap_use_dst_canvas, opengl_bitmap_use_dst_canvas, bm, ogl_colors::white);//use opengl to scale, faster and saves ram. -MPM
+		ogl_ubitmapm_cs(canvas, 0, 0, opengl_bitmap_use_dst_canvas, opengl_bitmap_use_dst_canvas, bm, ogl_colors::white, fill);//use opengl to scale, faster and saves ram. -MPM
 		return;
 	}
 #endif

--- a/common/3d/setup.cpp
+++ b/common/3d/setup.cpp
@@ -64,4 +64,17 @@ void g3_start_frame(grs_canvas &canvas)
 #endif
 }
 
+// modify the frame for stereo format
+#if DXX_USE_STEREOSCOPIC_RENDER
+void g3_stereo_frame(const int xeye, const int xoff)
+{
+#if DXX_USE_OGL
+	ogl_stereo_frame(xeye < 0, xoff);
+#else
+	(void)xeye;
+	(void)xoff;
+#endif
+}
+#endif
+
 }

--- a/common/include/3d.h
+++ b/common/include/3d.h
@@ -175,6 +175,11 @@ typedef g3s_point cg3s_point;
 //start the frame
 void g3_start_frame(grs_canvas &);
 
+#if DXX_USE_STEREOSCOPIC_RENDER
+//modify the frame for stereo format
+void g3_stereo_frame(const int xeye, const int xoff);
+#endif
+
 //set view from x,y,z, viewer matrix, and zoom.  Must call one of g3_set_view_*() 
 void g3_set_view_matrix(const vms_vector &view_pos,const vms_matrix &view_matrix,fix zoom);
 

--- a/common/include/fwd-gr.h
+++ b/common/include/fwd-gr.h
@@ -241,7 +241,7 @@ void gr_uline(grs_canvas &canvas, fix x0,fix y0,fix x1,fix y1, color_palette_ind
 // Draw the bitmap into the current canvas at the specified location.
 void gr_bitmap(grs_canvas &, unsigned x,unsigned y,grs_bitmap &bm);
 void gr_ubitmap(grs_canvas &, grs_bitmap &bm);
-void show_fullscr(grs_canvas &, grs_bitmap &bm);
+void show_fullscr(grs_canvas &, grs_bitmap &bm, bool fill = true);
 
 // Find transparent area in bitmap
 void gr_bitblt_find_transparent_area(const grs_bitmap &bm, unsigned &minx, unsigned &miny, unsigned &maxx, unsigned &maxy);

--- a/common/include/ogl_init.h
+++ b/common/include/ogl_init.h
@@ -99,6 +99,8 @@ constexpr int opengl_bitmap_use_src_bitmap = 0;
 constexpr int opengl_bitmap_use_dst_canvas = -1;
 bool ogl_ubitmapm_cs(grs_canvas &, int x, int y,int dw, int dh, grs_bitmap &bm, int c);
 bool ogl_ubitmapm_cs(grs_canvas &, int x, int y,int dw, int dh, grs_bitmap &bm, const ogl_colors::array_type &c);
+bool ogl_ubitmapm_cs(grs_canvas &, int x, int y, int dw, int dh, grs_bitmap &bm, const ogl_colors::array_type &c, bool fill);
+bool ogl_ubitblt_cs(grs_canvas &, int dw, int dh, int dx, int dy, int sx, int sy);
 bool ogl_ubitblt_i(unsigned dw, unsigned dh, unsigned dx, unsigned dy, unsigned sw, unsigned sh, unsigned sx, unsigned sy, const grs_bitmap &src, grs_bitmap &dest, opengl_texture_filter texfilt);
 bool ogl_ubitblt(unsigned w, unsigned h, unsigned dx, unsigned dy, unsigned sx, unsigned sy, const grs_bitmap &src, grs_bitmap &dest);
 void ogl_upixelc(const grs_bitmap &, unsigned x, unsigned y, color_palette_index c);

--- a/common/main/fwd-game.h
+++ b/common/main/fwd-game.h
@@ -100,6 +100,7 @@ extern StereoFormat VR_stereo;
 extern fix  VR_eye_width;
 extern int  VR_eye_offset;
 extern int  VR_sync_width;
+extern int  VR_sync_param;
 extern grs_subcanvas VR_hud_left;
 extern grs_subcanvas VR_hud_right;
 #endif

--- a/common/main/game.h
+++ b/common/main/game.h
@@ -147,9 +147,89 @@ enum class StereoFormat : uint8_t
 	SideBySideFullHeight,
 	SideBySideHalfHeight,
 	AboveBelowSync,
-	HighestFormat = AboveBelowSync
+	QuadBuffers,
+	HighestFormat = QuadBuffers
 };
-#endif
+
+// stereo viewport adjustments
+inline void gr_stereo_viewport_resize(const StereoFormat stereo, int &w, int &h)
+{
+	switch (stereo) {
+		case StereoFormat::None:
+		case StereoFormat::QuadBuffers:
+			return;
+		case StereoFormat::AboveBelowSync:
+			h -= VR_sync_width;
+			[[fallthrough]];
+		case StereoFormat::AboveBelow:
+			h /= 2;
+			break;
+		case StereoFormat::SideBySideHalfHeight:
+			h /= 2;
+			[[fallthrough]];
+		case StereoFormat::SideBySideFullHeight:
+			w /= 2;
+			break;
+	}
+}
+
+inline void gr_stereo_viewport_offset(const StereoFormat stereo, int &x, int &y, const int eye)
+{
+	if (!grd_curscreen)
+		return;
+
+	// left eye viewport origin
+	if (eye <= 0) {
+		if (stereo == StereoFormat::SideBySideHalfHeight)
+			y += SHEIGHT/4;
+		return;
+	}
+
+	// right eye viewport origin
+	switch (stereo) {
+		case StereoFormat::None:
+		case StereoFormat::QuadBuffers:
+			return;
+		case StereoFormat::AboveBelowSync:
+			y += VR_sync_width/2;
+			[[fallthrough]];
+		case StereoFormat::AboveBelow:
+			y += SHEIGHT/2;
+			break;
+		case StereoFormat::SideBySideHalfHeight:
+			if (y == 0)
+				y += SHEIGHT/4;
+			[[fallthrough]];
+		case StereoFormat::SideBySideFullHeight:
+			x += SWIDTH/2;
+			break;
+	}
+}
+
+inline void gr_stereo_viewport_window(const StereoFormat stereo, int &x, int &y, int &w, int &h)
+{
+	switch (stereo) {
+		case StereoFormat::None:
+		case StereoFormat::QuadBuffers:
+			return;
+		case StereoFormat::AboveBelowSync:
+			h -= VR_sync_width / 2;
+			[[fallthrough]];
+		case StereoFormat::AboveBelow:
+			y -= y / 2;
+			h -= h / 2;
+			break;
+		case StereoFormat::SideBySideHalfHeight:
+			y -= y / 2;
+			h -= h / 2;
+			[[fallthrough]];
+		case StereoFormat::SideBySideFullHeight:
+			x -= x / 2;
+			w -= w / 2;
+			break;
+	}
+}
+#endif	// DXX_USE_STEREOSCOPIC_RENDER
 
 }
 

--- a/common/main/newmenu.h
+++ b/common/main/newmenu.h
@@ -384,7 +384,7 @@ struct listbox_layout
 {
 	struct marquee
 	{
-		class deleter : std::default_delete<fix64[]>
+	   	class deleter : std::default_delete<fix64[]>
 		{
 		public:
 			void operator()(marquee *const m) const

--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -58,6 +58,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "physfsrwops.h"
 #if DXX_USE_OGL
 #include "ogl_init.h"
+#include "game.h"
 #endif
 #include "args.h"
 
@@ -198,6 +199,11 @@ void MovieShowFrame(const uint8_t *buf, int dstx, int dsty, int bufw, int bufh, 
 #if DXX_USE_OGL
 	glDisable (GL_BLEND);
 
+#if DXX_USE_STEREOSCOPIC_RENDER
+	if (VR_stereo != StereoFormat::None)
+		ogl_ubitmapm_cs(*grd_curcanv, dstx, dsty, bufw, bufh, source_bm, ogl_colors::white, true);
+	else
+#endif
 	ogl_ubitblt_i(
 		bufw*scale, bufh*scale,
 		dstx, dsty,

--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -701,6 +701,14 @@ static int gr_check_mode(const screen_mode mode)
 }
 #endif
 
+#if DXX_USE_STEREOSCOPIC_RENDER
+static inline void gr_set_stereo_mode_sync(void)
+{
+	// calc stereo mode sync interval for above/below format
+	VR_sync_width = (VR_sync_param * SHEIGHT) / 480; // normalized for 640x480
+}
+#endif
+
 int gr_set_mode(screen_mode mode)
 {
 	unsigned char *gr_bm_data;
@@ -733,6 +741,10 @@ int gr_set_mode(screen_mode mode)
 	ogl_init_state();
 	gamefont_choose_game_font(w,h);
 	gr_remap_color_fonts();
+
+#if DXX_USE_STEREOSCOPIC_RENDER
+	gr_set_stereo_mode_sync();
+#endif
 
 	return 0;
 }
@@ -873,6 +885,19 @@ int gr_init()
 	gr_set_current_canvas(grd_curscreen->sc_canvas);
 
 	ogl_init_pixel_buffers(256, 128);       // for gamefont_init
+
+#if DXX_USE_STEREOSCOPIC_RENDER
+	// stereo display options
+	if (CGameArg.OglStereo)
+		VR_stereo = StereoFormat::QuadBuffers;
+	if (CGameArg.OglStereoView > static_cast<uint8_t>(StereoFormat::HighestFormat)) {
+		VR_sync_param = CGameArg.OglStereoView;
+		CGameArg.OglStereoView = static_cast<uint8_t>(StereoFormat::AboveBelowSync);
+	}
+	if (CGameArg.OglStereoView)
+		VR_stereo = static_cast<StereoFormat>(CGameArg.OglStereoView);
+	gr_set_stereo_mode_sync();
+#endif
 
 	gr_installed = 1;
 

--- a/similar/main/automap.cpp
+++ b/similar/main/automap.cpp
@@ -171,6 +171,14 @@ struct automap : ::dcx::automap
 
 static void init_automap_subcanvas(grs_subcanvas &view, grs_canvas &container)
 {
+#if DXX_USE_STEREOSCOPIC_RENDER
+	if (VR_stereo != StereoFormat::None) {
+		int x = (SWIDTH/23), y = (SHEIGHT/6), w = (SWIDTH/1.1), h = (SHEIGHT/1.45);
+		gr_stereo_viewport_window(VR_stereo, x, y, w, h);
+		gr_init_sub_canvas(view, container, x, y, w, h);
+		return;
+	}
+#endif
 #if defined(DXX_BUILD_DESCENT_I)
 	if (MacHog)
 		gr_init_sub_canvas(view, container, 38*(SWIDTH/640.0), 77*(SHEIGHT/480.0), 564*(SWIDTH/640.0), 381*(SHEIGHT/480.0));
@@ -686,7 +694,7 @@ constexpr char system_name[][17] = {
 			"Omega System"};
 #endif
 
-static void name_frame(grs_canvas &canvas, automap &am)
+static void name_frame(grs_canvas &canvas, automap &am, int dx = 0, int dy = 0)
 {
 	gr_set_fontcolor(canvas, am.green_31, -1);
 	char		name_level_left[128];
@@ -702,7 +710,7 @@ static void name_frame(grs_canvas &canvas, automap &am)
 	else
 		name_level = Current_level_name;
 
-	gr_string(canvas, game_font, (SWIDTH / 64), (SHEIGHT / 48), name_level);
+	gr_string(canvas, game_font, dx + (SWIDTH / 64), dy + (SHEIGHT / 48), name_level);
 #elif defined(DXX_BUILD_DESCENT_II)
 	char	name_level_right[128];
 	if (Current_level_num > 0)
@@ -716,9 +724,9 @@ static void name_frame(grs_canvas &canvas, automap &am)
 	else
 		snprintf(name_level_right, sizeof(name_level_right), " %s", current_level_name);
 
-	gr_string(canvas, game_font, (SWIDTH / 64), (SHEIGHT / 48), name_level_left);
+	gr_string(canvas, game_font, dx + (SWIDTH / 64), dy + (SHEIGHT / 48), name_level_left);
 	const auto &&[wr, h] = gr_get_string_size(game_font, name_level_right);
-	gr_string(canvas, game_font, canvas.cv_bitmap.bm_w - wr - (SWIDTH / 64), (SHEIGHT / 48), name_level_right, wr, h);
+	gr_string(canvas, game_font, dx + canvas.cv_bitmap.bm_w - wr - (SWIDTH / 64), dy + (SHEIGHT / 48), name_level_right, wr, h);
 #endif
 }
 
@@ -802,15 +810,33 @@ static void automap_apply_input(automap &am, const vms_matrix &plrorient, const 
 	}
 }
 
-static void draw_automap(fvcobjptr &vcobjptr, automap &am)
+static void draw_automap(fvcobjptr &vcobjptr, automap &am, fix eye)
 {
+#if DXX_USE_STEREOSCOPIC_RENDER
+	int sw = SWIDTH;
+	int sh = SHEIGHT;
+	int dx = 0, dy = 0, dw = sw, dh = sh;
+	if (VR_stereo != StereoFormat::None) {
+		gr_stereo_viewport_resize(VR_stereo, dw, dh);
+		gr_stereo_viewport_offset(VR_stereo, dx, dy, eye);
+	}
+	#define SCREEN_SIZE_STEREO 	grd_curscreen->set_screen_width_height(dw, dh)
+	#define SCREEN_SIZE_NORMAL 	grd_curscreen->set_screen_width_height(sw, sh)
+#else
+	#define SCREEN_SIZE_STEREO 	// no-op
+	#define SCREEN_SIZE_NORMAL 	// no-op
+	const int dx = 0, dy = 0;	// no x,y adjust
+#endif
+
 	if ( am.leave_mode==0 && am.controls.state.automap && (timer_query()-am.entry_time)>LEAVE_TIME)
 		am.leave_mode = 1;
 
 	{
 		auto &canvas = am.w_canv;
-		show_fullscr(canvas, am.automap_background);
+		if (eye <= 0)
+			show_fullscr(canvas, am.automap_background);
 		gr_set_fontcolor(canvas, BM_XRGB(20, 20, 20), -1);
+		SCREEN_SIZE_STEREO;
 	{
 		int x, y;
 #if defined(DXX_BUILD_DESCENT_I)
@@ -819,6 +845,7 @@ static void draw_automap(fvcobjptr &vcobjptr, automap &am)
 	else
 #endif
 			x = SWIDTH / 8, y = SHEIGHT / 16;
+		x += dx, y += dy;
 		gr_string(canvas, *HUGE_FONT, x, y, TXT_AUTOMAP);
 	}
 	{
@@ -850,6 +877,7 @@ static void draw_automap(fvcobjptr &vcobjptr, automap &am)
 		y1 = SHEIGHT / 1.083;
 		y2 = SHEIGHT / 1.043;
 #endif
+		x += dx, y0 += dy, y1 += dy, y2 += dy;
 		auto &game_font = *GAME_FONT;
 		gr_string(canvas, game_font, x, y0, TXT_TURN_SHIP);
 		gr_string(canvas, game_font, x, y1, s1);
@@ -857,16 +885,25 @@ static void draw_automap(fvcobjptr &vcobjptr, automap &am)
 	}
 
 	}
+	SCREEN_SIZE_NORMAL;
 	auto &canvas = am.automap_view;
 
-	gr_clear_canvas(canvas, BM_XRGB(0,0,0));
+	if (eye == 0)
+		gr_clear_canvas(canvas, BM_XRGB(0,0,0));
 
 	g3_start_frame(canvas);
 	render_start_frame();
 
+#if DXX_USE_STEREOSCOPIC_RENDER
+	// select stereo viewport/transform/buffer per left/right eye
+	if (VR_stereo != StereoFormat::None)
+		g3_stereo_frame(eye, VR_eye_offset);
+#endif
+
 	if (!PlayerCfg.AutomapFreeFlight)
 		vm_vec_scale_add(am.view_position,am.view_target,am.viewMatrix.fvec,-am.viewDist);
 
+	am.view_position.x += eye;	// stereo viewpoint offset
 	g3_set_view_matrix(am.view_position,am.viewMatrix,am.zoom);
 
 	draw_all_edges(am);
@@ -942,7 +979,9 @@ static void draw_automap(fvcobjptr &vcobjptr, automap &am)
 
 	g3_end_frame();
 
-	name_frame(canvas, am);
+	SCREEN_SIZE_STEREO;
+	name_frame(canvas, am, dx, dy);
+	SCREEN_SIZE_NORMAL;
 
 #if defined(DXX_BUILD_DESCENT_II)
 	{
@@ -982,6 +1021,18 @@ static void draw_automap(fvcobjptr &vcobjptr, automap &am)
 		calc_d_tick();
 	}
 	am.t1 = am.t2;
+}
+
+static void draw_automap(fvcobjptr &vcobjptr, automap &am)
+{
+#if DXX_USE_STEREOSCOPIC_RENDER
+	if (VR_stereo != StereoFormat::None) {
+		draw_automap(vcobjptr, am, -VR_eye_width);
+		draw_automap(vcobjptr, am,  VR_eye_width);
+	}
+	else
+#endif
+		draw_automap(vcobjptr, am, 0);
 }
 
 #if defined(DXX_BUILD_DESCENT_I)

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -204,7 +204,8 @@ screen_mode Game_screen_mode = initial_large_game_screen_mode;
 StereoFormat VR_stereo;
 fix  VR_eye_width = F1_0;
 int  VR_eye_offset = 0;
-int  VR_sync_width = 20;
+int  VR_sync_width = 24;
+int  VR_sync_param = 24;
 grs_subcanvas VR_hud_left;
 grs_subcanvas VR_hud_right;
 #endif
@@ -219,8 +220,6 @@ void init_stereo()
 #if DXX_USE_OGL
 	// init stereo options
 	if (CGameArg.OglStereo || CGameArg.OglStereoView) {
-		if (VR_stereo == StereoFormat::None && !VR_eye_offset)
-			VR_stereo = (CGameArg.OglStereoView) ? static_cast<StereoFormat>(CGameArg.OglStereoView % (static_cast<unsigned>(StereoFormat::HighestFormat) + 1)) : StereoFormat::AboveBelow;
 		constexpr int half_width_eye_offset = -6;
 		constexpr int full_width_eye_offset = -12;
 		switch (VR_stereo)
@@ -228,6 +227,7 @@ void init_stereo()
 			case StereoFormat::None:
 			case StereoFormat::AboveBelow:
 			case StereoFormat::AboveBelowSync:
+			case StereoFormat::QuadBuffers:
 				VR_eye_offset = full_width_eye_offset;
 				break;
 			case StereoFormat::SideBySideFullHeight:
@@ -236,7 +236,7 @@ void init_stereo()
 				break;
 		}
 		VR_eye_width = (F1_0 * 7) / 10;	// Descent 1.5 defaults
-		VR_sync_width = (20 * SHEIGHT) / 480;
+		VR_sync_width = (VR_sync_param * SHEIGHT) / 480; // normalized for 640x480
 		PlayerCfg.CockpitMode[1] = cockpit_mode_t::full_screen;
 	}
 	else {
@@ -308,6 +308,7 @@ void init_cockpit()
 				switch (VR_stereo)
 				{
 					case StereoFormat::None:
+					case StereoFormat::QuadBuffers:
 						/* Preserve width */
 						/* Preserve height */
 						break;
@@ -404,6 +405,13 @@ void game_init_render_sub_buffers(grs_canvas &canvas, const int x, const int y, 
 			case StereoFormat::None:
 			default:
 				return;
+			case StereoFormat::QuadBuffers:
+				l.x = x + dx;
+				l.y = r.y = y;
+				l.w = r.w = w - dx;
+				l.h = r.h = h;
+				r.x = x;
+				break;
 			case StereoFormat::AboveBelow:
 				l.x = x + dx;
 				l.y = y;

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -978,20 +978,14 @@ static window_event_result HandleSystemKey(int key)
 #endif
 
 #if DXX_USE_STEREOSCOPIC_RENDER
-#if 0
-			/* These conflict with the drop-primary and drop-secondary
-			 * keybindings.  Dropping items is more common than using VR, so
-			 * disable these.
-			 */
-		case KEY_SHIFTED + KEY_F5:
+		case KEY_ALTED + KEY_F5:
 			VR_eye_offset -= 1;
 			reset_cockpit();
 			break;
-		case KEY_SHIFTED + KEY_F6:
+		case KEY_ALTED + KEY_F6:
 			VR_eye_offset += 1;
 			reset_cockpit();
 			break;
-#endif
 		case KEY_SHIFTED + KEY_ALTED + KEY_F5:
 			VR_eye_width -= (F1_0/10); //*= 10/11;
 			reset_cockpit();
@@ -1000,13 +994,11 @@ static window_event_result HandleSystemKey(int key)
 			VR_eye_width += (F1_0/10); //*= 11/10;
 			reset_cockpit();
 			break;
-		case KEY_SHIFTED + KEY_F7:
 		case KEY_SHIFTED + KEY_ALTED + KEY_F7:
 			VR_eye_width = F1_0;
 			VR_eye_offset = 0;
 			reset_cockpit();
 			break;
-		case KEY_SHIFTED + KEY_F8:
 		case KEY_SHIFTED + KEY_ALTED + KEY_F8:
 			VR_stereo = static_cast<StereoFormat>((static_cast<unsigned>(VR_stereo) + 1) % (static_cast<unsigned>(StereoFormat::HighestFormat) + 1));
 			init_stereo();

--- a/similar/main/gamerend.cpp
+++ b/similar/main/gamerend.cpp
@@ -1007,11 +1007,19 @@ void show_boxed_message(grs_canvas &canvas, const char *msg)
 	
 	gr_set_fontcolor(canvas, BM_XRGB(31, 31, 31), -1);
 	auto &medium1_font = *MEDIUM1_FONT;
-	const auto &&[w, h] = gr_get_string_size(medium1_font, msg);
+	auto &&[w, h] = gr_get_string_size(medium1_font, msg);
 	
 	x = (SWIDTH-w)/2;
 	y = (SHEIGHT-h)/2;
 	
+#if DXX_USE_STEREOSCOPIC_RENDER
+	if (VR_stereo != StereoFormat::None) {
+		int dw = w, dh = h;
+		gr_stereo_viewport_window(VR_stereo, x, y, dw, dh);
+		w = dw, h = dh;
+	}
+#endif
+
 	nm_draw_background(canvas, x - BORDERX, y - BORDERY, x + w + BORDERX, y + h + BORDERY);
 	
 	gr_string(canvas, medium1_font, 0x8000, y, msg, w, h);

--- a/similar/main/render.cpp
+++ b/similar/main/render.cpp
@@ -1249,11 +1249,9 @@ void render_frame(grs_canvas &canvas, fix eye_offset, window_rendered_data &wind
 	g3_start_frame(canvas);
 
 #if DXX_USE_STEREOSCOPIC_RENDER
-#if DXX_USE_OGL
 	// select stereo viewport/transform/buffer per left/right eye
 	if (VR_stereo != StereoFormat::None && eye_offset)
-		ogl_stereo_frame(eye_offset < 0, VR_eye_offset);
-#endif
+		g3_stereo_frame(eye_offset, VR_eye_offset);
 #endif
 
 	auto Viewer_eye = Viewer->pos;

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -1286,6 +1286,16 @@ static int init_new_page(grs_canvas &canvas, briefing *br)
 	return r;
 }
 
+#if DXX_USE_STEREOSCOPIC_RENDER
+static inline void stereo_viewport_adjust(short &x, short &y, short &w, short &h)
+{
+	int dx = x, dy = y, dw = w, dh = h;
+	gr_stereo_viewport_window(VR_stereo, dx, dy, dw, dh);
+	gr_stereo_viewport_offset(VR_stereo, dx, dy, -1);
+	x = dx, y = dy, w = dw, h = dh;
+}
+#endif
+
 #if defined(DXX_BUILD_DESCENT_II)
 static int DefineBriefingBox(const grs_bitmap &cv_bitmap, const char *&buf)
 {
@@ -1316,6 +1326,12 @@ static int DefineBriefingBox(const grs_bitmap &cv_bitmap, const char *&buf)
 	Briefing_screens[n].text_uly = rescale_y(cv_bitmap, Briefing_screens[n].text_uly);
 	Briefing_screens[n].text_width = rescale_x(cv_bitmap, Briefing_screens[n].text_width);
 	Briefing_screens[n].text_height = rescale_y(cv_bitmap, Briefing_screens[n].text_height);
+
+#if DXX_USE_STEREOSCOPIC_RENDER
+	if (VR_stereo != StereoFormat::None)
+		stereo_viewport_adjust(Briefing_screens[n].text_ulx, Briefing_screens[n].text_uly,
+					Briefing_screens[n].text_width, Briefing_screens[n].text_height);
+#endif
 
 	return (n);
 }
@@ -1394,6 +1410,11 @@ static int load_briefing_screen(grs_canvas &canvas, briefing *const br, const ch
 	br->screen->text_uly = rescale_y(canvas.cv_bitmap, br->screen->text_uly);
 	br->screen->text_width = rescale_x(canvas.cv_bitmap, br->screen->text_width);
 	br->screen->text_height = rescale_y(canvas.cv_bitmap, br->screen->text_height);
+#if DXX_USE_STEREOSCOPIC_RENDER
+	if (VR_stereo != StereoFormat::None)
+		stereo_viewport_adjust(br->screen->text_ulx, br->screen->text_uly,
+					br->screen->text_width, br->screen->text_height);
+#endif
 	init_char_pos(br, br->screen->text_ulx, br->screen->text_uly);
 #elif defined(DXX_BUILD_DESCENT_II)
 	free_briefing_screen(br);
@@ -1426,6 +1447,11 @@ static int load_briefing_screen(grs_canvas &canvas, briefing *const br, const ch
 		br->screen->text_uly = rescale_y(canvas.cv_bitmap, br->screen->text_uly);
 		br->screen->text_width = rescale_x(canvas.cv_bitmap, br->screen->text_width);
 		br->screen->text_height = rescale_y(canvas.cv_bitmap, br->screen->text_height);
+#if DXX_USE_STEREOSCOPIC_RENDER
+		if (VR_stereo != StereoFormat::None)
+			stereo_viewport_adjust(br->screen->text_ulx, br->screen->text_uly,
+						br->screen->text_width, br->screen->text_height);
+#endif
 		init_char_pos(br, br->screen->text_ulx, br->screen->text_uly);
 	}
 


### PR DESCRIPTION
Updated with stereo viewport support for intro screens, popup menus, automap windows, and D2 extra viewports for guidebot/rearview displays when stereo viewport mode is enabled.

Extra stereo viewport handling allows for more uniform experience when stereo display mode is active, whereas original Descent 1/2 switched in and out stereo modes between game play and higher-res graphics for menus and automaps. 

Conditionals for DXX_USE_STEREOSCOPIC_RENDER=1 added for all stereo support steps dependent on VR_stereo variables. Negligible impact when compiling default non-stereo version with DXX_USE_STEREOSCOPIC_RENDER=0.

Added conditional compilation for DXX_USE_OGLES=1 to omit glDrawBuffer() calls used for GL_STEREO quad buffering, so stereo viewport options also supportable with GLES. Need GLES alternative to gCopyPixels() for viewport copy ops.

Stereo viewport handling needs to adjust x,y / w,h coordinates in each of these special cases. Fullscreen bitmaps were easily handled by blitting bitmaps twice via overloaded ogl_ubitmapm_cs() function mainly used by show_fullscr().

Popup menus & dialogs were trickier since text strings needed to be matched with background graphics. Right-eye viewport is simply copied from rendered left-eye viewport (default OGL). Would have preferred to render popup menu text & graphics composited to offscreen buffer and blitting to left/right viewports similar to fullscreen case, which was unexpectedly problematic for default OGL (non-GLES).