### PR TITLE
`PHYSFSRWOPS_openRead`: fulfill `SDL_RWops` contract

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4943,6 +4943,10 @@ class DXXArchive(DXXCommon):
 		RuntimeTest('test-mve-audio-stream', (
 			'd2x-rebirth/unittest/mve_audio_stream.cpp',
 			), nodefaultlibs=False),
+		RuntimeTest('test-physfsrwops', (
+			'common/unittest/physfsrwops.cpp',
+			'common/misc/physfsrwops.cpp',
+			), nodefaultlibs=False),
 		RuntimeTest('test-serial', (
 			'common/unittest/serial.cpp',
 			)),

--- a/SConstruct
+++ b/SConstruct
@@ -5959,7 +5959,7 @@ def main(register_program,_d1xp=D1XProgram,_d2xp=D2XProgram):
 	dxx = []
 	register_program(_d1xp, _d2xp, variables, filtered_help, dxx.append)
 	register_program(_d2xp, _d1xp, variables, filtered_help, dxx.append)
-	substenv = SCons.Environment.Base()
+	substenv = SCons.Environment.Base(tools=[])
 	variables.FormatVariableHelpText = filtered_help.FormatVariableHelpText
 	variables.Update(substenv)
 # show some help when running scons -h

--- a/common/misc/physfsrwops.cpp
+++ b/common/misc/physfsrwops.cpp
@@ -27,6 +27,7 @@
  */
 
 #include <stdio.h>  /* used for SEEK_SET, SEEK_CUR, SEEK_END ... */
+#include <limits>
 #include "physfsrwops.h"
 #include "physfsx.h"
 
@@ -41,6 +42,17 @@
 #endif
 
 namespace {
+
+#if SDL_MAJOR_VERSION == 2
+static Sint64 physfsrwops_size(SDL_RWops *rw)
+{
+    PHYSFS_File *handle = reinterpret_cast<PHYSFS_File *>(rw->hidden.unknown.data1);
+	const auto len{PHYSFS_fileLength(handle)};
+	if (len == -1)
+		SDL_SetError("Can't find end of file: %s", PHYSFS_getLastError());
+	return len;
+} /* physfsrwops_size */
+#endif
 
 static SDL_RWops_callback_seek_position physfsrwops_seek(SDL_RWops *rw, const SDL_RWops_callback_seek_position offset, const int whence)
 {
@@ -133,29 +145,62 @@ static SDL_RWops_callback_seek_position physfsrwops_seek(SDL_RWops *rw, const SD
     return(pos);
 } /* physfsrwops_seek */
 
+template <typename T>
+static bool physfsrwops_calculate_byte_count(const T size, const T number, PHYSFS_uint64 &count)
+{
+	if (!size || !number)
+	{
+		count = 0;
+		return true;
+	}
+	const auto object_size{static_cast<PHYSFS_uint64>(size)};
+	const auto object_count{static_cast<PHYSFS_uint64>(number)};
+	constexpr auto maximum_count{static_cast<PHYSFS_uint64>(std::numeric_limits<PHYSFS_sint64>::max())};
+	if (object_size > maximum_count || object_count > maximum_count / object_size)
+	{
+		SDL_SetError("I/O request is too large.");
+		return false;
+	}
+	count = object_size * object_count;
+	return true;
+}
 
 static SDL_RWops_callback_read_position physfsrwops_read(SDL_RWops *const rw, void *const ptr, const SDL_RWops_callback_read_position size, const SDL_RWops_callback_read_position maxnum)
 {
     PHYSFS_File *handle = reinterpret_cast<PHYSFS_File *>(rw->hidden.unknown.data1);
-	const auto count{size * maxnum};
+	PHYSFS_uint64 count;
+	if (!physfsrwops_calculate_byte_count(size, maxnum, count) || !count)
+		return 0;
 	const auto rc{PHYSFS_readBytes(handle, ptr, count)};
-	if (rc != count)
+	if (rc < 0)
+	{
+		SDL_SetError("PhysicsFS error: %s", PHYSFS_getLastError());
+		return 0;
+	}
+	if (rc != static_cast<PHYSFS_sint64>(count))
     {
         if (!PHYSFS_eof(handle)) /* not EOF? Must be an error. */
             SDL_SetError("PhysicsFS error: %s", PHYSFS_getLastError());
     } /* if */
-	return rc;
+	return rc / size;
 } /* physfsrwops_read */
 
 
 static SDL_RWops_callback_write_position physfsrwops_write(SDL_RWops *const rw, const void *const ptr, const SDL_RWops_callback_write_position size, const SDL_RWops_callback_write_position num)
 {
     PHYSFS_File *handle = reinterpret_cast<PHYSFS_File *>(rw->hidden.unknown.data1);
-	const auto count{size * num};
+	PHYSFS_uint64 count;
+	if (!physfsrwops_calculate_byte_count(size, num, count) || !count)
+		return 0;
 	const auto rc{PHYSFS_writeBytes(handle, reinterpret_cast<const uint8_t *>(ptr), count)};
-    if (rc != count)
+	if (rc < 0)
+	{
+		SDL_SetError("PhysicsFS error: %s", PHYSFS_getLastError());
+		return 0;
+	}
+	if (rc != static_cast<PHYSFS_sint64>(count))
         SDL_SetError("PhysicsFS error: %s", PHYSFS_getLastError());
-	return rc;
+	return rc / size;
 } /* physfsrwops_write */
 
 
@@ -188,6 +233,9 @@ std::pair<RWops_ptr, PHYSFS_ErrorCode> PHYSFSRWOPS_openRead(const char *fname)
 		RWops_ptr retval{SDL_AllocRW()};
 		if (retval)
         {
+#if SDL_MAJOR_VERSION == 2
+            retval->size  = physfsrwops_size;
+#endif
             retval->seek  = physfsrwops_seek;
             retval->read  = physfsrwops_read;
             retval->write = physfsrwops_write;
@@ -201,4 +249,3 @@ std::pair<RWops_ptr, PHYSFS_ErrorCode> PHYSFSRWOPS_openRead(const char *fname)
 } /* PHYSFSRWOPS_openRead */
 
 /* end of physfsrwops.c ... */
-

--- a/common/unittest/physfsrwops.cpp
+++ b/common/unittest/physfsrwops.cpp
@@ -1,0 +1,148 @@
+/*
+ * This file is part of the DXX-Rebirth project <https://github.com/dxx-rebirth/dxx-rebirth/>.
+ * It is copyright by its individual contributors, as recorded in the
+ * project's Git history.  See COPYING.txt at the top level for license
+ * terms and a link to the Git history.
+ */
+
+#include "dxxsconf.h"
+
+#include "physfsrwops.h"
+
+#include <SDL.h>
+#include <physfs.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE Rebirth PhysicsFS RWops
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+class physfsrwops_test_fixture
+{
+	static constexpr std::array<uint8_t, 7> payload{{1, 2, 3, 4, 5, 6, 7}};
+	static constexpr char filename[]{"physfsrwops-test-data"};
+	std::filesystem::path directory;
+	bool physfs_initialized{};
+	bool directory_mounted{};
+
+	void cleanup()
+	{
+		if (directory_mounted)
+			PHYSFS_unmount(directory.string().c_str());
+		if (physfs_initialized)
+			PHYSFS_deinit();
+		std::filesystem::remove_all(directory);
+	}
+
+public:
+	physfsrwops_test_fixture()
+	{
+		try {
+			const auto unique{std::chrono::steady_clock::now().time_since_epoch().count()};
+			directory = std::filesystem::temp_directory_path() / ("dxx-rebirth-physfsrwops-" + std::to_string(unique));
+			if (!std::filesystem::create_directory(directory))
+				throw std::runtime_error("Failed to create temporary directory");
+			{
+				std::ofstream output{directory / filename, std::ios::binary};
+				output.write(reinterpret_cast<const char *>(payload.data()), payload.size());
+				if (!output)
+					throw std::runtime_error("Failed to create test input");
+			}
+			const auto argv0{boost::unit_test::framework::master_test_suite().argv[0]};
+			if (!PHYSFS_init(argv0))
+				throw std::runtime_error(PHYSFS_getLastError());
+			physfs_initialized = true;
+			if (!PHYSFS_mount(directory.string().c_str(), nullptr, 1))
+				throw std::runtime_error(PHYSFS_getLastError());
+			directory_mounted = true;
+		} catch (...) {
+			cleanup();
+			throw;
+		}
+	}
+
+	~physfsrwops_test_fixture()
+	{
+		cleanup();
+	}
+
+	static RWops_ptr open()
+	{
+		auto &&[rwops, error]{PHYSFSRWOPS_openRead(filename)};
+		if (!rwops)
+			throw std::runtime_error(PHYSFS_getErrorByCode(error));
+		return std::move(rwops);
+	}
+};
+
+}
+
+#if SDL_MAJOR_VERSION == 2
+BOOST_FIXTURE_TEST_CASE(size_preserves_position, physfsrwops_test_fixture)
+{
+	auto rwops{open()};
+	BOOST_REQUIRE_EQUAL(SDL_RWseek(rwops.get(), 2, RW_SEEK_SET), 2);
+	BOOST_TEST(SDL_RWsize(rwops.get()) == 7);
+	BOOST_TEST(SDL_RWtell(rwops.get()) == 2);
+}
+#endif
+
+BOOST_FIXTURE_TEST_CASE(read_returns_complete_object_count, physfsrwops_test_fixture)
+{
+	auto rwops{open()};
+	std::array<uint8_t, 6> buffer{};
+	constexpr std::array<uint8_t, 6> expected{{1, 2, 3, 4, 5, 6}};
+	BOOST_TEST(SDL_RWread(rwops.get(), buffer.data(), 2, 3) == 3u);
+	BOOST_TEST(buffer == expected);
+	BOOST_TEST(SDL_RWtell(rwops.get()) == 6);
+}
+
+BOOST_FIXTURE_TEST_CASE(read_does_not_count_partial_object, physfsrwops_test_fixture)
+{
+	auto rwops{open()};
+	std::array<uint8_t, 8> buffer{};
+	BOOST_TEST(SDL_RWread(rwops.get(), buffer.data(), 4, 2) == 1u);
+	BOOST_TEST(buffer[6] == 7u);
+	BOOST_TEST(SDL_RWtell(rwops.get()) == 7);
+}
+
+BOOST_FIXTURE_TEST_CASE(zero_length_read_does_not_move_position, physfsrwops_test_fixture)
+{
+	auto rwops{open()};
+	uint8_t buffer{};
+	BOOST_TEST(SDL_RWread(rwops.get(), &buffer, 0, 1) == 0u);
+	BOOST_TEST(SDL_RWread(rwops.get(), &buffer, 1, 0) == 0u);
+	BOOST_TEST(SDL_RWtell(rwops.get()) == 0);
+}
+
+#if SDL_MAJOR_VERSION == 2
+BOOST_FIXTURE_TEST_CASE(read_rejects_size_product_overflow, physfsrwops_test_fixture)
+{
+	auto rwops{open()};
+	uint8_t buffer{};
+	SDL_ClearError();
+	constexpr auto maximum{std::numeric_limits<std::size_t>::max()};
+	BOOST_TEST(SDL_RWread(rwops.get(), &buffer, maximum, maximum) == 0u);
+	BOOST_TEST(SDL_GetError()[0] != '\0');
+	BOOST_TEST(SDL_RWtell(rwops.get()) == 0);
+}
+#endif
+
+BOOST_FIXTURE_TEST_CASE(write_error_returns_zero_objects, physfsrwops_test_fixture)
+{
+	auto rwops{open()};
+	std::array<uint8_t, 6> buffer{};
+	SDL_ClearError();
+	BOOST_TEST(SDL_RWwrite(rwops.get(), buffer.data(), 2, 3) == 0u);
+	BOOST_TEST(SDL_GetError()[0] != '\0');
+}


### PR DESCRIPTION
## Problem

The investigation in #854 narrowed the Windows crash to `SDL_GameControllerAddMappingsFromRW`, where the reporter's WinDbg trace showed an indirect jump through uninitialized memory.

`PHYSFSRWOPS_openRead` allocates an `SDL_RWops`, but does not initialize the `size` callback required by SDL2.  SDL 2.32.10 calls that callback before reading `gamecontrollerdb.txt`, causing the invalid indirect call.  The adapter's read and write callbacks also return byte counts, rather than the complete-object counts required by the SDL contract.

## Changes

- Implement the SDL2 `size` callback using `PHYSFS_fileLength`.
- Return complete-object counts from the read and write callbacks, report PhysicsFS failures as zero objects, and reject requests whose byte count cannot be represented safely.
- Add focused Boost tests for the SDL2 size callback and the shared SDL1/SDL2 read and write contracts.
- In a separate commit, prevent the SCons substitution environment from loading default tools.  This restores Windows CI compiler detection, which otherwise resolves the configured compiler to a literal `$CC` before reaching the build.

Fixes #854.

## Validation

- Reproduced the failure with the exact Windows artifact reported in #854 (`a531f57e423c82a50828604878f13ed63f098dbe`) on Windows 11.  It crashed while loading the controller database; `-nojoystick` bypassed the fault and reached the normal menu loop.
- Built a patched Windows artifact and repeated the same test with joystick handling enabled.  It loaded 580 mappings from the PhysicsFS `gamecontrollerdb.txt` and continued into graphics initialization.
- Passed six focused SDL2 tests, including size, object-count, error, zero-length, partial-object, and overflow cases.
- Passed the four shared tests under SDL 1.2.
- Built D1X-Rebirth and D2X-Rebirth with GCC 15 and SDL2 on Ubuntu 26.04.
- The Windows workflow passed configure, build, packaging, and artifact generation on the issue branch.  Its final header check encounters the independently tracked `multi.h` failure fixed by #855.
- A full Windows workflow run combining this branch with #855 passed, including the self-contained-header checks: https://github.com/data8504/dxx-rebirth/actions/runs/32669233627

> AI assistance disclosure: I prepared this change and PR description with assistance from OpenAI Codex, operating as a distinct coding agent. Codex reproduced the reported Windows failure in my authorized test environment, analyzed the `SDL_RWops` contract violations, implemented and tested the three-commit series, and ran the validation listed above. I reviewed the resulting changes and evidence before submission.
