### PR TITLE
MVE: preserve SDL2 movie audio resampler state

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3637,10 +3637,10 @@ class DXXCommon(LazyObjectConstructor):
 	class RuntimeTest(LazyObjectConstructor):
 		target: str
 		source: collections.abc.Sequence[str]
-		nodefaultlibs: bool = True
-		def __init__(self, target: str, source: collections.abc.Sequence[str]):
+		def __init__(self, target: str, source: collections.abc.Sequence[str], nodefaultlibs: bool = True):
 			self.target = target
 			self.source = LazyObjectConstructor.create_lazy_object_getter(source)
+			self.nodefaultlibs = nodefaultlibs
 
 	@cached_property
 	def program_message_prefix(self):
@@ -4930,6 +4930,9 @@ class DXXArchive(DXXCommon):
 		RuntimeTest('test-enumerate', (
 			'common/unittest/enumerate.cpp',
 			)),
+		RuntimeTest('test-mve-audio-stream', (
+			'd2x-rebirth/unittest/mve_audio_stream.cpp',
+			), nodefaultlibs=False),
 		RuntimeTest('test-serial', (
 			'common/unittest/serial.cpp',
 			)),

--- a/d2x-rebirth/libmve/mvelib.h
+++ b/d2x-rebirth/libmve/mvelib.h
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <cstdint>
+#include <mutex>
 #include <span>
 #include <vector>
 #include "dxxsconf.h"
@@ -22,6 +23,18 @@
 #include "physfsrwops.h"
 
 namespace dsx {
+
+#if DXX_USE_SDLMIXER && SDL_MAJOR_VERSION == 2
+struct MVE_audio_stream_deleter
+{
+	void operator()(SDL_AudioStream *const stream) const
+	{
+		SDL_FreeAudioStream(stream);
+	}
+};
+
+using MVE_audio_stream_ptr = std::unique_ptr<SDL_AudioStream, MVE_audio_stream_deleter>;
+#endif
 
 enum class mve_opcode : uint8_t
 {
@@ -113,6 +126,9 @@ struct MVESTREAM
 	std::span<const uint8_t> pCurMap{};
 	std::vector<unsigned char> vBuffers{};
 	std::unique_ptr<SDL_AudioSpec> mve_audio_spec;
+#if DXX_USE_SDLMIXER && SDL_MAJOR_VERSION == 2
+	MVE_audio_stream_ptr mve_audio_stream;
+#endif
 	const MVE_play_sounds mve_audio_enabled;
 	bool mve_audio_playing{};
 	uint8_t timer_created{};
@@ -130,10 +146,14 @@ struct MVESTREAM
 	int mve_audio_bufhead{};
 	int mve_audio_buftail{};
 	int mve_audio_curbuf_curpos{};
+	std::mutex mve_audio_mutex;
 	unsigned char *vBackBuf1{};
 	unsigned char *vBackBuf2{};
 	std::array<::dcx::unique_span<int16_t>, 64> mve_audio_buffers;
 	bool queue_mve_audio_buffer(::dcx::unique_span<int16_t> &&buffer);
+#if DXX_USE_SDLMIXER && SDL_MAJOR_VERSION == 2
+	bool drain_mve_audio_stream();
+#endif
 
 	handle_result handle_mve_segment_endofstream();
 	handle_result handle_mve_segment_endofchunk();

--- a/d2x-rebirth/libmve/mvelib.h
+++ b/d2x-rebirth/libmve/mvelib.h
@@ -133,6 +133,7 @@ struct MVESTREAM
 	unsigned char *vBackBuf1{};
 	unsigned char *vBackBuf2{};
 	std::array<::dcx::unique_span<int16_t>, 64> mve_audio_buffers;
+	bool queue_mve_audio_buffer(::dcx::unique_span<int16_t> &&buffer);
 
 	handle_result handle_mve_segment_endofstream();
 	handle_result handle_mve_segment_endofchunk();

--- a/d2x-rebirth/libmve/mveplay.cpp
+++ b/d2x-rebirth/libmve/mveplay.cpp
@@ -32,7 +32,6 @@
 #endif
 
 #include "config.h"
-#include "d_sdl_audio.h"
 #include "mvelib.h"
 #include "mve_audio.h"
 #include "byteutil.h"
@@ -237,6 +236,7 @@ static void mve_audio_callback(void *userdata, unsigned char *stream, int len);
 static void mve_audio_callback(void *const vstream, unsigned char *stream, int len)
 {
 	auto &mvestream = *reinterpret_cast<MVESTREAM *>(vstream);
+	const std::lock_guard lock{mvestream.mve_audio_mutex};
 #ifdef DXX_REPORT_TOTAL_LENGTH
 	int total{0};
 #endif
@@ -298,6 +298,7 @@ static void mve_audio_callback(void *const vstream, unsigned char *stream, int l
 
 bool MVESTREAM::queue_mve_audio_buffer(::dcx::unique_span<int16_t> &&buffer)
 {
+	const std::lock_guard lock{mve_audio_mutex};
 	auto next = mve_audio_buftail + 1;
 	if (next == mve_audio_buffers.size())
 		next = 0;
@@ -310,6 +311,35 @@ bool MVESTREAM::queue_mve_audio_buffer(::dcx::unique_span<int16_t> &&buffer)
 	mve_audio_buftail = next;
 	return true;
 }
+
+#if DXX_USE_SDLMIXER && SDL_MAJOR_VERSION == 2
+bool MVESTREAM::drain_mve_audio_stream()
+{
+	const auto available = SDL_AudioStreamAvailable(mve_audio_stream.get());
+	if (available < 0)
+	{
+		con_printf(CON_URGENT, "%s:%u: SDL_AudioStreamAvailable failed: %s", __FILE__, __LINE__, SDL_GetError());
+		return false;
+	}
+	if (!available)
+		return true;
+	auto output = std::make_unique<int16_t[]>((available + 1) / 2);
+	const auto converted = SDL_AudioStreamGet(mve_audio_stream.get(), output.get(), available);
+	if (converted < 0)
+	{
+		con_printf(CON_URGENT, "%s:%u: SDL_AudioStreamGet failed: %s", __FILE__, __LINE__, SDL_GetError());
+		return false;
+	}
+	if (converted & 1)
+	{
+		con_printf(CON_URGENT, "%s:%u: SDL_AudioStreamGet returned odd byte count: %d", __FILE__, __LINE__, converted);
+		return false;
+	}
+	if (!converted)
+		return true;
+	return queue_mve_audio_buffer(::dcx::unique_span<int16_t>{std::move(output), static_cast<std::size_t>(converted) / sizeof(int16_t)});
+}
+#endif
 
 MVESTREAM::handle_result MVESTREAM::handle_mve_segment_initaudiobuffers(unsigned char minor, const unsigned char *data)
 {
@@ -327,6 +357,7 @@ MVESTREAM::handle_result MVESTREAM::handle_mve_segment_initaudiobuffers(unsigned
 	if (!minor)
 		flags &= ~MVE_AUDIO_FLAGS_COMPRESSED;
 	mve_audio_flags = flags;
+	mve_audio_buffers = {};
 
 	const unsigned format = (bitsize)
 		? (words_bigendian ? AUDIO_S16MSB : AUDIO_S16LSB)
@@ -365,27 +396,53 @@ MVESTREAM::handle_result MVESTREAM::handle_mve_segment_initaudiobuffers(unsigned
 
 #if DXX_USE_SDLMIXER
 	else {
-		// MD2211: using the same old SDL audio callback as a postmixer in SDL_mixer
-		Mix_SetPostMix(s.callback, s.userdata);
+#if SDL_MAJOR_VERSION == 2
+		int output_frequency;
+		Uint16 output_format;
+		int output_channels;
+		if (!Mix_QuerySpec(&output_frequency, &output_format, &output_channels))
+		{
+			con_printf(CON_URGENT, "Mix_QuerySpec failed while preparing movie audio: %s", Mix_GetError());
+			mve_audio_spec = {};
+		}
+		else if (!(mve_audio_stream = MVE_audio_stream_ptr{SDL_NewAudioStream(
+			s.format, s.channels, s.freq, output_format, output_channels, output_frequency)}))
+		{
+			con_printf(CON_URGENT, "SDL_NewAudioStream failed while preparing movie audio: %s", SDL_GetError());
+			mve_audio_spec = {};
+		}
+		else
+#endif
+		{
+			// MD2211: using the same old SDL audio callback as a postmixer in SDL_mixer
+			Mix_SetPostMix(s.callback, s.userdata);
+		}
 	}
 #endif
 	}
 
-	mve_audio_buffers = {};
 	return MVESTREAM::handle_result::step_again;
 }
 
 MVESTREAM::handle_result MVESTREAM::handle_mve_segment_startstopaudio()
 {
-	if (mve_audio_spec && !mve_audio_playing && mve_audio_bufhead != mve_audio_buftail)
+	if (mve_audio_spec && !mve_audio_playing)
 	{
-		if (CGameArg.SndDisableSdlMixer)
-			SDL_PauseAudio(0);
+		bool have_queued_audio;
+		{
+			const std::lock_guard lock{mve_audio_mutex};
+			have_queued_audio = mve_audio_bufhead != mve_audio_buftail;
+		}
+		if (have_queued_audio)
+		{
+			if (CGameArg.SndDisableSdlMixer)
+				SDL_PauseAudio(0);
 #if DXX_USE_SDLMIXER
-		else
-			Mix_Pause(0);
+			else
+				Mix_Pause(0);
 #endif
-		mve_audio_playing = 1;
+			mve_audio_playing = 1;
+		}
 	}
 	return MVESTREAM::handle_result::step_again;
 }
@@ -412,10 +469,6 @@ MVESTREAM::handle_result MVESTREAM::handle_mve_segment_audioframedata(const mve_
 	static const int selected_chan=1;
 	if (const auto mve_audio_spec = this->mve_audio_spec.get())
 	{
-		std::optional<RAII_SDL_LockAudio> lock_audio{
-			mve_audio_playing ? std::optional<RAII_SDL_LockAudio>(std::in_place) : std::nullopt
-		};
-
 		const auto chan = get_ushort(data + 2);
 		unsigned nsamp = get_ushort(data + 4);
 		if (chan & selected_chan)
@@ -459,9 +512,18 @@ MVESTREAM::handle_result MVESTREAM::handle_mve_segment_audioframedata(const mve_
 				p = {nsamp / 2};
 			}
 
-			// MD2211: the following block does on-the-fly audio conversion for SDL_mixer
+			// Convert movie audio to the SDL_mixer output format.  SDL2 keeps one
+			// stream for the entire movie so resampler state is preserved across
+			// MVE segment boundaries.
 #if DXX_USE_SDLMIXER
 			if (!CGameArg.SndDisableSdlMixer) {
+#if SDL_MAJOR_VERSION == 2
+				if (SDL_AudioStreamPut(mve_audio_stream.get(), p.get(), nsamp))
+					con_printf(CON_URGENT, "%s:%u: SDL_AudioStreamPut failed: %s", __FILE__, __LINE__, SDL_GetError());
+				else
+					drain_mve_audio_stream();
+				p = {};
+#else
 				// build converter: in = MVE format, out = SDL_mixer output
 				int out_freq;
 				Uint16 out_format;
@@ -490,9 +552,11 @@ MVESTREAM::handle_result MVESTREAM::handle_mve_segment_audioframedata(const mve_
 					p = {converted_buffer_size / 2};
 					memcpy(p.get(), cvt.buf, converted_buffer_size);
 				}
+#endif
 			}
 #endif
-			queue_mve_audio_buffer(std::move(p));
+			if (p.get())
+				queue_mve_audio_buffer(std::move(p));
 		}
 	}
 
@@ -683,7 +747,11 @@ void MVE_rmEndMovie(std::unique_ptr<MVESTREAM> stream)
 		}
 #if DXX_USE_SDLMIXER
 		else
+		{
 			Mix_SetPostMix(nullptr, nullptr);
+			/* Wait for any callback that began before it was unregistered. */
+			const std::lock_guard lock{stream->mve_audio_mutex};
+		}
 #endif
 	}
 }

--- a/d2x-rebirth/libmve/mveplay.cpp
+++ b/d2x-rebirth/libmve/mveplay.cpp
@@ -296,6 +296,21 @@ static void mve_audio_callback(void *const vstream, unsigned char *stream, int l
 	//con_printf(CON_CRITICAL, "- <%d (%d), %d, %d>", mvestream.mve_audio_bufhead, mvestream.mve_audio_curbuf_curpos, mvestream.mve_audio_buftail, len);
 }
 
+bool MVESTREAM::queue_mve_audio_buffer(::dcx::unique_span<int16_t> &&buffer)
+{
+	auto next = mve_audio_buftail + 1;
+	if (next == mve_audio_buffers.size())
+		next = 0;
+	if (next == mve_audio_bufhead)
+	{
+		con_printf(CON_CRITICAL, "d'oh!  buffer ring overrun (%d)", mve_audio_bufhead);
+		return false;
+	}
+	mve_audio_buffers[mve_audio_buftail] = std::move(buffer);
+	mve_audio_buftail = next;
+	return true;
+}
+
 MVESTREAM::handle_result MVESTREAM::handle_mve_segment_initaudiobuffers(unsigned char minor, const unsigned char *data)
 {
 	if (mve_audio_enabled == MVE_play_sounds::silent)
@@ -477,13 +492,7 @@ MVESTREAM::handle_result MVESTREAM::handle_mve_segment_audioframedata(const mve_
 				}
 			}
 #endif
-			mve_audio_buffers[mve_audio_buftail] = std::move(p);
-
-			if (++mve_audio_buftail == mve_audio_buffers.size())
-				mve_audio_buftail = 0;
-
-			if (mve_audio_buftail == mve_audio_bufhead)
-				con_printf(CON_CRITICAL, "d'oh!  buffer ring overrun (%d)", mve_audio_bufhead);
+			queue_mve_audio_buffer(std::move(p));
 		}
 	}
 

--- a/d2x-rebirth/unittest/mve_audio_stream.cpp
+++ b/d2x-rebirth/unittest/mve_audio_stream.cpp
@@ -1,0 +1,101 @@
+/*
+ * This file is part of the DXX-Rebirth project <https://github.com/dxx-rebirth/dxx-rebirth/>.
+ * It is copyright by its individual contributors, as recorded in the
+ * project's Git history.  See COPYING.txt at the top level for license
+ * terms and a link to the Git history.
+ */
+
+#include "dxxsconf.h"
+
+#include <SDL.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE Rebirth MVE audio stream
+#include <boost/test/unit_test.hpp>
+
+#if DXX_USE_SDLMIXER && SDL_MAJOR_VERSION == 2
+
+namespace {
+
+struct audio_stream_deleter
+{
+	void operator()(SDL_AudioStream *const stream) const
+	{
+		SDL_FreeAudioStream(stream);
+	}
+};
+
+using audio_stream_ptr = std::unique_ptr<SDL_AudioStream, audio_stream_deleter>;
+
+std::vector<uint8_t> convert(const std::span<const int16_t> input, const std::span<const std::size_t> partitions)
+{
+	audio_stream_ptr stream{SDL_NewAudioStream(AUDIO_S16SYS, 1, 22050, AUDIO_S16SYS, 2, 44100)};
+	BOOST_REQUIRE(stream);
+	std::vector<uint8_t> output;
+	std::size_t offset{};
+	const auto drain = [&] {
+		const auto available = SDL_AudioStreamAvailable(stream.get());
+		BOOST_REQUIRE(available >= 0);
+		const auto old_size = output.size();
+		output.resize(old_size + available);
+		if (available)
+			BOOST_REQUIRE_EQUAL(SDL_AudioStreamGet(stream.get(), output.data() + old_size, available), available);
+	};
+	for (const auto count : partitions)
+	{
+		BOOST_REQUIRE(count <= input.size() - offset);
+		BOOST_REQUIRE_EQUAL(SDL_AudioStreamPut(stream.get(), input.data() + offset,
+			static_cast<int>(count * sizeof(input.front()))), 0);
+		offset += count;
+		drain();
+	}
+	BOOST_REQUIRE_EQUAL(offset, input.size());
+	BOOST_REQUIRE_EQUAL(SDL_AudioStreamFlush(stream.get()), 0);
+	drain();
+	return output;
+}
+
+}
+
+BOOST_AUTO_TEST_CASE(conversion_is_independent_of_input_partitioning)
+{
+	std::vector<int16_t> input(22050);
+	for (std::size_t i = 0; i != input.size(); ++i)
+		input[i] = static_cast<int16_t>(((i * 977u) % 60001u) - 30000);
+
+	std::vector<std::size_t> regular;
+	for (std::size_t left = input.size(); left;)
+	{
+		const auto count = std::min<std::size_t>(left, 733);
+		regular.push_back(count);
+		left -= count;
+	}
+
+	std::vector<std::size_t> irregular;
+	for (std::size_t left = input.size(), count = 1; left; count = (count * 17 + 31) % 509 + 1)
+	{
+		const auto actual = std::min(left, count);
+		irregular.push_back(actual);
+		left -= actual;
+	}
+
+	const auto regularly_chunked = convert(input, regular);
+	const auto irregularly_chunked = convert(input, irregular);
+	BOOST_TEST(regularly_chunked == irregularly_chunked, boost::test_tools::per_element());
+	BOOST_TEST(regularly_chunked.size() == input.size() * 2u * 2u * 2u);
+}
+
+#else
+
+BOOST_AUTO_TEST_CASE(requires_sdl2_mixer)
+{
+	BOOST_TEST(true);
+}
+
+#endif


### PR DESCRIPTION
## Problem

The SDL_mixer movie path creates a fresh `SDL_AudioCVT` for every MVE audio segment.  When movie audio is resampled to the mixer rate, that resets the resampler at every segment boundary and produces quiet clicks, most noticeably during loud passages in the Descent II intro.  Using `-nosdlmixer` avoids this path, but also gives up SDL_mixer music playback.

## Changes

- Serialize the movie producer and audio callback on the ring, and refuse a new buffer before it would overwrite an unread entry.
- Use one SDL2 `SDL_AudioStream` for the lifetime of the movie and drain converted audio after each segment, preserving resampler state across MVE boundaries.
- Leave the SDL1 and non-SDL_mixer conversion paths unchanged.
- Add a Boost runtime contract test confirming that persistent SDL2 conversion produces identical output for different input segment boundaries.

## Validation

- Full D2X build with GCC 15, SDL 2.32.10, and SDL_mixer 2.8.1.
- D2X MVE playback source compiled with SDL_mixer disabled.
- D1X shared MVE playback source compiled with SDL2 and SDL_mixer enabled.
- `test-mve-audio-stream` built through `register_runtime_test_link_targets=1` and passed.
- Repeated manual Descent II movie playback, including early aborts and the main-menu idle loop: clicks are gone, movie audio remains normal, and music and game audio remain normal after each playback.
