### PR TITLE
`multi.h`: restore direct type includes

### DIFF
--- a/common/main/multi.h
+++ b/common/main/multi.h
@@ -51,7 +51,12 @@ enum class multi_macro_message_index : uint8_t
 #include <optional>
 #include <ranges>
 #include <span>
+#include "fwd-event.h"
+#include "fwd-game.h"
+#include "fwd-piggy.h"
+#include "fwd-vecmat.h"
 #include "objnum.h"
+#include "player-callsign.h"
 
 #ifdef _WIN32
 #include <winsock2.h>


### PR DESCRIPTION
## Problem

After `multi.h` reduced its include set in 8fd51a64a0d2d759f37351d21ecbff6261ba8bb7, the self-contained-header checks fail for `multi.h` and, transitively, for `net_udp.h` and `multiinternal.h`.

## Change

Include the five headers that directly declare the event, game-mode, piggy, vector, and player-callsign types used by `multi.h`.

## Validation

- Built D1X-Rebirth and D2X-Rebirth with `scons -j8 sdl2=1`.
- Passed the full common, D1, and D2 self-contained-header matrix with GCC 15: `scons -j8 -k CXX=g++-15 sdl2=1 check_header_includes=1 build/common/check_header_includes build/d1x-rebirth/check_header_includes build/d2x-rebirth/check_header_includes`.

> AI assistance disclosure: I prepared this change and PR description with assistance from OpenAI Codex, operating as a distinct coding agent. Codex analyzed the failing GitHub Actions logs, reproduced the header failures in my authorized test environment, identified the missing direct dependencies, implemented the five-include repair, and ran the validation listed above.