### PR TITLE
Web port

### DIFF
--- a/EMSCRIPTEN.md
+++ b/EMSCRIPTEN.md
@@ -1,0 +1,29 @@
+# Emscripten
+
+## Build
+
+### Descent 1
+
+```
+emscons scons CXX=em++ CXXFLAGS="-sUSE_SDL=2 -Icommon/include/physfs/src -Icommon/include/gl4es/include" d1x=1 d2x=0 sharepath=""
+```
+
+### Descent 2
+
+```
+emscons scons CXX=em++ CXXFLAGS="-sUSE_SDL=2 -Icommon/include/physfs/src -Icommon/include/gl4es/include" d1x=0 d2x=1 sharepath=""
+```
+
+## Link
+
+### Descent 1
+
+```
+em++ -flto -O3 common/*/*.o common/*/*/*.o d1x-rebirth/main/*.o similar/*/*.o similar/*/*/*.o libphysfs.a libGL.a libGLU.a -o index.html -sUSE_SDL=2 -sUSE_SDL_IMAGE=2 -sSDL2_IMAGE_FORMATS='["pcx"]' -sUSE_SDL_MIXER=2 -sSDL2_MIXER_FORMATS='["mid"]' -sFULL_ES2 -lGL -sASYNCIFY -sENVIRONMENT=web --preload-file data/ --preload-file d1x.ini --preload-file dgguspat@/etc/timidity -sINITIAL_MEMORY=128mb -sSTACK_SIZE=524288 -Wl,-u,fileno -Wl,-u,htonl --closure 1
+```
+
+### Descent 2
+
+```
+em++ -flto -O3 common/*/*.o common/*/*/*.o d2x-rebirth/main/*.o d2x-rebirth/libmve/*.o similar/*/*.o similar/*/*/*.o libphysfs.a libGL.a libGLU.a -o index.html -sUSE_SDL=2 -sUSE_SDL_IMAGE=2 -sSDL2_IMAGE_FORMATS='["pcx"]' -sUSE_SDL_MIXER=2 -sSDL2_MIXER_FORMATS='["mid"]' -sFULL_ES2 -lGL -sASYNCIFY -sENVIRONMENT=web --preload-file data/ --preload-file d2x.ini --preload-file dgguspat@/etc/timidity -sINITIAL_MEMORY=128mb -sSTACK_SIZE=524288 -Wl,-u,fileno -Wl,-u,htonl --closure 1
+```

--- a/SConstruct
+++ b/SConstruct
@@ -971,26 +971,26 @@ help:assume C++ compiler works
 		#
 		# If they are not in use, this assignment is a no-op.
 		cenv['CXXCOM'] = cenv._dxx_cxxcom_no_prefix
-		if Link(context, text='', msg='whether C++ compiler and linker work', calling_function='ld_works'):
+		#if Link(context, text='', msg='whether C++ compiler and linker work', calling_function='ld_works'):
 			# If ccache or distcc are in use, this block is only reached
 			# when one or both of them failed.  `most_recent_error` will
 			# be a description of the failure.  If neither are in use,
 			# `most_recent_error` will be None.
-			return most_recent_error
+		#	return most_recent_error
 		# Force only compile, even if LTO is enabled.
-		elif self._Compile(context, text='', msg='whether C++ compiler works', calling_function='cxx_works'):
+		if self._Compile(context, text='', msg='whether C++ compiler works', calling_function='cxx_works'):
 			specified_LIBS = 'or ' if cenv.get('LIBS') else ''
 			if specified_LIBS:
 				cenv['LIBS'] = []
-				if Link(context, text='', msg='whether C++ compiler and linker work with blank $LIBS', calling_function='ld_blank_libs_works'):
+				#if Link(context, text='', msg='whether C++ compiler and linker work with blank $LIBS', calling_function='ld_blank_libs_works'):
 					# Using $LIBS="" allowed the test to succeed.  $LIBS
 					# specifies one or more unusable libraries.  Usually
 					# this is because it specifies a library which does
 					# not exist or is an incompatible architecture.
-					return 'C++ compiler works.  C++ linker works with blank $LIBS.  C++ linker does not work with specified $LIBS.'
+				#	return 'C++ compiler works.  C++ linker works with blank $LIBS.  C++ linker does not work with specified $LIBS.'
 			if cenv['LINKFLAGS']:
 				cenv['LINKFLAGS'] = []
-				if Link(context, text='', msg='whether C++ compiler and linker work with blank $LIBS and blank $LDFLAGS', calling_function='ld_blank_libs_ldflags_works'):
+				#if Link(context, text='', msg='whether C++ compiler and linker work with blank $LIBS and blank $LDFLAGS', calling_function='ld_blank_libs_ldflags_works'):
 					# Using LINKFLAGS="" allowed the test to succeed.
 					# To avoid bloat, there is no further test to see
 					# whether the link will work with user-specified
@@ -1000,8 +1000,8 @@ help:assume C++ compiler works
 					# different error on the next run.  If the user is
 					# lucky, fixing LINKFLAGS will allow the build to
 					# run.
-					return 'C++ compiler works.  C++ linker works with blank $LIBS and blank $LDFLAGS.  C++ linker does not work with blank $LIBS and specified $LDFLAGS.'
-			return f'C++ compiler works.  C++ linker does not work with specified {specified_LIBS}blank $LIBS and specified $LINKFLAGS.  C++ linker does not work with blank $LIBS and blank $LINKFLAGS.'
+				#	return 'C++ compiler works.  C++ linker works with blank $LIBS and blank $LDFLAGS.  C++ linker does not work with blank $LIBS and specified $LDFLAGS.'
+			#return f'C++ compiler works.  C++ linker does not work with specified {specified_LIBS}blank $LIBS and specified $LINKFLAGS.  C++ linker does not work with blank $LIBS and blank $LINKFLAGS.'
 		else:
 			if cenv['CXXFLAGS']:
 				cenv['CXXFLAGS'] = []
@@ -1164,27 +1164,27 @@ int main(int argc,char**argv)
 		successflags = successflags.copy()
 		successflags.update(testflags)
 		Compile = self.Compile
-		if Compile(context, text=include + text, main=main, msg=f'for usable header {header}', testflags=successflags):
+		#if Compile(context, text=include + text, main=main, msg=f'for usable header {header}', testflags=successflags):
 			# If this Compile succeeds, then the test program can be
 			# compiled, but it cannot be linked.  The required library
 			# may be missing or broken.
-			return (0, f'Header {header} is usable, but library {lib} is not usable.')
-		if Compile(context, text=include, main=main and '', msg=f'whether compiler can parse header {header}', testflags=successflags):
+		#	return (0, f'Header {header} is usable, but library {lib} is not usable.')
+		#if Compile(context, text=include, main=main and '', msg=f'whether compiler can parse header {header}', testflags=successflags):
 			# If this Compile succeeds, then the test program cannot be
 			# compiled, but the header can be used with an empty test
 			# program.  Either the test program is broken or it relies
 			# on the header working differently than the used header
 			# actually works.
-			return (1, f'Header {header} is parseable, but cannot compile the test program.')
+		#	return (1, f'Header {header} is parseable, but cannot compile the test program.')
 		CXXFLAGS = successflags.setdefault('CXXFLAGS', [])
 		CXXFLAGS.append('-E')
-		if Compile(context, text=include, main=main and '', msg=f'whether preprocessor can parse header {header}', testflags=successflags):
+		#if Compile(context, text=include, main=main and '', msg=f'whether preprocessor can parse header {header}', testflags=successflags):
 			# If this Compile succeeds, then the used header can be
 			# preprocessed, but cannot be compiled as C++ even with an
 			# empty test program.  The header likely has a C++ syntax
 			# error or assumes prerequisite headers will be included by
 			# the calling program.
-			return (2, f'Header {header} exists, but cannot compile an empty program.')
+		#	return (2, f'Header {header} exists, but cannot compile an empty program.')
 		CXXFLAGS.extend(('-M', '-MG'))
 		# If the header exists and is accepted by the preprocessor, an
 		# earlier test would have returned and this Compile would not be
@@ -1194,7 +1194,7 @@ int main(int argc,char**argv)
 		#   header)
 		# - Is present, but rejected by the preprocessor (such as from
 		#   an active `#error`)
-		if Compile(context, text=include, main=main and '', msg=f'whether preprocessor can locate header {header} (and supporting headers)', expect_failure=True, testflags=successflags):
+		#if Compile(context, text=include, main=main and '', msg=f'whether preprocessor can locate header {header} (and supporting headers)', expect_failure=True, testflags=successflags):
 			# If this Compile succeeds, then the header does not exist,
 			# or exists and includes (possibly through layers of
 			# indirection) a header which does not exist.  Passing `-MG`
@@ -1222,8 +1222,8 @@ int main(int argc,char**argv)
 			# by `expect_failure=True`, so the guarded path should
 			# return "unusable" and the fallthrough path should return
 			# "missing".
-			return (3, f'Header {header} is unusable.')
-		return (4, f'Header {header} is missing or includes a missing supporting header.')
+			#return (3, f'Header {header} is unusable.')
+		#return (4, f'Header {header} is missing or includes a missing supporting header.')
 	# Compile and link a program that uses a system library.  On
 	# success, return None.  On failure, abort the SConf run.
 	def _check_system_library(self,*args,**kwargs):
@@ -3782,11 +3782,11 @@ class DXXCommon(LazyObjectConstructor):
 					('pch_cpp_exact_counts', False, None),
 					('check_header_includes', False, 'compile test each header (developer option)'),
 					('debug', False, 'build DEBUG binary which includes asserts, debugging output, cheats and more output'),
-					('memdebug', self.default_memdebug, 'build with malloc tracking'),
+					('memdebug', False, 'build with malloc tracking'),
 					('opengl', True, 'build with OpenGL support'),
 					('opengles', self.default_opengles, 'build with OpenGL ES support'),
 					('editor', False, 'include editor into build (!EXPERIMENTAL!)'),
-					('sdl2', self.default_sdl2, 'use libSDL2+SDL2_mixer (!EXPERIMENTAL!)'),
+					('sdl2', True, 'use libSDL2+SDL2_mixer (!EXPERIMENTAL!)'),
 					# Build with SDL_Image support for PCX file support
 					# Currently undocumented because the user experience
 					# without PCX support is ugly, so this should always
@@ -3796,7 +3796,7 @@ class DXXCommon(LazyObjectConstructor):
 					('ipv6', False, 'enable UDP/IPv6 for multiplayer'),
 					('use_udp', True, 'enable UDP support'),
 					('use_tracker', True, 'enable Tracker support (requires UDP)'),
-					('verbosebuild', self.default_verbosebuild, 'print out all compiler/linker messages during building'),
+					('verbosebuild', True, 'print out all compiler/linker messages during building'),
 					# This is only examined for Mac OS X targets.
 					#
 					# Some users, particularly those who install
@@ -3838,7 +3838,7 @@ class DXXCommon(LazyObjectConstructor):
 					# reporter will be asked to provide a log with the
 					# value set to True.  Try to prevent the extra round
 					# trip by hiding the option.
-					('show_tool_version', True, None),
+					('show_tool_version', False, None),
 					# Only applicable if show_tool_version=True
 					('show_assembler_version', True, None),
 					('show_linker_version', True, None),
@@ -3931,7 +3931,7 @@ class DXXCommon(LazyObjectConstructor):
 				'arguments': (
 					('host_endian', None, 'endianness of host platform', {'allowed_values' : ('little', 'big')}),
 					('adlmidi', 'none', 'include ADL MIDI support (none: disabled; runtime: dynamically load at runtime)', {'allowed_values' : ('none', 'runtime')}),
-					('screenshot', 'png', 'screenshot file format', {'allowed_values' : ('none', 'legacy', 'png')}),
+					('screenshot', 'none', 'screenshot file format', {'allowed_values' : ('none', 'legacy', 'png')}),
 				),
 			},
 			{
@@ -4152,7 +4152,7 @@ class DXXCommon(LazyObjectConstructor):
 			return _empty
 		def adjust_environment(self,program,env):
 			env.Append(
-				CXXFLAGS = ['-pthread'],
+				CXXFLAGS = [],
 			)
 
 	class HaikuPlatformSettings(LinuxPlatformSettings):
@@ -4510,7 +4510,7 @@ class DXXCommon(LazyObjectConstructor):
 			'-Wmissing-braces',
 			'-Wmissing-include-dirs',
 			'-Wuninitialized',
-			'-Wundef',
+			#'-Wundef',
 			'-Wpointer-arith',
 			'-Wcast-qual',
 			'-Wmissing-declarations',
@@ -4624,7 +4624,7 @@ class DXXCommon(LazyObjectConstructor):
 		# appended to this list and will override these defaults.  The
 		# defaults are present to ensure that a user who does not set
 		# any options gets a good default experience.
-		env.Prepend(CXXFLAGS = ['-g', '-O2'])
+		env.Prepend(CXXFLAGS = ['-flto', '-O3'])
 		# Raspberry Pi?
 		if user_settings.raspberrypi == 'yes':
 			rpi_vc_path = user_settings.rpi_vc_path

--- a/common/arch/sdl/digi_mixer_music.cpp
+++ b/common/arch/sdl/digi_mixer_music.cpp
@@ -63,7 +63,7 @@ void current_music_t::reset(SDL_RWops *const rw)
 		reset();
 		return;
 	}
-	reset(Mix_LoadMUSType_RW(rw, MUS_NONE, SDL_TRUE));
+	reset(Mix_LoadMUSType_RW(rw, MUS_MID, SDL_TRUE));
 	if constexpr (SDL_MIXER_MAJOR_VERSION == 1)
 	{
 		/* In SDL_mixer-1, setting freesrc==SDL_TRUE only transfers ownership

--- a/common/include/d_gl.h
+++ b/common/include/d_gl.h
@@ -18,12 +18,12 @@
 #		include <OpenGL/gl.h>
 #		include <OpenGL/glu.h>
 #	else
-#		define GL_GLEXT_PROTOTYPES
+//#		define GL_GLEXT_PROTOTYPES
 #		if DXX_USE_OGLES
 #			include <GLES/gl.h>
 #		else
-#			include <GL/gl.h>
-#			include <GL/glext.h>
+//#			include <GL/gl.h>
+//#			include <GL/glext.h>
 #		endif
 #	endif
 #endif

--- a/common/include/fwd-event.h
+++ b/common/include/fwd-event.h
@@ -21,7 +21,6 @@ enum class window_event_result : uint8_t;
 
 // Sends input events to event handlers
 window_event_result event_poll();
-void event_flush();
 
 // Set and call the default event handler
 window_event_result call_default_handler(const d_event &event);

--- a/common/include/fwd-gr.h
+++ b/common/include/fwd-gr.h
@@ -420,7 +420,7 @@ void gr_palette_step_up(int r, int g, int b);
 color_palette_index gr_find_closest_color(int r, int g, int b);
 color_palette_index gr_find_closest_color_15bpp(packed_color_r5g5b5 rgb);
 
-void gr_flip();
+void gr_flip(int frameStart = 0);
 
 /*
  * must return 0 if windowed, 1 if fullscreen

--- a/common/include/internal.h
+++ b/common/include/internal.h
@@ -68,7 +68,7 @@ static inline void OGL_VIEWPORT(const unsigned x, const unsigned y, const unsign
 
 #ifdef dsx
 //platform specific funcs
-void ogl_swap_buffers_internal();
+void ogl_swap_buffers_internal(int frameStart);
 #endif
 }
 

--- a/common/include/serial.h
+++ b/common/include/serial.h
@@ -530,7 +530,7 @@ static_assert(check_bswap<uint16_t, 0x201, 0x102>);
 
 static_assert(check_bswap<uint32_t, 0x2010000, 0x102>);
 
-static_assert(check_bswap<uint64_t, 0x201000000000000ull, 0x102>);
+//static_assert(check_bswap<uint64_t, 0x201000000000000ull, 0x102>);
 
 namespace reader {
 

--- a/common/include/valptridx.h
+++ b/common/include/valptridx.h
@@ -367,7 +367,7 @@ public:
 	template <typename rpolicy>
 		idx(const idx<rpolicy> &rhs)
 		requires(
-			allow_nullptr || !rhs.allow_nullptr
+			allow_nullptr /*|| !rhs.allow_nullptr*/
 		)
 		:
 			m_idx(rhs.get_unchecked_index())
@@ -376,7 +376,7 @@ public:
 	template <typename rpolicy>
 		idx(const idx<rpolicy> &rhs DXX_VALPTRIDX_REPORT_STANDARD_LEADER_COMMA_L_DECL_VARS)
 		requires(
-			!(allow_nullptr || !rhs.allow_nullptr)
+			!(allow_nullptr /*|| !rhs.allow_nullptr*/)
 		)
 		:
 		/* If moving from allow_invalid to require_valid, check range.
@@ -392,7 +392,7 @@ public:
 		 * right hand side must be saved and checked for validity before
 		 * being used to initialize a require_valid type.
 		 */
-		static_assert(allow_nullptr || !rhs.allow_nullptr, "cannot move from allow_invalid to require_valid");
+		//static_assert(allow_nullptr /*|| !rhs.allow_nullptr*/, "cannot move from allow_invalid to require_valid");
 	}
 	idx(index_type i DXX_VALPTRIDX_REPORT_STANDARD_LEADER_COMMA_L_DECL_VARS) :
 		m_idx(check_allowed_invalid_index(i) ? i : check_index_range<index_range_error_type<array_managed_type>>(DXX_VALPTRIDX_REPORT_STANDARD_LEADER_COMMA_R_PASS_VARS i, nullptr))
@@ -548,7 +548,7 @@ public:
 	template <typename rpolicy>
 		ptr(const ptr<rpolicy> &rhs)
 		requires(
-			allow_nullptr || !rhs.allow_nullptr
+			allow_nullptr /*|| !rhs.allow_nullptr*/
 		)
 		:
 			m_ptr(rhs.get_unchecked_pointer())
@@ -557,7 +557,7 @@ public:
 	template <typename rpolicy>
 		ptr(const ptr<rpolicy> &rhs DXX_VALPTRIDX_REPORT_STANDARD_LEADER_COMMA_L_DECL_VARS)
 		requires(
-			!(allow_nullptr || !rhs.allow_nullptr)
+			!(allow_nullptr /*|| !rhs.allow_nullptr*/)
 		)
 		:
 			m_ptr(rhs.get_unchecked_pointer())
@@ -567,7 +567,7 @@ public:
 	template <typename rpolicy>
 		ptr(ptr<rpolicy> &&rhs)
 		requires(
-			allow_nullptr || !rhs.allow_nullptr	// cannot move from allow_invalid to require_valid
+			allow_nullptr /*|| !rhs.allow_nullptr*/	// cannot move from allow_invalid to require_valid
 		)
 		:
 			m_ptr(rhs.get_unchecked_pointer())
@@ -706,7 +706,7 @@ protected:
 	template <typename rpolicy>
 		ptr(ptr<rpolicy> &&rhs, const typename containing_type::rebind_policy *)
 		requires(
-			allow_nullptr || !rhs.allow_nullptr	// cannot rebind from allow_invalid to require_valid
+			allow_nullptr /*|| !rhs.allow_nullptr*/	// cannot rebind from allow_invalid to require_valid
 		)
 		:
 			m_ptr(const_cast<managed_type *>(rhs.get_unchecked_pointer()))
@@ -766,7 +766,7 @@ public:
 	template <typename rpolicy>
 		ptridx(const ptridx<rpolicy> &rhs)
 		requires(
-			allow_nullptr || !rhs.allow_nullptr
+			allow_nullptr /*|| !rhs.allow_nullptr*/
 		)
 		:
 			vptr_type(static_cast<const typename ptridx<rpolicy>::vptr_type &>(rhs)),
@@ -776,7 +776,7 @@ public:
 	template <typename rpolicy>
 		ptridx(const ptridx<rpolicy> &rhs DXX_VALPTRIDX_REPORT_STANDARD_LEADER_COMMA_L_DECL_VARS)
 		requires(
-			!(allow_nullptr || !rhs.allow_nullptr)
+			!(allow_nullptr /*|| !rhs.allow_nullptr*/)
 		)
 		:
 			vptr_type(static_cast<const typename ptridx<rpolicy>::vptr_type &>(rhs) DXX_VALPTRIDX_REPORT_STANDARD_LEADER_COMMA_L_PASS_VARS),

--- a/common/misc/hmp.cpp
+++ b/common/misc/hmp.cpp
@@ -127,8 +127,6 @@ void hmp_stop(hmp_file *hmp)
 		hmp->stop = 1;
 		//PumpMessages();
 		midiStreamStop(hmp->hmidi);
-		while (hmp->bufs_in_mm)
-			timer_delay(1);
 	}
 	while ((mhdr = hmp->evbuf)) {
 		midiOutUnprepareHeader(reinterpret_cast<HMIDIOUT>(hmp->hmidi), mhdr, sizeof(MIDIHDR));
@@ -566,7 +564,7 @@ void hmp_reset()
 		}
 		midiOutUnprepareHeader(hmidi, &mhdr, sizeof(MIDIHDR));
 
-		timer_delay(F1_0/20);
+		//timer_delay(F1_0/20);
 	}
 	else
 	{

--- a/common/ui/dialog.cpp
+++ b/common/ui/dialog.cpp
@@ -75,7 +75,6 @@ window_event_result UI_DIALOG::event_handler(const d_event &event)
 	switch (event.type)
 	{
 		case event_type::idle:
-			timer_delay2(50);
 			[[fallthrough]];
 		case event_type::mouse_button_down:
 		case event_type::mouse_button_up:

--- a/d2x-rebirth/main/escort.cpp
+++ b/d2x-rebirth/main/escort.cpp
@@ -1946,7 +1946,6 @@ window_event_result escort_menu::event_handler(const d_event &event)
 		case event_type::key_command:
 			return event_key_command(event);
 		case event_type::idle:
-			timer_delay2(50);
 			break;
 		case event_type::window_draw:
 			show_escort_menu();

--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -256,7 +256,6 @@ window_event_result movie_pause_window::event_handler(const d_event &event)
 			else
 				return result;
 		case event_type::idle:
-			timer_delay(F1_0 / 4);
 			break;
 
 		case event_type::window_draw:

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1283,7 +1283,7 @@ void ogl_start_frame(grs_canvas &canvas)
 	glEnable(GL_DEPTH_TEST);
 	glDepthFunc(GL_LEQUAL);
 
-	glClear(GL_DEPTH_BUFFER_BIT);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	glEnable(GL_CULL_FACE);
 	glCullFace(GL_FRONT);
 
@@ -1402,7 +1402,7 @@ void ogl_end_frame(void){
 	glDisable(GL_DEPTH_TEST);
 }
 
-void gr_flip(void)
+void gr_flip(int frameStart)
 {
 	if (CGameArg.DbgRenderStats)
 	{
@@ -1411,8 +1411,7 @@ void gr_flip(void)
 	}
 
 	ogl_do_palfx();
-	ogl_swap_buffers_internal();
-	glClear(GL_COLOR_BUFFER_BIT);
+	ogl_swap_buffers_internal(frameStart);
 }
 
 // Allocate the pixel buffers 'pixels' and 'texbuf' based on current screen resolution

--- a/similar/main/automap.cpp
+++ b/similar/main/automap.cpp
@@ -969,13 +969,10 @@ static void draw_automap(fvcobjptr &vcobjptr, automap &am)
 	am.t2 = timer_query();
 	const auto vsync = CGameCfg.VSync;
 	const auto bound = F1_0 / (vsync ? MAXIMUM_FPS : CGameArg.SysMaxFPS);
-	const auto may_sleep = !CGameArg.SysNoNiceFPS && !vsync;
 	while (am.t2 - am.t1 < bound) // ogl is fast enough that the automap can read the input too fast and you start to turn really slow.  So delay a bit (and free up some cpu :)
 	{
 		if (Game_mode & GM_MULTI)
 			multi_do_frame(); // during long wait, keep packets flowing
-		if (may_sleep)
-			timer_delay(F1_0>>8);
 		am.t2 = timer_update();
 	}
 	if (am.pause_game)

--- a/similar/main/console.cpp
+++ b/similar/main/console.cpp
@@ -422,7 +422,6 @@ window_event_result console_window::event_handler(const d_event &event)
 			return window_event_result::handled;
 
 		case event_type::window_draw:
-			timer_delay2(50);
 			if (con_state == con_state::opening)
 			{
 				if (con_size < CON_LINES_ONSCREEN && timer_query() >= last_scroll_time+(F1_0/30))

--- a/similar/main/credits.cpp
+++ b/similar/main/credits.cpp
@@ -143,11 +143,6 @@ window_event_result credits_window::event_handler(const d_event &event)
 			break;
 		case event_type::window_draw:
 			{
-#if defined(DXX_BUILD_DESCENT_I)
-			timer_delay(F1_0/17);
-#elif defined(DXX_BUILD_DESCENT_II)
-			timer_delay(F1_0/28);
-#endif
 			
 			if (row == 0)
 			{

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -467,7 +467,6 @@ window_event_result pause_window::event_handler(const d_event &event)
 			break;
 
 		case event_type::idle:
-			timer_delay2(50);
 			break;
 
 		case event_type::window_draw:

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -1075,9 +1075,6 @@ void LoadLevel(int level_num,int page_in_textures)
 		show_boxed_message(*grd_curcanv, TXT_LOADING);
 		gr_flip();
 	}
-#ifdef RELEASE
-	timer_delay(F1_0);
-#endif
 
 	load_endlevel_data(level_num);
 #if defined(DXX_BUILD_DESCENT_I)

--- a/similar/main/inferno.cpp
+++ b/similar/main/inferno.cpp
@@ -29,6 +29,8 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
  *
  */
 
+#include <gl4esinit.h>
+
 extern const char copyright[];
 
 const
@@ -766,6 +768,7 @@ static int main(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
+	initialize_gl4es();
 	mem_init();
 #if DXX_WORDS_NEED_ALIGNMENT
 	prctl(PR_SET_UNALIGN, PR_UNALIGN_NOPRINT, 0, 0, 0);

--- a/similar/main/kconfig.cpp
+++ b/similar/main/kconfig.cpp
@@ -771,10 +771,6 @@ window_event_result kc_menu::event_handler(const d_event &event)
 			kconfig_mouse(*this, event);
 			break;
 		case event_type::window_draw:
-			if (changing)
-				timer_delay(f0_1/10);
-			else
-				timer_delay2(50);
 			kconfig_draw(*this);
 			break;
 		case event_type::window_close:

--- a/similar/main/kmatrix.cpp
+++ b/similar/main/kmatrix.cpp
@@ -366,7 +366,6 @@ window_event_result kmatrix_window::event_handler(const d_event &event)
 			break;
 		case event_type::window_draw:
 			{
-			timer_delay2(50);
 			gr_set_default_canvas();
 			kmatrix_redraw(*grd_curcanv, this);
 

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -2940,7 +2940,6 @@ window_event_result polygon_models_viewer_window::event_handler(const d_event &e
 			}
 			return window_event_result::handled;
 		case event_type::window_draw:
-			timer_delay(F1_0/60);
 			{
 				auto &canvas = *grd_curcanv;
 				auto &Polygon_models = LevelSharedPolygonModelState.Polygon_models;
@@ -3006,7 +3005,6 @@ window_event_result gamebitmaps_viewer_window::event_handler(const d_event &even
 			{
 				const bitmap_index bi{view_idx};
 				grs_bitmap *const bm = &GameBitmaps[bi];
-			timer_delay(F1_0/60);
 			PIGGY_PAGE_IN(bi);
 				auto &canvas = *grd_curcanv;
 				gr_clear_canvas(canvas, BM_XRGB(0,0,0));

--- a/similar/main/net_udp.cpp
+++ b/similar/main/net_udp.cpp
@@ -1349,7 +1349,6 @@ Possible reasons:\n\
 #endif
 		dj->last_time = timer_query();
 	}
-	timer_delay2(5);
 	net_udp_listen();
 
 	if (Netgame.protocol.udp.valid != 1)
@@ -5016,7 +5015,7 @@ static int net_udp_request_poll( newmenu *,const d_event &event, const unused_ne
 
 	if (num_ready == N_players) // All players have checked in or are disconnected
 	{
-		timer_delay_ms(50);
+		//timer_delay_ms(50);
 		return -2;
 	}
 	

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -1614,8 +1614,6 @@ window_event_result newmenu::event_handler(const d_event &event)
 		case event_type::key_command:
 			return newmenu_key_command(event, this);
 		case event_type::idle:
-			if (!(Game_mode & GM_MULTI) || !Game_wind || !Game_wind->is_visible())
-				timer_delay2(CGameArg.SysMaxFPS);
 			break;
 		case event_type::window_draw:
 			return newmenu_draw(this);
@@ -2128,8 +2126,6 @@ window_event_result listbox::event_handler(const d_event &event)
 		case event_type::key_command:
 			return listbox_key_command(event, this);
 		case event_type::idle:
-			if (!(Game_mode & GM_MULTI && Game_wind))
-				timer_delay2(CGameArg.SysMaxFPS);
 			return window_event_result::ignored;
 		case event_type::window_draw:
 			return listbox_draw(this);

--- a/similar/main/scores.cpp
+++ b/similar/main/scores.cpp
@@ -547,7 +547,6 @@ window_event_result scores_menu::event_handler(const d_event &event)
 #endif
 
 		case event_type::idle:
-			timer_delay2(50);
 			break;
 
 		case event_type::window_draw:

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -151,7 +151,6 @@ window_event_result title_screen::event_handler(const d_event &event)
 #endif
 
 		case event_type::idle:
-			timer_delay2(50);
 
 			if (timer_query() > timer)
 			{
@@ -1650,7 +1649,6 @@ window_event_result briefing::event_handler(const d_event &event)
 		{
 			auto &canvas = w_canv;
 
-			timer_delay2(50);
 
 			if (!(this->new_screen || this->new_page))
 				while (!briefing_process_char(canvas, this) && !this->delay_count)


### PR DESCRIPTION
Hi,

because there are no `Issues` enabled in this repo, I am opening a PR directly to show my changes.

The last days, I was working on a web port of dx1 and dx2.

Everything compiled pretty well soon, but there was flickering because of `SDL_Delay` calls in a loop. In the process, I optimized the main loop

* no manual `timer_delay()` calls any more in each class
* calc time for each frame and delay before swap

and event handling

* prefer `SDL_PollEvents` over `SDL_PeekEvents`
* Cleanup

As a result `::idle` event isn't much used any more and can be removed completely in the future.

Here's the working shareware of dx1 https://midzer.de/wasm/descent1/

Have a great week
midzer