### PR TITLE
Fix macOS compilation by removing unused variable

### DIFF
--- a/common/misc/ignorecase.cpp
+++ b/common/misc/ignorecase.cpp
@@ -59,7 +59,7 @@ static std::optional<std::size_t> caseInsensitiveStringCompare(const char *x, co
 
 static PHYSFSX_case_search_result locateOneElement(char *const sptr, char *const ptr, const char *buf)
 {
-    if (const auto r = PHYSFS_exists(buf))
+    if (PHYSFS_exists(buf))
         return PHYSFSX_case_search_result::success;  /* quick rejection: exists in current case. */
 
 	struct search_result : PHYSFSX_uncounted_list


### PR DESCRIPTION
Currently, macOS compilation is failing with:

```
common/misc/ignorecase.cpp:62:20: error: variable 'r' set but not used [-Werror,-Wunused-but-set-variable]
   62 |     if (const auto r = PHYSFS_exists(buf))
      |                    ^
1 error generated.
scons: *** [build/common/misc/ignorecase.o] Error 1
scons: building terminated because of errors.
```

It looks like that variable isn't used anywhere, so this just changes that check to not save the result of `PHYSFS_exists()` and just use it in the `if` statement instead.