### PR TITLE
Update Workflows

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -5,8 +5,10 @@ on:
 
 jobs:
   package:
-    name: macOS
+    name: OS 14
     runs-on: macos-14
+    env:
+        MACOSX_DEPLOYMENT_TARGET: 14
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
-          tag_name: ${{ inputs.tag_name || github.ref }}
-          prerelease: ${{ inputs.prerelease || contains(github.ref, '-') }}
+          tag_name: ${{ inputs.tag_name || github.ref_name }}
+          prerelease: ${{ inputs.prerelease || contains(github.ref_name, '-') }}
           generate_release_notes: true
           files: '*/*.zip'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
         description: Pre-release?
         default: true
         type: boolean
+  push:
+    tags:
+      - "v*.*"
 
 jobs:
   package:
@@ -33,6 +36,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag_name }}
-          prerelease: ${{ inputs.prerelease }}
+          tag_name: ${{ inputs.tag_name || github.ref }}
+          prerelease: ${{ inputs.prerelease || contains(github.ref, '-') }}
+          generate_release_notes: true
           files: '*/*.zip'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: ls -R
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
           tag_name: ${{ inputs.tag_name || github.ref }}
           prerelease: ${{ inputs.prerelease || contains(github.ref, '-') }}

--- a/contrib/packaging/linux/build_package.sh
+++ b/contrib/packaging/linux/build_package.sh
@@ -1,59 +1,30 @@
 #!/bin/bash
-
 set -eux -o pipefail
 
+arch=$(uname -m)
+
 # Grab latest AppImage package
-curl	\
-	--silent	\
-	--show-error	\
-	--location	\
-	--output '#1'	\
-	https://github.com/AppImage/AppImageKit/releases/download/continuous/'{appimagetool-x86_64.AppImage,AppRun-x86_64}'	\
-	|| exit 3
-chmod a+x appimagetool-x86_64.AppImage AppRun-x86_64
+curl --silent --show-error --location --output "#1" \
+    https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/"{linuxdeploy-x86_64.AppImage}" || exit 3
+chmod a+x linuxdeploy-x86_64.AppImage
 
 build_appimage() {
     name="$1"
     prettyname="$2"
 
-    appdir="${name}.appdir"
-    appimagename="${prettyname}.AppImage"
-
-    # Install
-    mkdir "${appdir}"
-
-    # Copy resources into package dir
-    mkdir -p "${appdir}/usr/bin"
-    cp --link "build/${name}/${name}" "${appdir}/usr/bin"
-
-    mkdir -p "${appdir}/usr/share/pixmaps"
-    cp --link "${name}/${name}.xpm" "${appdir}/usr/share/pixmaps"
-    cp --link "${name}/${name}.xpm" "${appdir}/"
-
-    mkdir -p "${appdir}/usr/share/icons/hicolor/128x128/apps/"
-    cp --link "${name}/${name}.png" "${appdir}/usr/share/icons/hicolor/128x128/apps/"
-    cp --link "${name}/${name}.png" "${appdir}/"
-
-    mkdir -p "${appdir}/usr/share/applications"
-    cp --link "${name}/${name}.desktop" "${appdir}/usr/share/applications"
-    cp --link "${name}/${name}.desktop" "${appdir}/"
-
-    # Package
-    cp --link "AppRun-x86_64" "${appdir}/AppRun"
-
     # Package!
-    "./appimagetool-x86_64.AppImage" --no-appstream --verbose "${appdir}" "${appimagename}"
-
-    # Clean
-    rm -rf "${appdir}"
+    export OUTPUT="${prettyname}.AppImage"
+    ./linuxdeploy-x86_64.AppImage \
+        --output appimage \
+        --appdir="${name}.appdir" \
+        --executable="build/${name}/${name}" \
+        --desktop-file="${name}/${name}.desktop" \
+        --icon-file="${name}/${name}.png"
 }
 
-# Build each subunit
+# Build each app
 build_appimage "d1x-rebirth" "D1X-Rebirth"
 build_appimage "d2x-rebirth" "D2X-Rebirth"
 
-# Consolidate into a single zip file
-zip -r -X DXX-Rebirth-Linux-AppImage-`uname -m`.zip D1X-Rebirth.AppImage D2X-Rebirth.AppImage
-
-# Clean
-rm -f appimagetool* AppRun* D1X-Rebirth.AppImage D2X-Rebirth.AppImage
+# Consolidate both apps into a single zip file
+zip -r -X "DXX-Rebirth-Linux-AppImage-${arch}.zip" "D1X-Rebirth.AppImage" "D2X-Rebirth.AppImage"

--- a/contrib/packaging/linux/build_package.sh
+++ b/contrib/packaging/linux/build_package.sh
@@ -4,8 +4,13 @@ set -eux -o pipefail
 arch=$(uname -m)
 
 # Grab AppImage package at specific version
-curl --silent --show-error --location --output "#1" \
-    https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/"{linuxdeploy-x86_64.AppImage}" || exit 3
+curl \
+    --silent \
+    --show-error \
+    --location \
+    --output "#1" \
+    https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/"{linuxdeploy-x86_64.AppImage}" \
+    || exit 3
 chmod a+x linuxdeploy-x86_64.AppImage
 
 build_appimage() {

--- a/contrib/packaging/linux/build_package.sh
+++ b/contrib/packaging/linux/build_package.sh
@@ -3,9 +3,9 @@ set -eux -o pipefail
 
 arch=$(uname -m)
 
-# Grab latest AppImage package
+# Grab AppImage package at specific version
 curl --silent --show-error --location --output "#1" \
-    https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/"{linuxdeploy-x86_64.AppImage}" || exit 3
+    https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/"{linuxdeploy-x86_64.AppImage}" || exit 3
 chmod a+x linuxdeploy-x86_64.AppImage
 
 build_appimage() {

--- a/contrib/packaging/macos/build_package.sh
+++ b/contrib/packaging/macos/build_package.sh
@@ -1,22 +1,8 @@
 #!/bin/bash
-set -x
+set -eux -o pipefail
 
-export MACOSX_DEPLOYMENT_TARGET=14
+arch=$(uname -m)
 
-GIT_HASH=$(git rev-parse --short HEAD)
-
-build_app() {
-    name="$1"
-    prettyname="$2"
-    
-    cd build
-    
-    # Create a single zip file containing both applications
-    zip -r -X ../DXX-Rebirth-MacOS14-`uname -m`.zip D1X-Rebirth.app D2X-Rebirth.app
-    
-    cd ..
-}
-
-# Build both applications
-build_app "d1x-rebirth" "D1X-Rebirth"
-build_app "d2x-rebirth" "D2X-Rebirth"
+# Consolidate both apps into a single zip file
+cd "./build"
+zip -r -X "../DXX-Rebirth-MacOS${MACOSX_DEPLOYMENT_TARGET}-${arch}.zip" "D1X-Rebirth.app" "D2X-Rebirth.app"

--- a/contrib/packaging/windows/build_package.sh
+++ b/contrib/packaging/windows/build_package.sh
@@ -1,39 +1,36 @@
 #!/bin/bash
-
 set -eux -o pipefail
+
+arch=$(uname -m)
+outdir="./tmp"
 
 build_app() {
     name="$1"
     prettyname="$2"
     
-    zipfilename="${prettyname}-win.zip"
-    outdir="."
-
     # Create a subdirectory for each app at the top level
-    mkdir -p "${outdir}/tmp/${prettyname}/Demos"
-    mkdir -p "${outdir}/tmp/${prettyname}/Missions"
-    mkdir -p "${outdir}/tmp/${prettyname}/Screenshots"
+    mkdir -p "${outdir}/${prettyname}/Demos"
+    mkdir -p "${outdir}/${prettyname}/Missions"
+    mkdir -p "${outdir}/${prettyname}/Screenshots"
 
-    # Copy executable and libraries to the respective app directory
-    cp --link "build/${name}/${name}.exe" "${outdir}/tmp/${prettyname}/"
+    # Copy executable to the respective app directory
+    cp --link "build/${name}/${name}.exe" "${outdir}/${prettyname}/"
 
-    # Copy DLLs
-    ldd "${outdir}/tmp/${prettyname}/${name}.exe" | grep mingw64 | sort | cut -d' ' -f3 | while read dll; do cp "${dll}" "${outdir}/tmp/${prettyname}/"; done
+    # Copy libraries to the respective app directory
+    ldd "${outdir}/${prettyname}/${name}.exe" | grep mingw64 | sort | cut -d' ' -f3 | while read dll; do cp "${dll}" "${outdir}/${prettyname}/"; done
 
     # Copy other resources to the respective app directory
-    cp --link "${name}/"*.ini "${outdir}/tmp/${prettyname}/"
-    cp --link COPYING.txt "${outdir}/tmp/${prettyname}/"
-    cp --link GPL-3.txt "${outdir}/tmp/${prettyname}/"
-    cp --link README.md "${outdir}/tmp/${prettyname}/"
-    cp --link INSTALL.markdown "${outdir}/tmp/${prettyname}/"
+    cp --link "${name}/"*.ini "${outdir}/${prettyname}/"
+    cp --link "COPYING.txt" "${outdir}/${prettyname}/"
+    cp --link "GPL-3.txt" "${outdir}/${prettyname}/"
+    cp --link "README.md" "${outdir}/${prettyname}/"
+    cp --link "INSTALL.markdown" "${outdir}/${prettyname}/"
 }
 
-# Build D1X-Rebirth
+# Build each app
 build_app "d1x-rebirth" "D1X-Rebirth"
-
-# Build D2X-Rebirth
 build_app "d2x-rebirth" "D2X-Rebirth"
 
-# zip up and output to top-level dir
-cd tmp
-zip -r -X ../DXX-Rebirth-Win-`uname -m`.zip D1X-Rebirth D2X-Rebirth
+# Consolidate both apps into a single zip file
+cd "${outdir}"
+zip -r -X "../DXX-Rebirth-Win-${arch}.zip" "D1X-Rebirth" "D2X-Rebirth"


### PR DESCRIPTION
Among other things, this PR: 

* Splits monolithic `package.yml` into separate reusable workflows
* Updates various names and spacing for readability
* Reverts builds to SDL1 builds w/ default SCons parameters
  * Choosing this for now until SDL2 support is out of beta
    (except for MacOS, where it's needed)
* Updates Linux deployment:
  * Use GCC 13
  * Remove ubuntu-20.04 package job (seemed redundant for building similar image w/ GCC)
  * Use existing linux/build_package.sh and simplify job a bit
* Updates MacOS deployment:
  * Target OS 14 and simplify job a bit
    * For some reason, macos-13 refuses to work with an error installing scons? No idea
    * macos-12 works, but [generates a few errors during compile](https://github.com/alexstrout/dxx-rebirth/actions/runs/8224723834/job/22488900411#step:4:191)
* Adds `ci.yml`, which runs automatically on merges / PRs to `master` and simply provides build status
* Adds `release.yml`, which can be run manually to generate a release tag
  * See https://github.com/alexstrout/dxx-rebirth/releases/tag/v0.0.2 for an example release from this action
  * Alternatively, you can simply:
    * Download the build artifacts from any workflow run
    * Manually create a release in the GitHub UI with the appropriate builds attached

These _should_ work as-is - hit me up if there's any trouble getting these running under the dxx-rebirth org. :P

Also currently, it looks like there's an issue with the Linux build failing due to a change in b3b4d90b - for demonstration purposes, I reverted that change in my master branch, which is how that example release above is compiled.

Thanks!