### PR TITLE
Fix building without OpenGL using GCC 14

### DIFF
--- a/similar/main/automap.cpp
+++ b/similar/main/automap.cpp
@@ -653,14 +653,17 @@ static void draw_player(const g3_draw_line_context &context, const object_base &
 	g3_draw_line(context, sphere_point, arrow_point);
 
 	// Draw right head of arrow
-		g3_draw_line(context, arrow_point, /* head_point = */ g3_rotate_point(/* rhead_pos = */ vm_vec_scale_add(head_pos, obj.orient.rvec, obj_size)));
+		auto lhead_point = g3_rotate_point(/* rhead_pos = */ vm_vec_scale_add(head_pos, obj.orient.rvec, obj_size));
+		g3_draw_line(context, arrow_point, lhead_point);
 
 	// Draw left head of arrow
-		g3_draw_line(context, arrow_point, /* head_point = */ g3_rotate_point(/* lhead_pos = */ vm_vec_scale_add(head_pos, obj.orient.rvec, -obj_size)));
+		auto rhead_point = g3_rotate_point(/* lhead_pos = */ vm_vec_scale_add(head_pos, obj.orient.rvec, -obj_size));
+		g3_draw_line(context, arrow_point, rhead_point);
 	}
 
 	// Draw player's up vector
-	g3_draw_line(context, sphere_point, /* arrow_point = */ g3_rotate_point(/* arrow_pos = */ vm_vec_scale_add(obj.pos, obj.orient.uvec, obj_size * 2)));
+	auto arrow_point = g3_rotate_point(/* arrow_pos = */ vm_vec_scale_add(obj.pos, obj.orient.uvec, obj_size * 2));
+	g3_draw_line(context, sphere_point, arrow_point);
 }
 
 #if defined(DXX_BUILD_DESCENT_II)


### PR DESCRIPTION
This was the error:

```
g++ -c -g -O2 -ftabstop=4 -Wall -Wformat=2 -Werror=extra -Werror=missing-braces -Werror=missing-include-dirs -Werror=uninitialized -Werror=undef -Werror=pointer-arith -Werror=cast-qual -Werror=missing-declarations -Werror=vla -pthread -funsigned-char -std=gnu++20 -Werror=unused -Werror=useless-cast -Wimplicit-fallthrough=5 -fstrict-flex-arrays -fvisibility=hidden -Wduplicated-branches -Wduplicated-cond -Wstrict-flex-arrays -Wsuggest-attribute=noreturn -Wsuggest-final-types -Wsuggest-override -Wlogical-op -Wold-style-cast -Wredundant-decls -Wno-sign-compare -DPHYSFS_DEPRECATED= -DDXX_USE_SHAREPATH=1 -DNDEBUG -DRELEASE -D_REENTRANT -DDXX_BUILD_DESCENT_I -D__STDC_FORMAT_MACROS -Icommon/include -Icommon/main -I. -Ibuild/main -I/usr/include/libpng16 -I/usr/include/SDL -I/usr/include/webp -I/usr/include/opus -I/usr/include/pipewire-0.3 -I/usr/include/spa-0.2 -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/usr/include/elogind -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/SDL2 -Id1x-rebirth/main similar/main/automap.cpp -o build/main/similar/main/.d1x-rebirth.automap.o
similar/main/automap.cpp: In function ‘void d1x::{anonymous}::draw_player(const dcx::g3_draw_line_context&, const dcx::object_base&)’:
similar/main/automap.cpp:656:78: error: cannot bind non-const lvalue reference of type ‘dcx::cg3s_point&’ {aka ‘g3s_point&’} to an rvalue of type ‘g3s_point’
  656 |         g3_draw_line(context, arrow_point, /* head_point = */ g3_rotate_point(/* rhead_pos = */ vm_vec_scale_add(head_pos, obj.orient.rvec, obj_size)));
      |                                                               ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from similar/main/automap.cpp:37:
common/include/3d.h:406:84: note:   initializing argument 3 of ‘void dcx::g3_draw_line(const g3_draw_line_context&, cg3s_point&, cg3s_point&)’
  406 | void g3_draw_line(const g3_draw_line_context &context, cg3s_point &p0, cg3s_point &p1);
      |                                                                        ~~~~~~~~~~~~^~
similar/main/automap.cpp:659:78: error: cannot bind non-const lvalue reference of type ‘dcx::cg3s_point&’ {aka ‘g3s_point&’} to an rvalue of type ‘g3s_point’
  659 |         g3_draw_line(context, arrow_point, /* head_point = */ g3_rotate_point(/* lhead_pos = */ vm_vec_scale_add(head_pos, obj.orient.rvec, -obj_size)));
      |                                                               ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
common/include/3d.h:406:84: note:   initializing argument 3 of ‘void dcx::g3_draw_line(const g3_draw_line_context&, cg3s_point&, cg3s_point&)’
  406 | void g3_draw_line(const g3_draw_line_context &context, cg3s_point &p0, cg3s_point &p1);
      |                                                                        ~~~~~~~~~~~~^~
similar/main/automap.cpp:663:76: error: cannot bind non-const lvalue reference of type ‘dcx::cg3s_point&’ {aka ‘g3s_point&’} to an rvalue of type ‘g3s_point’
  663 |     g3_draw_line(context, sphere_point, /* arrow_point = */ g3_rotate_point(/* arrow_pos = */ vm_vec_scale_add(obj.pos, obj.orient.uvec, obj_size * 2)));
      |                                                             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
common/include/3d.h:406:84: note:   initializing argument 3 of ‘void dcx::g3_draw_line(const g3_draw_line_context&, cg3s_point&, cg3s_point&)’
  406 | void g3_draw_line(const g3_draw_line_context &context, cg3s_point &p0, cg3s_point &p1);
      |                                                                        ~~~~~~~~~~~~^~
```