### PR TITLE
gamecontroller: validate legacy menu button index

### DIFF
--- a/common/arch/sdl/joy.cpp
+++ b/common/arch/sdl/joy.cpp
@@ -506,12 +506,14 @@ bool joy_translate_menu_key(const d_event &event) {
 	if (event.type != event_type::joystick_button_down)
 		return false;
 	auto &e = static_cast<const d_event_joystickbutton &>(event);
-	assert(e.button < joy_key_map.size());
-	auto key = joy_key_map[e.button];
-	if (key)
+	if (e.button < joy_key_map.size())
 	{
-		event_keycommand_send(key);
-		return true;
+		auto key = joy_key_map[e.button];
+		if (key)
+		{
+			event_keycommand_send(key);
+			return true;
+		}
 	}
 #if SDL_MAJOR_VERSION == 2
 	return gamecontroller_translate_menu_key(e.button);


### PR DESCRIPTION
## Problem

SDL GameControllers are intentionally excluded when constructing the legacy joystick menu map.  With only a GameController attached, that map is empty, but `joy_translate_menu_key` indexed it before reaching the existing GameController fallback.  In release builds, the first controller menu input therefore read past the end of the map and could crash.

## Change

Bounds-check the legacy lookup before using it.  This deliberately preserves the existing lookup order: a valid legacy mapping still wins, and the existing GameController translation remains the fallback.  In particular, this does not introduce device-source distinctions or otherwise change the current mixed-device mapping semantics.

Fixes #857.

## Validation

- Built both D1X-Rebirth and D2X-Rebirth in release mode with GCC 15 and SDL 2.
- Reproduced the failure on the exact current `master` using a virtual SDL GameController: the first A-button event at D2X-Rebirth's pilot-selection menu caused a `SIGSEGV`.
- Repeated the same test with this patch.  D2X-Rebirth processed 25 A-button presses and 25 left-stick excursions over 30 seconds without crashing, and continued translating controller menu input.

> AI assistance disclosure: I prepared this change and PR description with assistance from OpenAI Codex, operating as a distinct coding agent. Codex analyzed the report and core/source path, reproduced the failure with a virtual SDL GameController, implemented the bounds check, and ran the validation listed above. I directed the scope and required preservation of the existing input behavior.
