### PR TITLE
Fix release pipeline / missing Windows ogg playback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,13 @@ jobs:
       - name: Display Artifacts
         run: ls -R
 
+      - name: Compress Artifacts
+        run: ls . | while read dir; do cd ${dir}; zip -r ../${dir}.zip *; cd ..; done
+
       - name: Create Release
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           prerelease: ${{ inputs.prerelease || contains(github.ref_name, '-') }}
           generate_release_notes: true
-          files: '*/*.zip'
+          files: '*.zip'

--- a/contrib/packaging/windows/build_package.sh
+++ b/contrib/packaging/windows/build_package.sh
@@ -20,7 +20,7 @@ build_app() {
 	local name prettyname
     name="$1"
     prettyname="$2"
-    
+
     # Create a subdirectory for each app at the top level
     mkdir -p "${outdir}/${prettyname}/Demos"
     mkdir -p "${outdir}/${prettyname}/Missions"
@@ -30,7 +30,15 @@ build_app() {
     cp --link "build/${name}/${name}.exe" "${outdir}/${prettyname}/"
 
     # Copy libraries to the respective app directory
-    ldd "${outdir}/${prettyname}/${name}.exe" | grep mingw64 | sort | cut -d' ' -f3 | while read dll; do cp "${dll}" "${outdir}/${prettyname}/"; done
+    copy_lib() {
+        ldd "$1" | grep mingw64 | sort | cut -d' ' -f3 | while read dll; do cp "${dll}" "${outdir}/${prettyname}/"; done
+    }
+    copy_lib "${outdir}/${prettyname}/${name}.exe"
+
+    # ogg support is dynamically loaded, so manually copy this (and its libs) too
+    # TODO FLAC support? Missing libflac-8.dll but unable to find mingw64 package
+    cp "/mingw64/bin/libvorbisfile-3.dll" "${outdir}/${prettyname}/"
+    copy_lib "/mingw64/bin/libvorbisfile-3.dll"
 
     # Copy other resources to the respective app directory
     cp --link "${name}/"*.ini "${outdir}/${prettyname}/"


### PR DESCRIPTION
While trying a recent pipeline build, I noticed the release workflow no longer attaches any .zip files.

On closer inspection, it looks like the build artifacts are now folders instead of the pre-packaged .zips; see "Display Artifacts" step of [job/36825594735](https://github.com/alexstrout/dxx-rebirth/actions/runs/13191581990/job/36825594735) (note GitHub requires sign-in to view log details / artifacts)

This seems reasonable enough, so I added a final zip step to the release job. (and changed the path accordingly)

I also noticed that on Windows, .ogg playback (e.g. addon music) was failing due to missing `libvorbisfile-3.dll` (and its dependencies) - since it's dynamically loaded, ldd seems to miss it, so as a workaround I added a manual copy command to grab it (+ deps).

Here's a result of the above actions:
https://github.com/alexstrout/dxx-rebirth/releases/tag/v0.0.11

Open to suggestions / alternatives etc. Thanks!