### PR TITLE
`newmenu_mouse`: do not activate prior item when clicking text

### DIFF
--- a/similar/main/newmenu.cpp
+++ b/similar/main/newmenu.cpp
@@ -989,22 +989,20 @@ static window_event_result newmenu_mouse(const d_event &event, newmenu *menu, co
 			{
 				const auto [mx, my, mz] = mouse_get_pos();
 				const int line_spacing = static_cast<int>(LINE_SPACING(*canvas.cv_font, *GAME_FONT));
-				for (int i = menu->scroll_offset; i < menu->max_on_menu + menu->scroll_offset; ++i)
+				auto &iitem = *std::next(menu->items.begin(), menu->citem);
+				x1 = canvas.cv_bitmap.bm_x + iitem.x - fspacx(13);
+				x2 = x1 + iitem.w + fspacx(13);
+				y1 = canvas.cv_bitmap.bm_y + iitem.y - (line_spacing * menu->scroll_offset);
+				y2 = y1 + iitem.h;
+				if (((mx > x1) && (mx < x2)) && ((my > y1) && (my < y2)))
 				{
-					auto &iitem = *std::next(menu->items.begin(), i);
-					x1 = canvas.cv_bitmap.bm_x + iitem.x - fspacx(13);
-					x2 = x1 + iitem.w + fspacx(13);
-					y1 = canvas.cv_bitmap.bm_y + iitem.y - (line_spacing * menu->scroll_offset);
-					y2 = y1 + iitem.h;
-					if (((mx > x1) && (mx < x2)) && ((my > y1) && (my < y2))) {
-							// Tell callback, allow staying in menu
-							if (const auto r{menu->event_handler(d_select_event{menu->citem, d_event::source::mouse})}; r == window_event_result::handled)
-								return r;
+					// Tell callback, allow staying in menu
+					if (const auto r{menu->event_handler(d_select_event{menu->citem, d_event::source::mouse})}; r == window_event_result::handled)
+						return r;
 
-							if (menu->rval)
-								*menu->rval = menu->citem;
-							return window_event_result::close;
-					}
+					if (menu->rval)
+						*menu->rval = menu->citem;
+					return window_event_result::close;
 				}
 			}
 


### PR DESCRIPTION
## Problem

On mouse-down, a non-selectable text row leaves `citem` pointing to the previous selectable row.  On mouse-up, the menu could then dispatch a select event for that previous row while the pointer was over the text row.  In the load-game menu, clicking the empty autosave row could therefore load save slot 10.

## Change

Only dispatch the mouse select event when the hit row is also the current menu item.  This leaves non-selectable text rows inert without changing their display or the normal activation path for selectable rows.

Fixes #830.

## Validation

- Built D1X-Rebirth and D2X-Rebirth with GCC 15, SDL 2, and SDL_mixer on Ubuntu 26.04.
- In both games, saved in slot 10, aborted to the main menu, and reopened the load screen.
- Clicking the 11th, empty autosave row did nothing; clicking slot 10 loaded it; and leaving the load screen still worked normally.

> AI assistance disclosure: I prepared this change and PR description with assistance from OpenAI Codex, operating as a distinct coding agent. Codex analyzed the issue and source, helped implement and review the fix, and verified the recorded build evidence. I performed the D1X/D2X runtime validation described above before submission.
