### PR TITLE
Fix macOS compilation errors

### DIFF
--- a/common/include/vecmat.h
+++ b/common/include/vecmat.h
@@ -27,6 +27,7 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 #include <cassert>
 #include <cstdint>
+#include <cstdlib>
 #include <utility>
 #include "fwd-vecmat.h"
 

--- a/common/main/text.h
+++ b/common/main/text.h
@@ -27,6 +27,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 #include "dxxsconf.h"
 #include <array>
+#include <bit>
 #include <span>
 
 //Symbolic constants for all the strings

--- a/similar/main/fvi.cpp
+++ b/similar/main/fvi.cpp
@@ -815,7 +815,7 @@ static fvi_hit_type fvi_sub(const fvi_query &fq, vms_vector &intp, segnum_t &int
 				continue;
 			if (objnum->flags & OF_SHOULD_BE_DEAD)
 				continue;
-			if (collision_result{CollisionResult[this_collision_upper_bits | static_cast<unsigned>(objnum->type)]} == collision_result::ignore)
+			if (collision_result{static_cast<bool>(CollisionResult[this_collision_upper_bits | static_cast<unsigned>(objnum->type)])} == collision_result::ignore)
 				continue;
 			if (laser_are_related(objnum, thisobjnum))
 				continue;
@@ -876,7 +876,7 @@ static fvi_hit_type fvi_sub(const fvi_query &fq, vms_vector &intp, segnum_t &int
 	 * it is kept for consistency with other uses where both terms need to be
 	 * used.  The compiler should optimize out the resulting `0 |` in this case.
 	 */
-	if (fq.thisobjnum != object_none && collision_result{CollisionResult[(object_type::OBJ_WALL << 4) | static_cast<unsigned>(fq.thisobjnum->type)]} == collision_result::ignore)
+	if (fq.thisobjnum != object_none && collision_result{static_cast<bool>(CollisionResult[(object_type::OBJ_WALL << 4) | static_cast<unsigned>(fq.thisobjnum->type)])} == collision_result::ignore)
 		rad = 0;		//HACK - ignore when edges hit walls
 
 	//now, check segment walls


### PR DESCRIPTION
This fixes some compilation errors that I noticed in the current tree when I attempted to build commit 1421a3a2da5d8080916a9d2ceedb5fc1bfb65109.  Specifically, the issues resolved are:

For the `vecmat.h` change:

```
common/maths/vecmat.cpp:301:8: error: no member named 'abs' in
      namespace 'std'; did you mean simply 'abs'?
  301 |     fix a{std::abs(v.x)};
      |           ^~~~~~~~
      |           abs
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/math.h:437:20: note:
      'abs' declared here
  437 | using std::__math::abs;
      |                    ^
common/maths/vecmat.cpp:301:8: error: non-constant-expression
      cannot be narrowed from type 'long long' to 'fix' (aka 'int') in initializer list
      [-Wc++11-narrowing]
  301 |     fix a{std::abs(v.x)};
      |           ^~~~~~~~~~~~~
common/maths/vecmat.cpp:301:8: note: insert an explicit cast to
      silence this issue
  301 |     fix a{std::abs(v.x)};
      |           ^~~~~~~~~~~~~
      |           static_cast<fix>( )
common/maths/vecmat.cpp:302:8: error: no member named 'abs' in
      namespace 'std'; did you mean simply 'abs'?
  302 |     fix b{std::abs(v.y)};
      |           ^~~~~~~~
      |           abs
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/math.h:437:20: note:
      'abs' declared here
  437 | using std::__math::abs;
      |                    ^
common/maths/vecmat.cpp:302:8: error: non-constant-expression
      cannot be narrowed from type 'long long' to 'fix' (aka 'int') in initializer list
      [-Wc++11-narrowing]
  302 |     fix b{std::abs(v.y)};
      |           ^~~~~~~~~~~~~
common/maths/vecmat.cpp:302:8: note: insert an explicit cast to
      silence this issue
  302 |     fix b{std::abs(v.y)};
      |           ^~~~~~~~~~~~~
      |           static_cast<fix>( )
common/maths/vecmat.cpp:308:8: error: no member named 'abs' in
      namespace 'std'; did you mean simply 'abs'?
  308 |     fix c{std::abs(v.z)};
      |           ^~~~~~~~
      |           abs
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/math.h:437:20: note:
      'abs' declared here
  437 | using std::__math::abs;
      |                    ^
common/maths/vecmat.cpp:308:8: error: non-constant-expression
      cannot be narrowed from type 'long long' to 'fix' (aka 'int') in initializer list
      [-Wc++11-narrowing]
  308 |     fix c{std::abs(v.z)};
      |           ^~~~~~~~~~~~~
common/maths/vecmat.cpp:308:8: note: insert an explicit cast to
      silence this issue
  308 |     fix c{std::abs(v.z)};
      |           ^~~~~~~~~~~~~
      |           static_cast<fix>( )
6 errors generated.
```

For `fvi.cpp`:

```
similar/main/fvi.cpp:818:8: error: no viable conversion from
      '__const_reference' (aka '__bit_const_reference<__bitset<4, 256>>') to
      'collision_result'
  818 |   ...collision_result{CollisionResult[this_collision_upper_bits | static_cast<unsigned>(objnum->type)]}...
      |      ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__bit_reference:232:43: note:
      candidate function
  232 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR operator bool() const _NOEXCEPT {
      |                                           ^
similar/main/fvi.cpp:879:38: error: no viable conversion from
      '__const_reference' (aka '__bit_const_reference<__bitset<4, 256>>') to
      'collision_result'
  879 |   ...collision_result{CollisionResult[(object_type::OBJ_WALL << 4) | static_cast<unsigned>(fq.thisobjnum->type)]}...
      |      ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__bit_reference:232:43: note:
      candidate function
  232 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR operator bool() const _NOEXCEPT {
      |                                           ^
2 errors generated.
```

And for `text.h`:

```
similar/main/text.cpp:60:26: error: no member named 'rotl' in
      namespace 'std'
   60 |     const uint8_t c2 = std::rotl(c, 1) ^ BITMAP_TBL_XOR;
      |                             ^~~~
similar/main/text.cpp:61:15: error: no member named 'rotl' in
      namespace 'std'
   61 |     return {std::rotl(c2, 1)};
      |                  ^~~~
2 errors generated.
```