### PR TITLE
Fix GitHub Actions Linux builds

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -4,11 +4,9 @@ on:
   workflow_call:
 
 jobs:
-  package:
+  build:
     name: GCC 13
-    runs-on: ubuntu-latest
-    container:
-      image: "ubuntu:24.04"
+    runs-on: "ubuntu:24.04"
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
@@ -27,11 +25,5 @@ jobs:
           CC: gcc-13
           CXX: g++-13
 
-      - name: Package
-        run: ./contrib/packaging/linux/build_package.sh
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux
-          path: '*.zip'
+      - name: Package AppImage
+        run: contrib/packaging/linux/build_package.sh

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -38,7 +38,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Install AppImage dependencies
-        run: sudo apt-get update && sudo apt-get install -y libphysfs1 libfuse2 wget curl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libphysfs1 libsdl1.2 libsdl-image1.2 libsdl-mixer1.2 libpng \
+            libfuse2 wget curl
 
       - name: Clone Repository
         uses: actions/checkout@v4

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -52,6 +52,5 @@ jobs:
 
       - name: Package AppImage
         run: |
-          mv linux-loose/build .
-          rmdir linux-loose
+          ls -la
           contrib/packaging/linux/build_package.sh

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -49,8 +49,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: linux-loose
+          path: build/
 
       - name: Package AppImage
         run: |
-          ls -la
+          ls -la ./build
           contrib/packaging/linux/build_package.sh

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -37,7 +37,7 @@ jobs:
   package:
     name: Package AppImage
     needs: build
-    runs-on: "ubuntu:latest"
+    runs-on: "ubuntu-latest"
     steps:
       - name: Install AppImage dependencies
         run: apt-get update && apt-get install -y libfuse2 wget curl

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: GCC 13 / Ubuntu 24.04
-    runs-on: "ubuntu:latest"
+    runs-on: "ubuntu-latest"
     container:
       image: "ubuntu:24.04"
     steps:

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -36,6 +36,7 @@ jobs:
 
   package:
     name: Package AppImage
+    needs: build
     runs-on: "ubuntu:latest"
     steps:
       - name: Install AppImage dependencies

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -13,15 +13,12 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v4
 
-      - name: Update Package Database
+      - name: Install build tools and dependencies
         run: |
-          apt-get update &&
+          apt-get update
           apt install -y \
-              # Build tools \
               gcc-13 g++-13 python3 scons \
-              # Dependencies \
               libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libphysfs-dev libpng-dev \
-              # AppImage build requirements \
               libfuse2 wget curl
 
       - name: Configure and Build

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Install AppImage dependencies
-        run: apt-get update && apt-get install -y libfuse2 wget curl
+        run: sudo apt-get update && sudo apt-get install -y libfuse2 wget curl
 
       - name: Clone Repository
         uses: actions/checkout@v4

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Update Package Database
         run: |
           apt-get update &&
-          apt install -y
-              # Build tools
-              gcc-13 g++-13 python3 scons
-              # Dependencies
-              libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libphysfs-dev libpng-dev
-              # AppImage build requirements
+          apt install -y \
+              # Build tools \
+              gcc-13 g++-13 python3 scons \
+              # Dependencies \
+              libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libphysfs-dev libpng-dev \
+              # AppImage build requirements \
               libfuse2 wget curl
 
       - name: Configure and Build

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -30,9 +30,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linux-loose
-          path: |
-            build/d1x-rebirth/d1x-rebirth
-            build/d2x-rebirth/d2x-rebirth
+          path: build
 
   package:
     name: Package AppImage

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -6,28 +6,29 @@ on:
 jobs:
   package:
     name: GCC 13
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: "ubuntu:24.04"
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
 
       - name: Update Package Database
-        run: sudo apt-get update
-
-      - name: Install Build Dependencies
-        run: sudo apt install -y gcc-13 g++-13 python3 scons
-
-      - name: Install dxx-rebirth Dependencies
-        run: sudo apt install -y libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libphysfs-dev libpng-dev
+        run: |
+          apt-get update &&
+          apt install -y
+              # Build tools
+              gcc-13 g++-13 python3 scons
+              # Dependencies
+              libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libphysfs-dev libpng-dev
+              # AppImage build requirements
+              libfuse2 wget curl
 
       - name: Configure and Build
         run: scons -j`nproc`
         env:
           CC: gcc-13
           CXX: g++-13
-
-      - name: Install AppImage Requirements
-        run: sudo apt-get install -y libfuse2 wget curl
 
       - name: Package
         run: ./contrib/packaging/linux/build_package.sh

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libphysfs1 libsdl1.2 libsdl-image1.2 libsdl-mixer1.2 libpng \
+            libphysfs1 libsdl1.2-compat libsdl-image1.2 libsdl-mixer1.2 libpng \
             libfuse2 wget curl
 
       - name: Clone Repository

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Install AppImage dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfuse2 wget curl
+        run: sudo apt-get update && sudo apt-get install -y libphysfs libfuse2 wget curl
 
       - name: Clone Repository
         uses: actions/checkout@v4

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -57,3 +57,9 @@ jobs:
         run: |
           ls -la ./build
           contrib/packaging/linux/build_package.sh
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-appimage
+          path: '*.zip'

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libphysfs1 libsdl1.2-compat libsdl-image1.2 libsdl-mixer1.2 \
+            libphysfs1 libsdl1.2-compat libsdl-image1.2 libsdl-mixer1.2 libglu1-mesa \
             libfuse2 wget curl
 
       - name: Clone Repository

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Install AppImage dependencies
-        run: sudo apt-get update && sudo apt-get install -y libphysfs libfuse2 wget curl
+        run: sudo apt-get update && sudo apt-get install -y libphysfs1 libfuse2 wget curl
 
       - name: Clone Repository
         uses: actions/checkout@v4

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libphysfs1 libsdl1.2-compat libsdl-image1.2 libsdl-mixer1.2 libpng \
+            libphysfs1 libsdl1.2-compat libsdl-image1.2 libsdl-mixer1.2 \
             libfuse2 wget curl
 
       - name: Clone Repository

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -5,8 +5,10 @@ on:
 
 jobs:
   build:
-    name: GCC 13
-    runs-on: "ubuntu:24.04"
+    name: GCC 13 / Ubuntu 24.04
+    runs-on: "ubuntu:latest"
+    container:
+      image: "ubuntu:24.04"
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
@@ -16,8 +18,7 @@ jobs:
           apt-get update
           apt install -y \
               gcc-13 g++-13 python3 scons \
-              libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libphysfs-dev libpng-dev \
-              libfuse2 wget curl
+              libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libphysfs-dev libpng-dev
 
       - name: Configure and Build
         run: scons -j`nproc`
@@ -25,5 +26,31 @@ jobs:
           CC: gcc-13
           CXX: g++-13
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-loose
+          path: |
+            build/d1x-rebirth/d1x-rebirth
+            build/d2x-rebirth/d2x-rebirth
+
+  package:
+    name: Package AppImage
+    runs-on: "ubuntu:latest"
+    steps:
+      - name: Install AppImage dependencies
+        run: apt-get update && apt-get install -y libfuse2 wget curl
+
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-loose
+
       - name: Package AppImage
-        run: contrib/packaging/linux/build_package.sh
+        run: |
+          mv linux-loose/build .
+          rmdir linux-loose
+          contrib/packaging/linux/build_package.sh


### PR DESCRIPTION
Apparently at some point in the last few weeks, the GCC 13 packages seem to have vanished from Ubuntu 22 repos. From looking around these are now only available on Ubuntu 24.04, the current LTS release.

I've updated the Linux workflow to build on Ubuntu 24 instead - GitHub's runners for this are still in beta and have long queues for jobs, so I've moved the build into an Ubuntu 24 Docker container running on GitHub's `ubuntu-latest` runners (being the standard ones, but currently still on 22.04) and then use the artifacts in a separate job to run the `AppImage` packaging.