### PR TITLE
Fix package names

### DIFF
--- a/d1x-rebirth/io.github.dxx_rebirth.dxx_rebirth.d1x-rebirth.metainfo.xml
+++ b/d1x-rebirth/io.github.dxx_rebirth.dxx_rebirth.d1x-rebirth.metainfo.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>io.github.dxx_rebirth.d1x-rebirth</id>
+  <id>io.github.dxx_rebirth.dxx_rebirth.d1x-rebirth</id>
   <name>D1X-Rebirth</name>
   <developer id="io.github.dxx-rebirth.contributors">
     <name>DXX-Rebirth Contributors</name>
     <url>https://github.com/dxx-rebirth/dxx-rebirth/graphs/contributors</url>
   </developer>
-  <launchable type="desktop-id">io.github.dxx_rebirth.d1x-rebirth.desktop</launchable>
+  <launchable type="desktop-id">io.github.dxx_rebirth.dxx_rebirth.d1x-rebirth.desktop</launchable>
   <summary>Modern cross-platform port of the Descent 1 engine</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary=https://raw.githubusercontent.com/dxx-rebirth/dxx-rebirth/master/COPYING.txt,GPL-3.0</project_license>

--- a/d2x-rebirth/io.github.dxx_rebirth.dxx_rebirth.d2x-rebirth.metainfo.xml
+++ b/d2x-rebirth/io.github.dxx_rebirth.dxx_rebirth.d2x-rebirth.metainfo.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>io.github.dxx_rebirth.d2x-rebirth</id>
+  <id>io.github.dxx_rebirth.dxx_rebirth.d2x-rebirth</id>
   <name>D2X-Rebirth</name>
   <developer id="io.github.dxx-rebirth.contributors">
     <name>DXX-Rebirth Contributors</name>
     <url>https://github.com/dxx-rebirth/dxx-rebirth/graphs/contributors</url>
   </developer>
-  <launchable type="desktop-id">io.github.dxx_rebirth.d2x-rebirth.desktop</launchable>
+  <launchable type="desktop-id">io.github.dxx_rebirth.dxx_rebirth.d2x-rebirth.desktop</launchable>
   <summary>Modern cross-platform port of the Descent 2 engine</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary=https://raw.githubusercontent.com/dxx-rebirth/dxx-rebirth/master/COPYING.txt,GPL-3.0</project_license>


### PR DESCRIPTION
I got the package names wrong here, as I've found out when trying to get this through Flathub's CI. The first four components should be io.github.owner.repository, and of course there are no `dxx-rebirth/d1x-rebirth`/`dxx-rebirth/d2x-rebirth` repositories. Fixed that...