### PR TITLE
Restore older Rebirth perceived digi_mixer volume

### DIFF
--- a/similar/arch/sdl/digi_mixer.cpp
+++ b/similar/arch/sdl/digi_mixer.cpp
@@ -586,9 +586,14 @@ void digi_mixer_end_sound(const sound_channel channel)
 
 void digi_mixer_set_digi_volume( int dvolume )
 {
+	/*
+	* Double-scale Mix_Volume to more closely match old pre-20a0166c Rebirth builds
+	* This also preserves the (unintentionally?) more accurate percieved volume scaling of those builds
+	* (e.g. perceived sound volume will match perceived midi volume more closely)
+	*/
 	digi_volume = dvolume;
 	if (!digi_initialised) return;
-	Mix_Volume(-1, fix2byte(dvolume));
+	Mix_Volume(-1, fix2byte(fixmul(dvolume, dvolume)));
 }
 
 int digi_mixer_is_channel_playing(const sound_channel c)

--- a/similar/main/ai.cpp
+++ b/similar/main/ai.cpp
@@ -190,7 +190,7 @@ static robot_gun_number robot_advance_current_gun_prefer_second(const robot_info
 namespace dcx {
 namespace {
 constexpr std::integral_constant<int, F1_0 * 8> CHASE_TIME_LENGTH{};
-constexpr std::integral_constant<int, F0_5> Robot_sound_volume{};
+constexpr std::integral_constant<int, F1_0> Robot_sound_volume{};
 enum {
 	Flinch_scale = 4,
 	Attack_scale = 24,

--- a/similar/main/gameseq.cpp
+++ b/similar/main/gameseq.cpp
@@ -899,7 +899,7 @@ void create_player_appearance_effect(const d_vclip_array &Vclip, const object_ba
 
 		const auto sound_num = Vclip[vclip_index::player_appearance].sound_num;
 		if (sound_num > -1)
-			digi_link_sound_to_pos(sound_num, seg, sidenum_t::WLEFT, effect_obj->pos, 0, F0_5);
+			digi_link_sound_to_pos(sound_num, seg, sidenum_t::WLEFT, effect_obj->pos, 0, F1_0);
 	}
 }
 }

--- a/similar/main/laser.cpp
+++ b/similar/main/laser.cpp
@@ -837,9 +837,9 @@ imobjptridx_t Laser_create_new(const vms_vector &direction, const vms_vector &po
 			if (parent == Viewer)
 			{
 				// Make your own vulcan gun  1/2 as loud.
-				digi_play_sample(weapon_info.flash_sound, weapon_type == weapon_id_type::VULCAN_ID ? (F0_5 / 2) : F0_5);
+				digi_play_sample(weapon_info.flash_sound, weapon_type == weapon_id_type::VULCAN_ID ? F0_5 : F1_0);
 			} else {
-				digi_link_sound_to_pos(weapon_info.flash_sound, segnum.absolute_sibling(obj->segnum), sidenum_t::WLEFT, obj->pos, 0, F0_5);
+				digi_link_sound_to_pos(weapon_info.flash_sound, segnum.absolute_sibling(obj->segnum), sidenum_t::WLEFT, obj->pos, 0, F1_0);
 			}
 		}
 	}

--- a/similar/main/weapon.cpp
+++ b/similar/main/weapon.cpp
@@ -638,7 +638,7 @@ void select_primary_weapon(player_info &player_info, const char *const weapon_na
 			auto &Next_laser_fire_time = player_info.Next_laser_fire_time;
 			if (wait_for_rearm)
 			{
-				multi_digi_play_sample_once(SOUND_GOOD_SELECTION_PRIMARY, F0_5);
+				multi_digi_play_sample_once(SOUND_GOOD_SELECTION_PRIMARY, F1_0);
 				Next_laser_fire_time = GameTime64 + REARM_TIME;
 			}
 			else
@@ -702,7 +702,7 @@ void select_secondary_weapon(player_info &player_info, const char *const weapon_
 			auto &Next_missile_fire_time = player_info.Next_missile_fire_time;
 			if (wait_for_rearm)
 			{
-				multi_digi_play_sample_once(SOUND_GOOD_SELECTION_SECONDARY, F0_5);
+				multi_digi_play_sample_once(SOUND_GOOD_SELECTION_SECONDARY, F1_0);
 				Next_missile_fire_time = GameTime64 + REARM_TIME;
 			}
 			else


### PR DESCRIPTION
This attempts to address the perceived volume issues noted in #753.

As @vLKp noted, old pre- 20a0166c builds had an unintentional effect of double-scaling certain (most) sounds, but not others. This PR attempts to emulate this behavior by instead double-scaling overall Mix_Volume, instead of the Mix_Distance call on individual sounds.

It also reverts any of the individual volume intensity changes made, restoring the overall expected mix.
(particularly with -nosdlmixer)

An interesting side-effect of the old double-scaling is that it actually set the perceived sound volume - at least on Windows - closer to the perceived midi volume? I couldn't find any obvious reason for this in the Rebirth code itself, but my best guess is the system's midi volume scaling may be accounting for [logarithmic intensity of sound](https://www.britannica.com/science/sound-physics/The-decibel-scale) whereas SDL may not?
As such, this change preserves that (subjectively pleasant) behaviour.

Example [test.dem.zip](https://github.com/dxx-rebirth/dxx-rebirth/files/14544574/test.dem.zip) on 0.58.1 vs e59df93f:

https://github.com/dxx-rebirth/dxx-rebirth/assets/3589969/ba969e59-637a-4441-834b-06dce171cc0a

https://github.com/dxx-rebirth/dxx-rebirth/assets/3589969/b0bb4409-9cb6-4a56-903e-c291586ffc26

