### PR TITLE
Silence -Wuseless-cast on i386

### DIFF
--- a/similar/main/game.cpp
+++ b/similar/main/game.cpp
@@ -992,7 +992,7 @@ void save_screen_shot(int automap_flag)
 	unsigned tm_year;
 	const auto t = time(nullptr);
 	struct tm *tm = nullptr;
-	if (t == static_cast<time_t>(-1) || !(tm = gmtime(&t)))
+	if (t == time_t{-1} || !(tm = gmtime(&t)))
 		tm_year = tm_mon = tm_mday = tm_hour = tm_min = tm_sec = 0;
 	else
 	{


### PR DESCRIPTION
Some platforms still use an i32 for time_t for i386. Those platforms fail to build with -Werror, so I silenced the lint since the cast is sound and the warning is spurious.

---

Hi, and thanks for the amazing source port! The direct cause of this PR is the i386 build for FreeBSD [failing](https://portsfallout.com/port/11440/). Fixing it seemed simple enough. I opted to fix it here instead of squelching the lint in FreeBSD's Makefile because it captures the intent better than simply silencing _all_ of `-Wuseless-cast`. Let me know if you'd prefer that I just fix it for FreeBSD directly. :grin: