### PR TITLE
Add automatic release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: ls -R
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           prerelease: ${{ inputs.prerelease || contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
     inputs:
       tag_name:
         description: Tag Name (new or existing)
+        required: true
         type: string
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: ls -R
 
       - name: Create Release
-        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           prerelease: ${{ inputs.prerelease || contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         description: Pre-release?
         default: true
         type: boolean
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Tag Name (new or existing)
+        type: string
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
   push:
     tags:
-      - "v*.*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   package:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,6 +21,8 @@ jobs:
   release:
     name: Create release
     needs: tag
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     with:
         tag_name: ${{ needs.tag.steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,19 @@
+name: Create version tag
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  tag:
+    name: Create tag
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -25,4 +25,4 @@ jobs:
       contents: write
     uses: ./.github/workflows/release.yml
     with:
-        tag_name: ${{ needs.tag.steps.tag_version.outputs.new_tag }}
+      tag_name: ${{ needs.tag.steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   tag:
     name: Create tag
+    id: create_tag
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -18,7 +19,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create release
-        uses: release.yml
-        with:
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+  release:
+    name: Create release
+    needs: create_tag
+    uses: ./.github/workflows/release.yml
+    with:
+        tag_name: ${{ needs.create_tag.steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   tag:
     name: Create tag
-    id: create_tag
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -21,7 +20,7 @@ jobs:
 
   release:
     name: Create release
-    needs: create_tag
+    needs: tag
     uses: ./.github/workflows/release.yml
     with:
-        tag_name: ${{ needs.create_tag.steps.tag_version.outputs.new_tag }}
+        tag_name: ${{ needs.tag.steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: Create version tag
+name: Create tagged release
 on:
   push:
     branches:
@@ -7,7 +7,9 @@ on:
 
 jobs:
   tag:
-    name: Create tag
+    name: Create new tag
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -25,4 +27,4 @@ jobs:
       contents: write
     uses: ./.github/workflows/release.yml
     with:
-      tag_name: ${{ needs.tag.steps.tag_version.outputs.new_tag }}
+      tag_name: ${{ needs.tag.outputs.new_tag }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,3 +17,8 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        uses: release.yml
+        with:
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ See [COPYING.txt](COPYING.txt) and [GPL-3.txt](GPL-3.txt)
 ## 5. Contact:
 
 - https://www.dxx-rebirth.com/
+- zico [at] dxx-rebirth [dot] com
+
 
 ## 6. Issue Reporting
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ See [COPYING.txt](COPYING.txt) and [GPL-3.txt](GPL-3.txt)
 ## 5. Contact:
 
 - https://www.dxx-rebirth.com/
-- zico [at] dxx-rebirth [dot] com
-   
+
 ## 6. Issue Reporting
 
 Use GitHub issues tab report a [new issue](https://github.com/dxx-rebirth/dxx-rebirth/issues/new), be sure to add as much detail as possible in the template provided.


### PR DESCRIPTION
This adds a new workflow, `tag.yml`, which will automatically create a new semver tag on the repository when changes are merged to `master` (or the more modern equivalent `main` in case `master` ever gets renamed there); additionally this will then run the existing `release.yml` workflow to create a new GitHub release for the new tag.