### PR TITLE
D1X movies patch

### DIFF
--- a/common/include/compiler-poison.h
+++ b/common/include/compiler-poison.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#if DXX_HAVE_POISON
 #include <algorithm>
-#endif
-
 #include <cstdint>
 #include <memory>
 #include <span>

--- a/common/include/event.h
+++ b/common/include/event.h
@@ -10,6 +10,7 @@
 
 #include <SDL_version.h>
 #include "fwd-event.h"
+#include "fwd-window.h"
 #include "maths.h"
 
 #if SDL_MAJOR_VERSION == 2
@@ -147,7 +148,11 @@ fix event_get_idle_seconds();
 // without its own event loop
 static inline void event_process_all(void)
 {
-	while (event_process() != window_event_result::deleted) {}
+	while (event_process() != window_event_result::deleted)
+	{
+		if (!window_get_front())
+			break;
+	}
 }
 
 }

--- a/common/include/loadgl.h
+++ b/common/include/loadgl.h
@@ -27,7 +27,11 @@
 #define OGLFUNCCALL
 #endif
 
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #include "pstypes.h"
 
 //gl extensions.

--- a/d1x-rebirth/main/movie.cpp
+++ b/d1x-rebirth/main/movie.cpp
@@ -69,19 +69,6 @@ struct movie_pause_window : window
 	virtual window_event_result event_handler(const d_event &) override;
 };
 
-static constexpr bool valid_palette_color_range(const unsigned start, const unsigned count)
-{
-	if (start == 0)
-		return false;
-	if (start > 254)
-		return false;
-	if (count > 254)
-		return false;
-	if (start + count > 255)
-		return false;
-	return true;
-}
-
 }
 
 unsigned MovieFileRead(SDL_RWops *const handle, const std::span<uint8_t> buf)

--- a/d1x-rebirth/main/movie.cpp
+++ b/d1x-rebirth/main/movie.cpp
@@ -131,20 +131,12 @@ void MovieShowFrame(const uint8_t *buf, int dstx, int dsty, int bufw, int bufh, 
 	source_bm.clear_flags();
 	source_bm.bm_data = buf;
 
-	if (dstx == -1 && dsty == -1) // Fullscreen movie so set scale to fit the actual screen size
-	{
-		if ((static_cast<float>(SWIDTH)/SHEIGHT) < (static_cast<float>(sw)/bufh))
-			scale = (static_cast<float>(SWIDTH)/sw);
-		else
-			scale = (static_cast<float>(SHEIGHT)/bufh);
-	}
-	else // Other movie so set scale to min. screen dimension
-	{
-		if ((static_cast<float>(SWIDTH)/bufw) < (static_cast<float>(SHEIGHT)/bufh))
-			scale = (static_cast<float>(SWIDTH)/sw);
-		else
-			scale = (static_cast<float>(SHEIGHT)/sh);
-	}
+	(void)sw;
+	(void)sh;
+	if ((static_cast<float>(SWIDTH) / bufw) < (static_cast<float>(SHEIGHT) / bufh))
+		scale = static_cast<float>(SWIDTH) / bufw;
+	else
+		scale = static_cast<float>(SHEIGHT) / bufh;
 
 	if (dstx == -1) // center it
 		dstx = (SWIDTH/2)-((bufw*scale)/2);
@@ -166,7 +158,16 @@ void MovieShowFrame(const uint8_t *buf, int dstx, int dsty, int bufw, int bufh, 
 
 	glEnable (GL_BLEND);
 #else
-	gr_bm_ubitbltm(*grd_curcanv, bufw, bufh, dstx, dsty, 0, 0, source_bm);
+	{
+		const int dstw = static_cast<int>(bufw * scale);
+		const int dsth = static_cast<int>(bufh * scale);
+		const std::array<grs_point, 3> vertbuf{{
+			{i2f(dstx), i2f(dsty)},
+			{0, 0},
+			{i2f(dstx + dstw), i2f(dsty + dsth)}
+		}};
+		scale_bitmap(source_bm, vertbuf, 0, grd_curcanv->cv_bitmap);
+	}
 #endif
 }
 

--- a/similar/main/titles.cpp
+++ b/similar/main/titles.cpp
@@ -242,11 +242,11 @@ static int DefineBriefingBox(const grs_bitmap &, const char *&buf);
 void show_titles(void)
 {
 #if DXX_BUILD_DESCENT == 1
-	songs_play_song(song_number::title, 1);
-#endif
 	if (CGameArg.SysNoTitles)
+	{
+		songs_play_song(song_number::title, 1);
 		return;
-#if DXX_BUILD_DESCENT == 1
+	}
 
 	// Try to play PSX intro movies if present (from extra1-h.mvl)
 	if (PlayMovie({}, "starta.mve", play_movie_warn_missing::verbose) == movie_play_status::skipped)
@@ -267,6 +267,7 @@ void show_titles(void)
 		show_title_screen((resolution_at_least_640_480 && PHYSFS_exists(logo_hires_pcx)) ? logo_hires_pcx : "logo.pcx", title_load_location::from_hog_only);
 		show_title_screen((resolution_at_least_640_480 && PHYSFS_exists(descent_hires_pcx)) ? descent_hires_pcx : "descent.pcx", title_load_location::from_hog_only);
 	}
+	songs_play_song(song_number::title, 1);
 #elif DXX_BUILD_DESCENT == 2
 	int song_playing{0};
 


### PR DESCRIPTION
Addresses #841

- Title music plays after movies
- Movies stretch to fill screen (sized differently than d2x)
- Clicking X in window bar during briefing closes briefing and skips to gameplay (not ideal, should just close the app, but avoids the hang)
- Fix macos build failure and ci failure where build would succeed but ci would fail

https://github.com/JeodC/dxx-rebirth/actions/runs/24340838318