### PR TITLE
Replace manual delays by frame time measurement

### DIFF
--- a/common/arch/sdl/timer.cpp
+++ b/common/arch/sdl/timer.cpp
@@ -48,30 +48,4 @@ void timer_delay_ms(unsigned milliseconds)
 	SDL_Delay(milliseconds);
 }
 
-// Replacement for timer_delay which considers calc time the program needs between frames (not reentrant)
-void timer_delay_bound(const unsigned caller_bound)
-{
-	static uint32_t FrameStart;
-
-	uint32_t start = FrameStart;
-	const auto multiplayer = Game_mode & GM_MULTI;
-	const auto vsync = CGameCfg.VSync;
-	const auto bound = vsync ? 1000u / MAXIMUM_FPS : caller_bound;
-	for (;;)
-	{
-		const uint32_t tv_now = SDL_GetTicks();
-		if (multiplayer)
-			multi_do_frame(); // during long wait, keep packets flowing
-		if (!vsync)
-			SDL_Delay(1);
-		if (unlikely(start > tv_now))
-			start = tv_now;
-		if (unlikely(tv_now - start >= bound))
-		{
-			FrameStart = tv_now;
-			break;
-		}
-	}
-}
-
 }

--- a/common/include/fwd-gr.h
+++ b/common/include/fwd-gr.h
@@ -420,7 +420,7 @@ void gr_palette_step_up(int r, int g, int b);
 color_palette_index gr_find_closest_color(int r, int g, int b);
 color_palette_index gr_find_closest_color_15bpp(packed_color_r5g5b5 rgb);
 
-void gr_flip();
+void gr_flip(Uint32 frameStart = 0);
 
 /*
  * must return 0 if windowed, 1 if fullscreen

--- a/common/include/internal.h
+++ b/common/include/internal.h
@@ -68,7 +68,7 @@ static inline void OGL_VIEWPORT(const unsigned x, const unsigned y, const unsign
 
 #ifdef dsx
 //platform specific funcs
-void ogl_swap_buffers_internal();
+void ogl_swap_buffers_internal(Uint32 frameStart);
 #endif
 }
 

--- a/common/include/timer.h
+++ b/common/include/timer.h
@@ -24,15 +24,6 @@ fix64 timer_update();
 fix64 timer_query();
 
 void timer_delay_ms(unsigned milliseconds);
-static inline void timer_delay(fix seconds)
-{
-	timer_delay_ms(f2i(seconds * 1000));
-}
-void timer_delay_bound(unsigned bound);
-static inline void timer_delay2(int fps)
-{
-	timer_delay_bound(1000u / fps);
-}
 
 }
 #endif

--- a/common/misc/hmp.cpp
+++ b/common/misc/hmp.cpp
@@ -127,8 +127,6 @@ void hmp_stop(hmp_file *hmp)
 		hmp->stop = 1;
 		//PumpMessages();
 		midiStreamStop(hmp->hmidi);
-		while (hmp->bufs_in_mm)
-			timer_delay(1);
 	}
 	while ((mhdr = hmp->evbuf)) {
 		midiOutUnprepareHeader(reinterpret_cast<HMIDIOUT>(hmp->hmidi), mhdr, sizeof(MIDIHDR));
@@ -565,8 +563,6 @@ void hmp_reset()
 			}
 		}
 		midiOutUnprepareHeader(hmidi, &mhdr, sizeof(MIDIHDR));
-
-		timer_delay(F1_0/20);
 	}
 	else
 	{

--- a/common/ui/dialog.cpp
+++ b/common/ui/dialog.cpp
@@ -75,7 +75,6 @@ window_event_result UI_DIALOG::event_handler(const d_event &event)
 	switch (event.type)
 	{
 		case event_type::idle:
-			timer_delay2(50);
 			[[fallthrough]];
 		case event_type::mouse_button_down:
 		case event_type::mouse_button_up:

--- a/d2x-rebirth/main/escort.cpp
+++ b/d2x-rebirth/main/escort.cpp
@@ -1946,7 +1946,6 @@ window_event_result escort_menu::event_handler(const d_event &event)
 		case event_type::key_command:
 			return event_key_command(event);
 		case event_type::idle:
-			timer_delay2(50);
 			break;
 		case event_type::window_draw:
 			show_escort_menu();

--- a/d2x-rebirth/main/movie.cpp
+++ b/d2x-rebirth/main/movie.cpp
@@ -256,7 +256,6 @@ window_event_result movie_pause_window::event_handler(const d_event &event)
 			else
 				return result;
 		case event_type::idle:
-			timer_delay(F1_0 / 4);
 			break;
 
 		case event_type::window_draw:

--- a/similar/arch/ogl/gr.cpp
+++ b/similar/arch/ogl/gr.cpp
@@ -151,9 +151,23 @@ static bool TestEGLError(const char* pszLocation)
 
 namespace dcx {
 
-void ogl_swap_buffers_internal(void)
+void ogl_swap_buffers_internal(Uint32 frameStart)
 {
 	sync_helper.before_swap();
+
+	const bool vsync = CGameCfg.VSync;
+	const Uint32 frameDelay = 1000 / (likely(vsync) ? MAXIMUM_FPS : CGameArg.SysMaxFPS);
+	const bool may_sleep = !CGameArg.SysNoNiceFPS && !vsync;
+
+	// This measures how long this iteration of the loop took
+	const Uint32 frameTime = SDL_GetTicks() - frameStart;
+
+	// This keeps us from displaying more frames
+	if (frameDelay > frameTime && may_sleep)
+    {
+		SDL_Delay(frameDelay - frameTime - CGameArg.OglSyncWait);
+    }
+
 #if DXX_USE_OGLES && SDL_MAJOR_VERSION == 1
 	eglSwapBuffers(eglDisplay, eglSurface);
 #else

--- a/similar/arch/ogl/ogl.cpp
+++ b/similar/arch/ogl/ogl.cpp
@@ -1283,7 +1283,7 @@ void ogl_start_frame(grs_canvas &canvas)
 	glEnable(GL_DEPTH_TEST);
 	glDepthFunc(GL_LEQUAL);
 
-	glClear(GL_DEPTH_BUFFER_BIT);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	glEnable(GL_CULL_FACE);
 	glCullFace(GL_FRONT);
 
@@ -1402,7 +1402,7 @@ void ogl_end_frame(void){
 	glDisable(GL_DEPTH_TEST);
 }
 
-void gr_flip(void)
+void gr_flip(Uint32 frameStart)
 {
 	if (CGameArg.DbgRenderStats)
 	{
@@ -1411,8 +1411,7 @@ void gr_flip(void)
 	}
 
 	ogl_do_palfx();
-	ogl_swap_buffers_internal();
-	glClear(GL_COLOR_BUFFER_BIT);
+	ogl_swap_buffers_internal(frameStart);
 }
 
 // Allocate the pixel buffers 'pixels' and 'texbuf' based on current screen resolution

--- a/similar/main/automap.cpp
+++ b/similar/main/automap.cpp
@@ -969,13 +969,10 @@ static void draw_automap(fvcobjptr &vcobjptr, automap &am)
 	am.t2 = timer_query();
 	const auto vsync = CGameCfg.VSync;
 	const auto bound = F1_0 / (vsync ? MAXIMUM_FPS : CGameArg.SysMaxFPS);
-	const auto may_sleep = !CGameArg.SysNoNiceFPS && !vsync;
 	while (am.t2 - am.t1 < bound) // ogl is fast enough that the automap can read the input too fast and you start to turn really slow.  So delay a bit (and free up some cpu :)
 	{
 		if (Game_mode & GM_MULTI)
 			multi_do_frame(); // during long wait, keep packets flowing
-		if (may_sleep)
-			timer_delay(F1_0>>8);
 		am.t2 = timer_update();
 	}
 	if (am.pause_game)

--- a/similar/main/console.cpp
+++ b/similar/main/console.cpp
@@ -422,7 +422,6 @@ window_event_result console_window::event_handler(const d_event &event)
 			return window_event_result::handled;
 
 		case event_type::window_draw:
-			timer_delay2(50);
 			if (con_state == con_state::opening)
 			{
 				if (con_size < CON_LINES_ONSCREEN && timer_query() >= last_scroll_time+(F1_0/30))

--- a/similar/main/credits.cpp
+++ b/similar/main/credits.cpp
@@ -142,13 +142,7 @@ window_event_result credits_window::event_handler(const d_event &event)
 			}
 			break;
 		case event_type::window_draw:
-			{
-#if defined(DXX_BUILD_DESCENT_I)
-			timer_delay(F1_0/17);
-#elif defined(DXX_BUILD_DESCENT_II)
-			timer_delay(F1_0/28);
-#endif
-			
+			{			
 			if (row == 0)
 			{
 				do {

--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -123,7 +123,6 @@ d_time_fix ThisLevelTime;
 namespace dcx {
 namespace {
 static fix64 last_timer_value;
-static fix64 sync_timer_value;
 }
 grs_subcanvas Screen_3d_window;							// The rectangle for rendering the mine to
 int	force_cockpit_redraw=0;
@@ -574,18 +573,6 @@ pause_game_world_time::~pause_game_world_time()
 	start_time();
 }
 
-namespace {
-
-static void game_flush_common_inputs()
-{
-	event_flush();
-	key_flush();
-	joy_flush();
-	mouse_flush();
-}
-
-}
-
 }
 
 namespace dsx {
@@ -593,7 +580,10 @@ namespace dsx {
 void game_flush_inputs(control_info &Controls)
 {
 	Controls = {};
-	game_flush_common_inputs();
+	event_flush();
+	key_flush();
+	joy_flush();
+	mouse_flush();
 }
 
 void game_flush_respawn_inputs(control_info &Controls)
@@ -633,36 +623,15 @@ void reset_time()
 
 void calc_frame_time()
 {
-	fix last_frametime = FrameTime;
-
-	const auto vsync = CGameCfg.VSync;
-	const auto bound = f1_0 / (likely(vsync) ? MAXIMUM_FPS : CGameArg.SysMaxFPS);
-	const auto may_sleep = !CGameArg.SysNoNiceFPS && !vsync;
-	for (;;)
-	{
-		const auto timer_value = timer_update();
-		FrameTime = timer_value - last_timer_value;
-		if (FrameTime > 0 && timer_value - sync_timer_value >= bound)
-		{
-			last_timer_value = timer_value;
-
-			sync_timer_value += bound;
-			if (sync_timer_value + bound < timer_value) {
-				sync_timer_value = timer_value;
-			}
-			break;
-		}
-		if (Game_mode & GM_MULTI)
-			multi_do_frame(); // during long wait, keep packets flowing
-		if (may_sleep)
-			timer_delay_ms(1);
-	}
+	const auto timer_value = timer_update();
+	FrameTime = timer_value - last_timer_value;
+	last_timer_value = timer_value;
+	
+	if (Game_mode & GM_MULTI)
+		multi_do_frame(); // during long wait, keep packets flowing
 
 	if ( cheats.turbo )
 		FrameTime *= 2;
-
-	if (FrameTime < 0)				//if bogus frametime...
-		FrameTime = (last_frametime==0?1:last_frametime);		//...then use time from last frame
 
 	GameTime64 += FrameTime;
 

--- a/similar/main/gamecntl.cpp
+++ b/similar/main/gamecntl.cpp
@@ -467,7 +467,6 @@ window_event_result pause_window::event_handler(const d_event &event)
 			break;
 
 		case event_type::idle:
-			timer_delay2(50);
 			break;
 
 		case event_type::window_draw:

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -1075,9 +1075,6 @@ void LoadLevel(int level_num,int page_in_textures)
 		show_boxed_message(*grd_curcanv, TXT_LOADING);
 		gr_flip();
 	}
-#ifdef RELEASE
-	timer_delay(F1_0);
-#endif
 
 	load_endlevel_data(level_num);
 #if defined(DXX_BUILD_DESCENT_I)

--- a/similar/main/kconfig.cpp
+++ b/similar/main/kconfig.cpp
@@ -771,10 +771,6 @@ window_event_result kc_menu::event_handler(const d_event &event)
 			kconfig_mouse(*this, event);
 			break;
 		case event_type::window_draw:
-			if (changing)
-				timer_delay(f0_1/10);
-			else
-				timer_delay2(50);
 			kconfig_draw(*this);
 			break;
 		case event_type::window_close:

--- a/similar/main/kmatrix.cpp
+++ b/similar/main/kmatrix.cpp
@@ -366,7 +366,6 @@ window_event_result kmatrix_window::event_handler(const d_event &event)
 			break;
 		case event_type::window_draw:
 			{
-			timer_delay2(50);
 			gr_set_default_canvas();
 			kmatrix_redraw(*grd_curcanv, this);
 

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -2951,7 +2951,6 @@ window_event_result polygon_models_viewer_window::event_handler(const d_event &e
 			}
 			return window_event_result::handled;
 		case event_type::window_draw:
-			timer_delay(F1_0/60);
 			{
 				auto &canvas = *grd_curcanv;
 				auto &Polygon_models = LevelSharedPolygonModelState.Polygon_models;
@@ -3017,7 +3016,6 @@ window_event_result gamebitmaps_viewer_window::event_handler(const d_event &even
 			{
 				const bitmap_index bi{view_idx};
 				grs_bitmap *const bm = &GameBitmaps[bi];
-			timer_delay(F1_0/60);
 			PIGGY_PAGE_IN(bi);
 				auto &canvas = *grd_curcanv;
 				gr_clear_canvas(canvas, BM_XRGB(0,0,0));

--- a/similar/main/net_udp.cpp
+++ b/similar/main/net_udp.cpp
@@ -1349,7 +1349,6 @@ Possible reasons:\n\
 #endif
 		dj->last_time = timer_query();
 	}
-	timer_delay2(5);
 	net_udp_listen();
 
 	if (Netgame.protocol.udp.valid != 1)

--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -1614,8 +1614,6 @@ window_event_result newmenu::event_handler(const d_event &event)
 		case event_type::key_command:
 			return newmenu_key_command(event, this);
 		case event_type::idle:
-			if (!(Game_mode & GM_MULTI) || !Game_wind || !Game_wind->is_visible())
-				timer_delay2(CGameArg.SysMaxFPS);
 			break;
 		case event_type::window_draw:
 			return newmenu_draw(this);
@@ -2128,8 +2126,6 @@ window_event_result listbox::event_handler(const d_event &event)
 		case event_type::key_command:
 			return listbox_key_command(event, this);
 		case event_type::idle:
-			if (!(Game_mode & GM_MULTI && Game_wind))
-				timer_delay2(CGameArg.SysMaxFPS);
 			return window_event_result::ignored;
 		case event_type::window_draw:
 			return listbox_draw(this);

--- a/similar/main/scores.cpp
+++ b/similar/main/scores.cpp
@@ -547,7 +547,6 @@ window_event_result scores_menu::event_handler(const d_event &event)
 #endif
 
 		case event_type::idle:
-			timer_delay2(50);
 			break;
 
 		case event_type::window_draw:

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -151,7 +151,6 @@ window_event_result title_screen::event_handler(const d_event &event)
 #endif
 
 		case event_type::idle:
-			timer_delay2(50);
 
 			if (timer_query() > timer)
 			{
@@ -1649,8 +1648,6 @@ window_event_result briefing::event_handler(const d_event &event)
 		case event_type::window_draw:
 		{
 			auto &canvas = w_canv;
-
-			timer_delay2(50);
 
 			if (!(this->new_screen || this->new_page))
 				while (!briefing_process_char(canvas, this) && !this->delay_count)


### PR DESCRIPTION
Hi,

According to good dialogue in https://github.com/dxx-rebirth/dxx-rebirth/pull/746, here's mentioned PR to improve render performance (should give more FPS) by replacing all manual delays.

Code is tested for Descent 1 Shareware.

Have a nice week
midzer